### PR TITLE
Fix: Resolve all Clippy errors in tool implementations

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -346,16 +346,16 @@ async fn cmd_db(config: &crate::config::Config, operation: DbCommands) -> Result
                 .execute(db.pool())
                 .await?;
 
-            sqlx::query("DELETE FROM files")
-                .execute(db.pool())
-                .await?;
+            sqlx::query("DELETE FROM files").execute(db.pool()).await?;
 
             sqlx::query("DELETE FROM sessions")
                 .execute(db.pool())
                 .await?;
 
-            println!("✅ Successfully cleared {} sessions, {} messages, and {} files",
-                session_count, message_count, file_count);
+            println!(
+                "✅ Successfully cleared {} sessions, {} messages, and {} files",
+                session_count, message_count, file_count
+            );
 
             Ok(())
         }
@@ -370,20 +370,10 @@ async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -
             agent::AgentService,
             provider::{anthropic::AnthropicProvider, openai::OpenAIProvider, Provider},
             tools::{
-                bash::BashTool,
-                code_exec::CodeExecTool,
-                context::ContextTool,
-                edit::EditTool,
-                glob::GlobTool,
-                grep::GrepTool,
-                http::HttpClientTool,
-                ls::LsTool,
-                notebook::NotebookEditTool,
-                read::ReadTool,
-                registry::ToolRegistry,
-                task::TaskTool,
-                web_search::WebSearchTool,
-                write::WriteTool,
+                bash::BashTool, code_exec::CodeExecTool, context::ContextTool, edit::EditTool,
+                glob::GlobTool, grep::GrepTool, http::HttpClientTool, ls::LsTool,
+                notebook::NotebookEditTool, read::ReadTool, registry::ToolRegistry, task::TaskTool,
+                web_search::WebSearchTool, write::WriteTool,
             },
         },
         services::ServiceContext,
@@ -490,15 +480,12 @@ async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -
     // Create agent service with system prompt
     let agent_service = Arc::new(
         AgentService::new(provider.clone(), service_context.clone())
-            .with_system_prompt(SYSTEM_PROMPT.to_string())
+            .with_system_prompt(SYSTEM_PROMPT.to_string()),
     );
 
     // Create TUI app first (so we can get the event sender)
     tracing::debug!("Creating TUI app");
-    let mut app = tui::App::new(
-        agent_service,
-        service_context.clone(),
-    );
+    let mut app = tui::App::new(agent_service, service_context.clone());
 
     // Get event sender from app
     let event_sender = app.event_sender();
@@ -578,20 +565,10 @@ async fn cmd_run(
             agent::AgentService,
             provider::{anthropic::AnthropicProvider, openai::OpenAIProvider, Provider},
             tools::{
-                bash::BashTool,
-                code_exec::CodeExecTool,
-                context::ContextTool,
-                edit::EditTool,
-                glob::GlobTool,
-                grep::GrepTool,
-                http::HttpClientTool,
-                ls::LsTool,
-                notebook::NotebookEditTool,
-                read::ReadTool,
-                registry::ToolRegistry,
-                task::TaskTool,
-                web_search::WebSearchTool,
-                write::WriteTool,
+                bash::BashTool, code_exec::CodeExecTool, context::ContextTool, edit::EditTool,
+                glob::GlobTool, grep::GrepTool, http::HttpClientTool, ls::LsTool,
+                notebook::NotebookEditTool, read::ReadTool, registry::ToolRegistry, task::TaskTool,
+                web_search::WebSearchTool, write::WriteTool,
             },
         },
         services::{ServiceContext, SessionService},

--- a/src/llm/tools/code_exec.rs
+++ b/src/llm/tools/code_exec.rs
@@ -104,7 +104,16 @@ impl Tool for CodeExecTool {
             ));
         }
 
-        let valid_languages = ["python", "python3", "javascript", "js", "node", "rust", "sh", "bash"];
+        let valid_languages = [
+            "python",
+            "python3",
+            "javascript",
+            "js",
+            "node",
+            "rust",
+            "sh",
+            "bash",
+        ];
         if !valid_languages.contains(&input.language.as_str()) {
             return Err(ToolError::InvalidInput(format!(
                 "Unsupported language: {}. Supported: {}",
@@ -123,7 +132,11 @@ impl Tool for CodeExecTool {
         let (interpreter, extension, extra_args) = match input.language.as_str() {
             "python" | "python3" => ("python3", "py", vec![]),
             "javascript" | "js" | "node" => ("node", "js", vec![]),
-            "rust" => ("rustc", "rs", vec!["--out-dir".to_string(), "/tmp".to_string()]),
+            "rust" => (
+                "rustc",
+                "rs",
+                vec!["--out-dir".to_string(), "/tmp".to_string()],
+            ),
             "sh" | "bash" => ("bash", "sh", vec![]),
             _ => {
                 return Ok(ToolResult::error(format!(
@@ -181,10 +194,7 @@ impl Tool for CodeExecTool {
             Ok(Err(e)) => {
                 // Clean up temp file
                 let _ = fs::remove_file(&temp_file).await;
-                return Ok(ToolResult::error(format!(
-                    "Code execution failed: {}",
-                    e
-                )));
+                return Ok(ToolResult::error(format!("Code execution failed: {}", e)));
             }
             Err(_) => {
                 // Clean up temp file
@@ -208,10 +218,7 @@ impl Tool for CodeExecTool {
         let exit_code = output.status.code().unwrap_or(-1);
 
         // Build output message
-        let mut result_text = format!(
-            "Language: {}\nExit Code: {}\n\n",
-            input.language, exit_code
-        );
+        let mut result_text = format!("Language: {}\nExit Code: {}\n\n", input.language, exit_code);
 
         if !stdout.is_empty() {
             result_text.push_str("STDOUT:\n");
@@ -238,8 +245,12 @@ impl Tool for CodeExecTool {
             ToolResult::error(result_text)
         };
 
-        tool_result.metadata.insert("exit_code".to_string(), exit_code.to_string());
-        tool_result.metadata.insert("language".to_string(), input.language);
+        tool_result
+            .metadata
+            .insert("exit_code".to_string(), exit_code.to_string());
+        tool_result
+            .metadata
+            .insert("language".to_string(), input.language);
 
         Ok(tool_result)
     }

--- a/src/llm/tools/code_exec.rs
+++ b/src/llm/tools/code_exec.rs
@@ -153,7 +153,7 @@ impl Tool for CodeExecTool {
         // Write code to temp file
         fs::write(&temp_file, &input.code)
             .await
-            .map_err(|e| ToolError::Io(e))?;
+            .map_err(ToolError::Io)?;
 
         // Prepare command
         let mut cmd = Command::new(interpreter);
@@ -216,12 +216,12 @@ impl Tool for CodeExecTool {
         if !stdout.is_empty() {
             result_text.push_str("STDOUT:\n");
             result_text.push_str(&stdout);
-            result_text.push_str("\n");
+            result_text.push('\n');
         }
 
         if !stderr.is_empty() {
             if !stdout.is_empty() {
-                result_text.push_str("\n");
+                result_text.push('\n');
             }
             result_text.push_str("STDERR:\n");
             result_text.push_str(&stderr);

--- a/src/llm/tools/context.rs
+++ b/src/llm/tools/context.rs
@@ -353,7 +353,7 @@ impl Tool for ContextTool {
             }
 
             ContextOperation::Summary => {
-                let mut output = format!("Session Context Summary\n");
+                let mut output = "Session Context Summary\n".to_string();
                 output.push_str(&format!("Session ID: {}\n", store.session_id));
                 output.push_str(&format!(
                     "Created: {}\n",

--- a/src/llm/tools/context.rs
+++ b/src/llm/tools/context.rs
@@ -93,14 +93,10 @@ enum ContextOperation {
     },
 
     #[serde(rename = "get")]
-    Get {
-        key: String,
-    },
+    Get { key: String },
 
     #[serde(rename = "delete")]
-    Delete {
-        key: String,
-    },
+    Delete { key: String },
 
     #[serde(rename = "list")]
     List {
@@ -109,14 +105,10 @@ enum ContextOperation {
     },
 
     #[serde(rename = "add_fact")]
-    AddFact {
-        fact: String,
-    },
+    AddFact { fact: String },
 
     #[serde(rename = "add_decision")]
-    AddDecision {
-        decision: String,
-    },
+    AddDecision { decision: String },
 
     #[serde(rename = "summary")]
     Summary,
@@ -202,10 +194,7 @@ impl Tool for ContextTool {
     }
 
     fn capabilities(&self) -> Vec<ToolCapability> {
-        vec![
-            ToolCapability::ReadFiles,
-            ToolCapability::WriteFiles,
-        ]
+        vec![ToolCapability::ReadFiles, ToolCapability::WriteFiles]
     }
 
     fn requires_approval(&self) -> bool {

--- a/src/llm/tools/edit.rs
+++ b/src/llm/tools/edit.rs
@@ -38,7 +38,10 @@ enum EditOperation {
 
     /// Regex replace
     #[serde(rename = "regex_replace")]
-    RegexReplace { pattern: String, replacement: String },
+    RegexReplace {
+        pattern: String,
+        replacement: String,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -177,9 +180,7 @@ impl Tool for EditTool {
         if input.create_backup {
             let backup_path = path.with_extension(format!(
                 "{}.backup",
-                path.extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("txt")
+                path.extension().and_then(|s| s.to_str()).unwrap_or("txt")
             ));
             fs::write(&backup_path, &content)
                 .await
@@ -285,7 +286,9 @@ impl Tool for EditTool {
                     )));
                 }
 
-                regex.replace_all(&content, replacement.as_str()).to_string()
+                regex
+                    .replace_all(&content, replacement.as_str())
+                    .to_string()
             }
         };
 

--- a/src/llm/tools/glob.rs
+++ b/src/llm/tools/glob.rs
@@ -80,7 +80,9 @@ impl Tool for GlobTool {
             .map_err(|e| ToolError::InvalidInput(format!("Invalid input: {}", e)))?;
 
         if input.pattern.trim().is_empty() {
-            return Err(ToolError::InvalidInput("Pattern cannot be empty".to_string()));
+            return Err(ToolError::InvalidInput(
+                "Pattern cannot be empty".to_string(),
+            ));
         }
 
         Ok(())
@@ -161,7 +163,11 @@ impl Tool for GlobTool {
         matches.sort();
 
         // Format output
-        let mut output = format!("Found {} files matching '{}':\n\n", matches.len(), input.pattern);
+        let mut output = format!(
+            "Found {} files matching '{}':\n\n",
+            matches.len(),
+            input.pattern
+        );
 
         for path in &matches {
             // Make path relative to base_dir for cleaner output

--- a/src/llm/tools/grep.rs
+++ b/src/llm/tools/grep.rs
@@ -120,7 +120,9 @@ impl Tool for GrepTool {
             .map_err(|e| ToolError::InvalidInput(format!("Invalid input: {}", e)))?;
 
         if input.pattern.trim().is_empty() {
-            return Err(ToolError::InvalidInput("Pattern cannot be empty".to_string()));
+            return Err(ToolError::InvalidInput(
+                "Pattern cannot be empty".to_string(),
+            ));
         }
 
         Ok(())
@@ -167,8 +169,14 @@ impl Tool for GrepTool {
         let mut total_matches = 0;
 
         if search_path.is_file() {
-            self.search_file(&search_path, &regex, &input, &mut matches, &mut total_matches)
-                .await?;
+            self.search_file(
+                &search_path,
+                &regex,
+                &input,
+                &mut matches,
+                &mut total_matches,
+            )
+            .await?;
         } else {
             self.search_directory(
                 &search_path,
@@ -266,7 +274,12 @@ impl GrepTool {
                 // Add context after
                 if let Some(ctx) = input.context {
                     let end = (line_num + ctx + 1).min(lines.len());
-                    for (i, line) in lines.iter().enumerate().skip(line_num + 1).take(end - line_num - 1) {
+                    for (i, line) in lines
+                        .iter()
+                        .enumerate()
+                        .skip(line_num + 1)
+                        .take(end - line_num - 1)
+                    {
                         result.push_str(&format!("\n  {}: {}", i + 1, line));
                     }
                 }

--- a/src/llm/tools/grep.rs
+++ b/src/llm/tools/grep.rs
@@ -255,8 +255,8 @@ impl GrepTool {
                 // Add context before
                 if let Some(ctx) = input.context {
                     let start = line_num.saturating_sub(ctx);
-                    for i in start..line_num {
-                        result.push_str(&format!("\n  {}: {}", i + 1, lines[i]));
+                    for (i, line) in lines.iter().enumerate().skip(start).take(line_num - start) {
+                        result.push_str(&format!("\n  {}: {}", i + 1, line));
                     }
                 }
 
@@ -266,8 +266,8 @@ impl GrepTool {
                 // Add context after
                 if let Some(ctx) = input.context {
                     let end = (line_num + ctx + 1).min(lines.len());
-                    for i in (line_num + 1)..end {
-                        result.push_str(&format!("\n  {}: {}", i + 1, lines[i]));
+                    for (i, line) in lines.iter().enumerate().skip(line_num + 1).take(end - line_num - 1) {
+                        result.push_str(&format!("\n  {}: {}", i + 1, line));
                     }
                 }
 

--- a/src/llm/tools/http.rs
+++ b/src/llm/tools/http.rs
@@ -191,12 +191,12 @@ impl Tool for HttpClientTool {
         if !input.headers.is_empty() {
             let mut header_map = HeaderMap::new();
             for (key, value) in &input.headers {
-                let header_name: reqwest::header::HeaderName = key
-                    .parse()
-                    .map_err(|e| ToolError::InvalidInput(format!("Invalid header name '{}': {}", key, e)))?;
-                let header_value: reqwest::header::HeaderValue = value
-                    .parse()
-                    .map_err(|e| ToolError::InvalidInput(format!("Invalid header value for '{}': {}", key, e)))?;
+                let header_name: reqwest::header::HeaderName = key.parse().map_err(|e| {
+                    ToolError::InvalidInput(format!("Invalid header name '{}': {}", key, e))
+                })?;
+                let header_value: reqwest::header::HeaderValue = value.parse().map_err(|e| {
+                    ToolError::InvalidInput(format!("Invalid header value for '{}': {}", key, e))
+                })?;
                 header_map.insert(header_name, header_value);
             }
             request = request.headers(header_map);
@@ -308,9 +308,7 @@ impl Tool for HttpClientTool {
         tool_result
             .metadata
             .insert("method".to_string(), input.method.to_uppercase());
-        tool_result
-            .metadata
-            .insert("url".to_string(), input.url);
+        tool_result.metadata.insert("url".to_string(), input.url);
 
         Ok(tool_result)
     }

--- a/src/llm/tools/ls.rs
+++ b/src/llm/tools/ls.rs
@@ -116,7 +116,7 @@ impl Tool for LsTool {
         let mut output = String::new();
 
         if input.recursive {
-            self.list_recursive(&path, &input, &mut output, 0).await?;
+            Self::list_recursive(&path, &input, &mut output, 0).await?;
         } else {
             self.list_directory(&path, &input, &mut output).await?;
         }
@@ -182,12 +182,10 @@ impl LsTool {
                 } else {
                     format!("{:>10}  {}  {}", size, modified_time, file_name)
                 }
+            } else if is_dir {
+                format!("{}/", file_name)
             } else {
-                if is_dir {
-                    format!("{}/", file_name)
-                } else {
-                    file_name.clone()
-                }
+                file_name.clone()
             };
 
             if is_dir {
@@ -211,7 +209,6 @@ impl LsTool {
     }
 
     fn list_recursive<'a>(
-        &'a self,
         path: &'a PathBuf,
         input: &'a LsInput,
         output: &'a mut String,
@@ -246,7 +243,7 @@ impl LsTool {
                 if is_dir {
                     output.push_str(&format!("{}{}/\n", indent, file_name));
                     let subdir = entry.path();
-                    self.list_recursive(&subdir, input, output, depth + 1)
+                    Self::list_recursive(&subdir, input, output, depth + 1)
                         .await?;
                 } else {
                     output.push_str(&format!("{}{}\n", indent, file_name));

--- a/src/llm/tools/ls.rs
+++ b/src/llm/tools/ls.rs
@@ -140,12 +140,7 @@ impl LsTool {
         }
 
         // Sort entries
-        entries.sort_by_key(|entry| {
-            entry
-                .file_name()
-                .into_string()
-                .unwrap_or_default()
-        });
+        entries.sort_by_key(|entry| entry.file_name().into_string().unwrap_or_default());
 
         let mut dirs = Vec::new();
         let mut files = Vec::new();
@@ -243,8 +238,7 @@ impl LsTool {
                 if is_dir {
                     output.push_str(&format!("{}{}/\n", indent, file_name));
                     let subdir = entry.path();
-                    Self::list_recursive(&subdir, input, output, depth + 1)
-                        .await?;
+                    Self::list_recursive(&subdir, input, output, depth + 1).await?;
                 } else {
                     output.push_str(&format!("{}{}\n", indent, file_name));
                 }

--- a/src/llm/tools/mod.rs
+++ b/src/llm/tools/mod.rs
@@ -9,22 +9,22 @@ mod r#trait;
 
 // Tool implementations - Phase 1: Essential File Operations
 pub mod bash;
-pub mod read;
-pub mod write;
 pub mod edit;
-pub mod ls;
 pub mod glob;
 pub mod grep;
+pub mod ls;
+pub mod read;
+pub mod write;
 
 // Tool implementations - Phase 2: Advanced Features
-pub mod web_search;
 pub mod code_exec;
 pub mod notebook;
+pub mod web_search;
 
 // Tool implementations - Phase 3: Workflow & Integration
-pub mod task;
 pub mod context;
 pub mod http;
+pub mod task;
 
 // Re-exports
 pub use error::{Result, ToolError};

--- a/src/llm/tools/notebook.rs
+++ b/src/llm/tools/notebook.rs
@@ -262,7 +262,10 @@ impl Tool for NotebookEditTool {
                     notebook.cells[index].execution_count = Some(Value::Null);
                 }
 
-                format!("Edited cell {} ({})", index, notebook.cells[index].cell_type)
+                format!(
+                    "Edited cell {} ({})",
+                    index, notebook.cells[index].cell_type
+                )
             }
 
             NotebookOperation::DeleteCell { index } => {
@@ -300,9 +303,7 @@ impl Tool for NotebookEditTool {
         let new_content = serde_json::to_string_pretty(&notebook)
             .map_err(|e| ToolError::Execution(format!("Failed to serialize notebook: {}", e)))?;
 
-        fs::write(&path, new_content)
-            .await
-            .map_err(ToolError::Io)?;
+        fs::write(&path, new_content).await.map_err(ToolError::Io)?;
 
         Ok(ToolResult::success(format!(
             "{}. Notebook saved: {}",

--- a/src/llm/tools/web_search.rs
+++ b/src/llm/tools/web_search.rs
@@ -198,7 +198,11 @@ impl Tool for WebSearchTool {
                             if result_count >= input.max_results {
                                 break;
                             }
-                            output.push_str(&format!("{}. {}\n", result_count + 1, topic_item.text));
+                            output.push_str(&format!(
+                                "{}. {}\n",
+                                result_count + 1,
+                                topic_item.text
+                            ));
                             output.push_str(&format!("   🔗 {}\n\n", topic_item.first_url));
                             result_count += 1;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use crustly::cli;
 async fn main() -> Result<()> {
     // Initialize logging to file to avoid interfering with TUI
     let log_dir = dirs::data_local_dir()
-        .unwrap_or_else(|| std::env::temp_dir())
+        .unwrap_or_else(std::env::temp_dir)
         .join("crustly")
         .join("logs");
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -197,7 +197,7 @@ fn render_chat(f: &mut Frame, app: &App, area: Rect) {
             ),
             Span::styled(
                 format!("{} is thinking...", model_name),
-                Style::default().fg(Color::Yellow)
+                Style::default().fg(Color::Yellow),
             ),
         ]));
     }
@@ -401,7 +401,10 @@ fn render_help(f: &mut Frame, app: &App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Clear current session messages", Style::default().fg(Color::White)),
+            Span::styled(
+                "Clear current session messages",
+                Style::default().fg(Color::White),
+            ),
         ]),
         Line::from(""),
         Line::from(Span::styled(


### PR DESCRIPTION
- Fix collapsible else-if block in ls.rs
- Fix only-used-in-recursion parameter by converting to associated function in ls.rs
- Fix needless range loops by using enumerate() in grep.rs
- Fix redundant closure in code_exec.rs
- Fix single-char push_str calls to use push() in code_exec.rs
- Fix useless format! to use to_string() in context.rs

All Clippy warnings have been resolved and cargo clippy --lib now passes cleanly.