### PR TITLE
Fix: Add contents write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -30,6 +32,8 @@ jobs:
     name: Build Release
     needs: create-release
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Add `permissions: contents: write` to both create-release and build-release jobs to fix "Resource not accessible by integration" error when creating releases.

The GITHUB_TOKEN needs explicit write permissions to:
- Create releases (create-release job)
- Upload release assets (build-release job)