### PR TITLE
Add ollama-rs integration plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ perf.data.old
 coverage/
 *.profraw
 *.profdata
+cobertura.xml
 
 # Documentation build
 /book/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,15 @@ shellexpand = "3.1"
 reqwest = { version = "0.11", features = ["json", "native-tls", "stream"], default-features = false }
 async-openai = { version = "0.20", optional = true }
 aws-sdk-bedrockruntime = { version = "1.15", optional = true }
+# Native Ollama provider. Pulls its own reqwest 0.12 client internally (ollama-rs
+# is built against reqwest 0.12, incompatible with the reqwest 0.11 client used
+# by the rest of this crate) - the two major versions coexist in the dependency
+# tree, they are not shared/reused across providers.
+ollama-rs = { version = "0.3", optional = true, features = ["stream"] }
+# Needed to build ollama-rs's `ToolInfo`/`FormatType` schemas from our generic
+# serde_json::Value tool definitions. Version must track ollama-rs's own
+# schemars dependency (currently 1.2.x).
+schemars = { version = "1.2", optional = true, features = ["preserve_order"] }
 
 # Provider Registry (Crabrace - replaces Catwalk)
 crabrace = "0.1.0"
@@ -131,7 +140,8 @@ default = []
 profiling = []
 openai = ["async-openai"]
 aws-bedrock = ["aws-sdk-bedrockruntime"]
-all-llm = ["openai", "aws-bedrock"]
+ollama = ["dep:ollama-rs", "dep:schemars"]
+all-llm = ["openai", "aws-bedrock", "ollama"]
 
 [profile.dev]
 opt-level = 0

--- a/README.md
+++ b/README.md
@@ -328,6 +328,32 @@ The OpenAI provider works with **any OpenAI-compatible API**, including:
 | Cerebras | 📅 Planned | — |
 | Huggingface | 📅 Planned | — |
 
+#### ✅ Native Ollama (via `ollama-rs`)
+
+In addition to the OpenAI-compatible route above (`OPENAI_BASE_URL="http://localhost:11434/v1"`),
+Crustly has a **native** Ollama provider built on [`ollama-rs`](https://github.com/pepperoni21/ollama-rs),
+enabled with `--features ollama` (or `all-llm`). It talks to Ollama's own `/api/chat` protocol instead
+of the OpenAI shim, which unlocks:
+
+- `keep_alive` / `num_ctx` control
+- Runtime performance metrics in the TUI header and under each reply: generation throughput
+  (tokens/sec), model load time, warm vs. cold start — none of this is available through the
+  OpenAI-compatible endpoint
+- Model management from the command line:
+
+  ```bash
+  crustly ollama list                              # locally installed models
+  crustly ollama pull qwen2.5-coder:7b              # download a model, with live progress
+  crustly ollama rm qwen2.5-coder:7b                # delete a model
+  crustly ollama show qwen2.5-coder:7b              # license, parameters, template, capabilities
+  crustly ollama embed nomic-embed-text "some text"  # generate an embedding vector
+  ```
+
+Configure it with `[providers.ollama]` in `config.toml` (see `config.toml.example`) or
+`OLLAMA_HOST`/`OLLAMA_MODEL` environment variables. Both the native and OpenAI-compatible routes to
+Ollama can be configured side by side; see [`ollama-rs-integration-plan.md`](./ollama-rs-integration-plan.md)
+for the full design and current status.
+
 ### Environment Variables
 
 | Variable | Provider | Required |

--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ Configure external MCP tool servers in `.crustly/config.toml` under `[[mcp.serve
 ### AWS Bedrock Support
 AWS Bedrock is now a supported provider. Enable it with `--features aws-bedrock` and configure your AWS credentials as usual.
 
+### Native Ollama Provider & Model Download Dialog
+Crustly now speaks Ollama's native `/api/chat` protocol directly (via [`ollama-rs`](https://github.com/pepperoni21/ollama-rs), `--features ollama`), alongside the existing OpenAI-compatible route. This unlocks:
+
+- **Runtime performance metrics** — generation throughput (tokens/sec), model load time, and warm/cold-start status shown live in the TUI header and under each reply
+- **`Ctrl+D` Model Download dialog** — type or pick an Ollama model from suggested/installed names, pull it with a live progress bar, and cancel mid-download with `Esc`, all without leaving the TUI
+- **Model management CLI** — `crustly ollama list|pull|rm|show|embed`
+- **`keep_alive` / `num_ctx` control** and provider identity (badge + icon) shown in the header for every configured provider, not just Ollama
+
+Both the native (`providers.ollama`) and OpenAI-compatible (`providers.openai.base_url`) routes to Ollama can be configured side by side — see the "Native Ollama" section under Providers below, and [`ollama-rs-integration-plan.md`](./ollama-rs-integration-plan.md) for the full design.
+
 ---
 
 ### 🆚 **Why Choose Crustly?**
@@ -339,6 +349,10 @@ of the OpenAI shim, which unlocks:
 - Runtime performance metrics in the TUI header and under each reply: generation throughput
   (tokens/sec), model load time, warm vs. cold start — none of this is available through the
   OpenAI-compatible endpoint
+- **`Ctrl+D` Model Download dialog** — pull a model without leaving the TUI: type a name or pick
+  from suggestions (already-installed models plus a curated list), watch a live progress bar, and
+  cancel with `Esc` if you change your mind. Ollama has no online search API, so suggestions are a
+  starting point, not a catalog search — you can always type any `repo:tag` you know.
 - Model management from the command line:
 
   ```bash
@@ -361,6 +375,8 @@ for the full design and current status.
 | `ANTHROPIC_API_KEY` | Anthropic Claude | ✅ For Anthropic |
 | `OPENAI_API_KEY` | OpenAI / Compatible APIs | ✅ For OpenAI |
 | `OPENAI_BASE_URL` | OpenAI-compatible APIs | Optional (for custom endpoints) |
+| `OLLAMA_HOST` (or `OLLAMA_BASE_URL`) | Native Ollama (`--features ollama`) | Optional (default: `http://localhost:11434`) |
+| `OLLAMA_MODEL` | Native Ollama (`--features ollama`) | Optional (default model override) |
 
 ### Example Configuration
 
@@ -2939,6 +2955,7 @@ Try again with correct parameters.
   - `Ctrl+N` - New session
   - `Ctrl+L` - List sessions
   - `Ctrl+H` - Show help (📚 **Press Ctrl+H from anywhere to see all commands!**)
+  - `Ctrl+D` - Download an Ollama model (native provider, `--features ollama`)
   - `Ctrl+C` - Quit
   - `Escape` - Clear input
   - `Page Up/Down` - Scroll chat history

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,14 @@
 - Phase 4 tools: `web_fetch`, `todo_write`, `ask_user`, `skill`, `agent`, `powershell`
 - `SubAgentLauncher` trait — decoupled sub-agent spawning with recursion guard
 
+### v0.4.2 — Native Ollama Integration
+- Native Ollama provider (`--features ollama`, built on [`ollama-rs`](https://github.com/pepperoni21/ollama-rs)) talking directly to `/api/chat`, alongside the existing OpenAI-compatible route
+- Runtime performance metrics — tokens/sec, model load time, warm/cold-start — surfaced in the TUI header and under each reply; provider identity badge in the header for every configured provider
+- `Ctrl+D` **Model Download dialog** — pick or type a model, pull with a live progress bar, cancel with `Esc`, without leaving the TUI
+- Model management CLI: `crustly ollama list|pull|rm|show|embed`
+- `keep_alive` / `num_ctx` control; `OLLAMA_HOST`/`OLLAMA_MODEL` env vars
+- See [`ollama-rs-integration-plan.md`](./ollama-rs-integration-plan.md) for the full design and implementation status
+
 ---
 
 ## Upcoming Milestones
@@ -95,7 +103,7 @@
 
 | Item | Notes |
 |------|-------|
-| RAG / vector store | Semantic search over the codebase; integrate with the existing codebase index |
+| RAG / vector store | Semantic search over the codebase; integrate with the existing codebase index. Raw embedding generation is already available via the native Ollama provider (`crustly ollama embed`) — no retrieval layer wired up yet |
 | Multi-pane TUI | Chat + file preview split; tabs for multiple conversations |
 | Web interface | Optional `crustly serve` command exposing a browser UI |
 | Multi-user / team | Shared sessions, role-based approval, audit log export |

--- a/config.toml.example
+++ b/config.toml.example
@@ -68,6 +68,30 @@ default_model = "qwen2.5-coder-7b-instruct"
 # default_model = "qwen-plus"  # qwen-max, qwen-plus, qwen-turbo
 # enable_thinking = false  # Thinking mode for Qwen3 models only
 
+# ========================================
+# Native Ollama Provider (via ollama-rs)
+# ========================================
+# Distinct from providers.openai.base_url pointed at Ollama's OpenAI-compat
+# shim above - this one talks to Ollama's own /api/chat protocol and unlocks
+# keep_alive/num_ctx control plus runtime performance metrics (tokens/sec,
+# model load time) shown in the TUI. Requires building crustly with
+# `--features ollama` (or `all-llm`).
+# [providers.ollama]
+# enabled = true
+# host = "http://localhost:11434"
+# default_model = "qwen2.5-coder:7b"
+# keep_alive = "5m"    # "-1" (never unload), "0" (unload immediately), or "5m"/"30s"/"2h"
+# num_ctx = 8192       # Context window size to request from the model
+#
+# Env var equivalents: OLLAMA_HOST (or OLLAMA_BASE_URL), OLLAMA_MODEL
+#
+# Model management from the command line (list/pull/delete/show/embed):
+#   crustly ollama list
+#   crustly ollama pull qwen2.5-coder:7b
+#   crustly ollama rm qwen2.5-coder:7b
+#   crustly ollama show qwen2.5-coder:7b
+#   crustly ollama embed nomic-embed-text "some text to embed"
+
 # Environment variables for Qwen:
 # - QWEN_BASE_URL: Local endpoint URL
 # - DASHSCOPE_API_KEY: Cloud API key

--- a/migrations/20260701000001_provider_perf_metrics.sql
+++ b/migrations/20260701000001_provider_perf_metrics.sql
@@ -1,0 +1,9 @@
+-- Adds provider identity + runtime performance metrics columns, populated by
+-- the native Ollama provider (ollama-rs). All columns are nullable and
+-- default to NULL for existing rows and for providers that don't expose
+-- this level of detail (Anthropic, OpenAI, Qwen, Azure).
+
+ALTER TABLE sessions ADD COLUMN provider TEXT;              -- Provider name (e.g. "ollama", "anthropic")
+
+ALTER TABLE messages ADD COLUMN provider_name TEXT;         -- Provider that generated this message
+ALTER TABLE messages ADD COLUMN perf_metrics_json TEXT;     -- Serialized PerfMetrics (load/prompt/eval durations)

--- a/ollama-rs-integration-plan.md
+++ b/ollama-rs-integration-plan.md
@@ -1,0 +1,223 @@
+# Plan d'intégration de `ollama-rs`
+
+Statut : proposition — non implémenté
+Branche : `claude/ollama-rs-integration-8an4bc`
+Dépendance visée : [`ollama-rs`](https://github.com/pepperoni21/ollama-rs) (crates.io)
+
+## 1. Objectif
+
+Ajouter un provider **Ollama natif**, basé sur la crate `ollama-rs`, en plus des
+providers existants — **sans rien retirer ni casser** pour :
+
+- LM Studio (via `providers.openai.base_url`, endpoint OpenAI-compatible)
+- OpenAI / GPT (`providers.openai`)
+- Anthropic / Claude (`providers.anthropic`)
+- Qwen / DashScope / vLLM (`providers.qwen`)
+- Azure OpenAI (`providers.azure`)
+
+Le nouveau provider est **additif** : Ollama reste utilisable comme aujourd'hui
+via le mode OpenAI-compatible (`OPENAI_BASE_URL=http://localhost:11434/v1`),
+et devient **en plus** utilisable via `providers.ollama`, qui parle à l'API
+native d'Ollama (`/api/chat`, `/api/generate`, `/api/tags`, `/api/pull`, …).
+
+## 2. Pourquoi un provider natif, alors qu'Ollama fonctionne déjà ?
+
+Le shim OpenAI-compatible (`src/llm/provider/openai.rs`) couvre déjà le chat,
+le streaming, les tool calls et la détection heuristique de vision. Ce qu'il
+**ne** couvre pas, et que l'API native d'Ollama (et donc `ollama-rs`) permet :
+
+| Fonctionnalité                                   | Shim OpenAI-compat | API native Ollama |
+|---------------------------------------------------|:---:|:---:|
+| Chat / streaming / tool calls                     | ✅ | ✅ |
+| Gestion des modèles (`list`, `pull`, `show`, `copy`, `delete`) | ❌ | ✅ |
+| `pull` avec progression (téléchargement de modèle) | ❌ | ✅ |
+| `keep_alive` (contrôle du déchargement mémoire)   | ❌ | ✅ |
+| `num_ctx` / options Modelfile natives              | ❌ (approximé) | ✅ |
+| Embeddings (`/api/embeddings`)                     | ❌ | ✅ |
+| Images en entrée (multimodal) sans base64 manuel   | partiel | ✅ (typed) |
+| Structured output (`format: <json schema>`)        | partiel (`response_format`) | ✅ |
+
+L'intérêt de `ollama-rs` est donc de débloquer la **gestion de modèles** (pull
+depuis Crustly, liste des modèles installés, suppression) et les
+**embeddings**, tout en gardant une implémentation plus fidèle au protocole
+natif qu'un mapping OpenAI approximatif.
+
+## 3. Contraintes de compatibilité (non négociables)
+
+1. Aucune modification de la trait `Provider` (`src/llm/provider/trait.rs`) —
+   le nouveau provider doit s'y conformer tel quel.
+2. Aucune régression sur `OpenAIProvider::local()` — LM Studio, Ollama via
+   compat OpenAI, LocalAI continuent de fonctionner exactement comme avant.
+3. `create_provider()` (factory) garde son comportement actuel par défaut :
+   l'ajout d'Ollama ne doit pas changer quel provider est choisi quand
+   seule une config `openai`/`anthropic`/`qwen` existe déjà.
+4. `ollama-rs` est ajouté comme dépendance **optionnelle**, activée par une
+   feature Cargo (`ollama`), cohérente avec le pattern existant
+   (`openai`, `aws-bedrock`, `all-llm`).
+5. Tous les tests existants (`cargo test`) doivent continuer à passer.
+
+## 4. Ce qui va changer / être ajouté
+
+### 4.1 Dépendances (`Cargo.toml`)
+
+```toml
+[dependencies]
+ollama-rs = { version = "0.2", optional = true, features = ["stream"] }
+
+[features]
+ollama = ["ollama-rs"]
+all-llm = ["openai", "aws-bedrock", "ollama"]
+```
+
+À vérifier à l'implémentation : version exacte publiée sur crates.io et
+compatibilité avec `tokio 1.35` / `reqwest 0.11` déjà présents dans l'arbre de
+dépendances (éviter un doublon de version de reqwest).
+
+### 4.2 Nouveau fichier `src/llm/provider/ollama.rs`
+
+Implémente `Provider` pour `OllamaProvider`, sur le modèle de
+`src/llm/provider/openai.rs` :
+
+- `OllamaProvider::new(host: String, port: u16)` / `OllamaProvider::default_local()`
+  (`http://localhost:11434`)
+- `with_default_model(model: String)`
+- `with_keep_alive(duration: KeepAlive)` (option native, absente du shim actuel)
+- Mapping `LLMRequest -> ollama_rs::generation::chat::ChatMessageRequest` :
+  - `messages`, `system` → message `system` en tête (comme `openai.rs`)
+  - `tools` → format d'outils natif d'Ollama (compatible OpenAI function
+    calling depuis Ollama ≥ 0.3)
+  - `temperature`, `top_p`, `seed`, `stop`, `frequency_penalty`,
+    `presence_penalty` → `ModelOptions` d'`ollama-rs`
+  - `response_format` → paramètre `format` natif (JSON mode / JSON Schema)
+  - `thinking` (Anthropic `ThinkingConfig`) → pas d'équivalent natif direct ;
+    conserver la stratégie actuelle de `extract_think_tags()` sur le texte de
+    réponse pour les modèles type DeepSeek-R1/QwQ (réutiliser la fonction
+    existante dans `types.rs`, ne pas la dupliquer)
+- Mapping réponse `ChatMessageResponse -> LLMResponse`, y compris
+  `ContentBlock::ToolUse` pour les tool calls et `TokenUsage` depuis
+  `prompt_eval_count` / `eval_count`
+- `stream()` : consommer le stream natif d'`ollama-rs` et le traduire vers
+  `StreamEvent` (`MessageStart` → `ContentBlockDelta` → `MessageStop`), en
+  suivant le même séquencement que celui déjà présent dans `openai.rs`
+  (accumulation des fragments de tool calls avant de les émettre)
+- `supports_vision()` : réutiliser la même liste de motifs de noms de modèles
+  que `openai.rs` (`llava`, `vision`, `minicpm-v`, etc.), potentiellement
+  extraite dans une fonction partagée `super::model_hints::is_vision_model()`
+  pour éviter la duplication entre les deux providers
+- Erreurs `ollama-rs::error::OllamaError` → `ProviderError` existant
+  (`ApiError`, `HttpError`, `Timeout`, …)
+
+### 4.3 Extension du modèle de configuration (`src/config/mod.rs`)
+
+```rust
+pub struct ProviderConfigs {
+    // ... existants inchangés ...
+    #[serde(default)]
+    pub ollama: Option<OllamaProviderConfig>,
+}
+
+pub struct OllamaProviderConfig {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_ollama_host")]
+    pub host: String,          // "http://localhost:11434"
+    pub default_model: Option<String>,
+    pub keep_alive: Option<String>,   // "5m", "-1" (toujours chargé), "0"
+    #[serde(default)]
+    pub num_ctx: Option<u32>,
+}
+```
+
+Variables d'environnement (suivant le pattern `OPENAI_BASE_URL` /
+`QWEN_BASE_URL` déjà en place dans `Config::from_env`/équivalent) :
+
+- `OLLAMA_HOST` (ou réutiliser `OLLAMA_BASE_URL` si on veut rester cohérent
+  avec la convention CLI officielle d'Ollama, qui utilise `OLLAMA_HOST`)
+- `OLLAMA_MODEL` pour le modèle par défaut
+
+### 4.4 Factory (`src/llm/provider/factory.rs`)
+
+Ajouter `try_create_ollama()`, inséré dans `create_provider()` **après** Qwen
+et **avant** OpenAI, pour ne pas changer la résolution par défaut existante
+quand seul `providers.openai` (LM Studio) est configuré :
+
+```
+1. Qwen (si configuré)
+2. Ollama natif (si providers.ollama configuré)   <-- nouveau
+3. OpenAI / compat local (LM Studio, Ollama via /v1, LocalAI)
+4. Anthropic (fallback par défaut)
+```
+
+Comme pour Qwen/OpenAI, le choix ne s'active que si `providers.ollama` est
+explicitement renseigné dans la config ou via variable d'env — sinon
+comportement 100 % identique à aujourd'hui.
+
+### 4.5 Gestion de modèles (nouvelle capacité, hors trait `Provider`)
+
+Ajouter un module utilitaire optionnel `src/llm/provider/ollama_models.rs`
+(derrière la feature `ollama`) exposant :
+
+- `list_models()`, `pull_model(name, on_progress)`, `delete_model(name)`
+
+Exposés via une sous-commande CLI `crustly ollama <list|pull|rm>` dans
+`src/cli/mod.rs` (nouveau, additif — n'affecte pas les commandes existantes).
+Cette partie est **optionnelle** pour une v1 : elle peut être livrée dans une
+seconde phase.
+
+### 4.6 Documentation
+
+- `config.toml.example` : ajouter un bloc `[providers.ollama]` commenté, à
+  côté du bloc existant `[providers.openai]` (qui reste la méthode
+  recommandée pour LM Studio).
+- `README.md` : nouvelle sous-section « Ollama natif (via `ollama-rs`) » dans
+  la section Local LLMs, en clarifiant explicitement les **deux** chemins
+  disponibles :
+  - `providers.openai.base_url = "http://localhost:11434/v1"` (existant,
+    compatible tool calling actuel)
+  - `providers.ollama.host = "http://localhost:11434"` (nouveau, gestion de
+    modèles + embeddings)
+
+## 5. Ce qui NE change PAS
+
+- `OpenAIProvider`, `AnthropicProvider`, `QwenProvider`, `AzureOpenAIProvider` :
+  aucune modification de comportement.
+- Le trait `Provider` : signature inchangée.
+- `crabrace` (registry de providers) : pas de dépendance croisée avec ce plan
+  sauf si l'on souhaite y déclarer Ollama comme provider connu (à évaluer
+  séparément, hors scope v1).
+- Comportement par défaut de `create_provider()` sans config `ollama` :
+  identique bit-à-bit à l'existant.
+
+## 6. Plan de test
+
+1. Tests unitaires (offline, sans dépendre d'un serveur Ollama réel) :
+   - construction du provider, mapping requête/réponse, mapping d'erreurs —
+     même style que les tests déjà présents dans `openai.rs`/`qwen.rs`.
+2. Tests de non-régression : `cargo test --no-default-features` et
+   `cargo test --features all-llm` doivent tous les deux passer.
+3. Test manuel local (nécessite un Ollama réel, non exécutable en CI) :
+   - `ollama pull llama3.2` puis validation chat/stream/tool-call/pull via
+     `providers.ollama`.
+4. Vérifier que la configuration existante (`providers.openai.base_url =
+   "http://localhost:11434/v1"`) continue de fonctionner à l'identique en
+   parallèle (non-régression LM Studio/Ollama-compat).
+
+## 7. Phasage proposé
+
+- **Phase 1 (MVP)** : dépendance optionnelle + `OllamaProvider` (chat,
+  streaming, tool calls, vision) + config + factory + doc. Livrable testable
+  isolément, sans toucher aux autres providers.
+- **Phase 2** : gestion de modèles (`list`/`pull`/`rm`) + sous-commande CLI.
+- **Phase 3** : embeddings natifs Ollama, exposés à la couche RAG/recherche
+  interne si Crustly en a une (à confirmer selon le code existant).
+
+## 8. Points ouverts à trancher avant implémentation
+
+1. Nom de la variable d'environnement : `OLLAMA_HOST` (convention officielle
+   Ollama) vs `OLLAMA_BASE_URL` (cohérence avec `OPENAI_BASE_URL`/`QWEN_BASE_URL`
+   internes) — recommandation : accepter les deux, `OLLAMA_HOST` prioritaire.
+2. Faut-il activer `ollama` dans la feature `default` ou la garder strictement
+   optionnelle (recommandé, pour ne pas alourdir le binaire par défaut) ?
+3. Faut-il, à terme, migrer le tool-parsing Ollama actuel (via le shim OpenAI)
+   vers le provider natif, ou garder les deux indéfiniment ? → recommandation :
+   garder les deux, laisser l'utilisateur choisir via sa config.

--- a/ollama-rs-integration-plan.md
+++ b/ollama-rs-integration-plan.md
@@ -1,7 +1,8 @@
 # Plan d'intégration de `ollama-rs`
 
-Statut : **Phases 1 et 2 implémentées et testées. Phases 3 et 4 partiellement
-implémentées** (voir détail ci-dessous).
+Statut : **Phases 1, 2 et 3 implémentées et testées** (le panneau "Model
+Info" dans la TUI reste à faire, cf. tableau). **Phase 4 partiellement
+implémentée** (voir détail ci-dessous).
 Branche : `claude/ollama-rs-integration-8an4bc`
 Dépendance : [`ollama-rs`](https://github.com/pepperoni21/ollama-rs) 0.3.5 (crates.io)
 
@@ -9,9 +10,9 @@ Dépendance : [`ollama-rs`](https://github.com/pepperoni21/ollama-rs) 0.3.5 (cra
 
 | Phase | Statut | Détail |
 |---|---|---|
-| 1 — Provider natif | ✅ Fait | `src/llm/provider/ollama.rs` (`OllamaProvider`), config, factory, tests unitaires. Testé avec `cargo test --features ollama` (415 tests, 0 échec) et sans la feature (400 tests, 0 échec). |
+| 1 — Provider natif | ✅ Fait | `src/llm/provider/ollama.rs` (`OllamaProvider`), config, factory, tests unitaires. Testé avec `cargo test --features ollama` (418 tests, 0 échec) et sans la feature (403 tests, 0 échec). `cargo clippy --features ollama` et sans la feature : 0 warning. |
 | 2 — Métriques TUI | ✅ Fait | `PerfMetrics` sur `LLMResponse`, propagé via `AgentResponse` → `DisplayMessage`/`Session` → `render.rs` (badge provider + tok/s en en-tête, ligne de métriques sous chaque réponse). Persisté en base (migration `20260701000001_provider_perf_metrics.sql`). |
-| 3 — Gestion de modèles | 🟡 Partiel | `src/llm/provider/ollama_models.rs` (list/pull/delete/show) + sous-commande CLI `crustly ollama list\|pull\|rm\|show` avec barre de progression **en terminal**. **Le dialog interactif dans la TUI décrit en §5.7 (saisie/sélection à l'écran, barre de progression rendue dans l'interface, annulation, suggestions curatées) n'est PAS implémenté** — seul l'équivalent CLI existe à ce stade. |
+| 3 — Gestion de modèles | ✅ Fait (sauf panneau Model Info TUI) | `src/llm/provider/ollama_models.rs` (list/pull/delete/show) + sous-commande CLI `crustly ollama list\|pull\|rm\|show` avec barre de progression terminal. **Dialog interactif dans la TUI** (`Ctrl+D` en mode Chat, `src/tui/ollama_download.rs` + `AppMode::ModelDownload`) : saisie du nom de modèle avec suggestions filtrées (modèles déjà installés + liste curatée), navigation ↑↓, `Tab` pour reprendre une suggestion, `Enter` pour lancer le pull, barre de progression live rendue dans l'interface, `Esc` annule le téléchargement en cours (`JoinHandle::abort()`). Le panneau "Model Info" dans la TUI (§5.4 point 3) n'est pas fait — `crustly ollama show` en CLI reste le seul accès. |
 | 4 — Embeddings | 🟡 Partiel | `ollama_models::generate_embeddings()` + `crustly ollama embed <model> <text>`. **Pas de couche RAG/retrieval à brancher dessus : Crustly n'en a pas** (vérifié — aucune référence à "embedding" dans le code avant cette phase). La capacité brute est exposée pour un usage futur. |
 
 Écarts connus par rapport au plan technique ci-dessous (à noter avant toute
@@ -30,6 +31,14 @@ implémentation ultérieure) :
   rechargement de session depuis la base (la colonne `token_count` stocke
   input+output combinés, pas le nombre de tokens de sortie seul nécessaire
   au calcul).
+- Dialog "Model Download" : la barre de progression suit la **couche
+  courante** téléchargée par Ollama (`completed`/`total` de la réponse
+  `/api/pull`), pas une estimation globale multi-couches agrégée — décrit
+  comme option possible en §5.7.3 mais non implémenté (Ollama ne renvoie pas
+  la taille totale de toutes les couches à l'avance). Pas non plus de
+  confirmation "re-pull ?" si le modèle est déjà installé (§5.7.2 point 3) —
+  le pull est relancé directement ; simplification acceptée pour rester
+  cohérent avec `ollama pull` en CLI qui a le même comportement.
 
 ## 1. Objectif
 
@@ -585,13 +594,17 @@ pas créer d'attente erronée.
   badge provider + segment tok/s dans l'en-tête, pied de message avec durée
   de génération. C'est la partie qui bénéficie **aussi** aux providers déjà
   en place (badge provider transverse).
-- **Phase 3 (gestion de modèles + téléchargement interactif)** :
-  `list`/`pull`/`rm`/`show` + sous-commande CLI + panneau "Model Info" +
-  **dialog "Model Download" dans la TUI** (§5.7) permettant à l'utilisateur
-  de choisir/saisir un modèle et de le télécharger avec barre de progression
-  en direct, sans quitter Crustly.
-- **Phase 4** : embeddings natifs Ollama, exposés à la couche RAG/recherche
-  interne si Crustly en a une (à confirmer selon le code existant).
+- **Phase 3 (gestion de modèles + téléchargement interactif)** : ✅
+  `list`/`pull`/`rm`/`show` + sous-commande CLI, et **dialog "Model
+  Download" dans la TUI** (§5.7, `Ctrl+D`) permettant à l'utilisateur de
+  choisir/saisir un modèle et de le télécharger avec barre de progression
+  en direct, sans quitter Crustly. Reste non fait : le panneau "Model Info"
+  dans la TUI décrit en §5.4 point 3 (`crustly ollama show` en CLI reste
+  le seul moyen de voir license/parameters/template/capabilities).
+- **Phase 4** : ✅ (partiel) `generate_embeddings()` + `crustly ollama embed`
+  exposés comme capacité brute — pas de couche RAG/recherche interne à y
+  brancher, Crustly n'en a pas (vérifié, aucune référence à "embedding"
+  dans le code avant cette phase).
 
 ## 9. Points ouverts à trancher avant implémentation
 
@@ -611,17 +624,19 @@ pas créer d'attente erronée.
    plus de colonnes à faire évoluer) — recommandation : JSON, cohérent avec
    le fait que ces métriques sont avant tout informatives/TUI et non
    utilisées dans des requêtes analytiques pour l'instant.
-6. Raccourci/entrée exacte pour ouvrir le dialog "Model Download" (`Ctrl+D`
-   proposé en §5.7.2, à vérifier vs raccourcis existants dans
-   `src/tui/events.rs`) et son alternative en commande slash (`/pull`,
-   `/download`) — à aligner sur les conventions déjà en place dans la barre
-   de saisie de Crustly (à confirmer si des commandes slash existent déjà).
-7. Faut-il permettre l'annulation propre d'un `pull` en cours (`Esc` →
-   `CancellationToken`), ou accepter que l'utilisateur laisse le
-   téléchargement se terminer en arrière-plan tout en revenant au chat
-   (moins de complexité, mais moins de contrôle utilisateur) ?
+6. ✅ Tranché et implémenté : `Ctrl+D` (mode Chat), libre dans
+   `src/tui/events.rs` (`keys::is_model_download`). Pas de commande slash
+   séparée — Crustly n'a pas de système de commandes slash dans sa barre de
+   saisie, `Ctrl+D` reste donc la seule entrée.
+7. ✅ Tranché et implémenté : annulation via `JoinHandle::abort()` sur la
+   tâche tokio qui exécute `ollama_models::pull_model()` (stockée dans
+   `App::model_download_task`), déclenchée par `Esc`. Pas de
+   `CancellationToken` : `abort()` suffit puisque le stream HTTP tourne
+   entièrement dans cette tâche.
 8. La liste curatée de modèles suggérés (§5.7.2) doit-elle être codée en dur
    dans le binaire (simple, nécessite une recompilation pour la mettre à
    jour) ou chargée depuis un fichier de config/JSON embarqué modifiable par
    l'utilisateur (plus flexible, légère complexité en plus) — recommandation :
-   codée en dur pour la v1, réévaluable si demande utilisateur.
+   codée en dur pour la v1, réévaluable si demande utilisateur. **Tranché :
+   codée en dur** (`ollama_download::CURATED_MODELS`), cohérent avec la
+   recommandation ci-dessus.

--- a/ollama-rs-integration-plan.md
+++ b/ollama-rs-integration-plan.md
@@ -20,6 +20,12 @@ via le mode OpenAI-compatible (`OPENAI_BASE_URL=http://localhost:11434/v1`),
 et devient **en plus** utilisable via `providers.ollama`, qui parle à l'API
 native d'Ollama (`/api/chat`, `/api/generate`, `/api/tags`, `/api/pull`, …).
 
+En complément du provider lui-même, ce plan couvre la **remontée dans la TUI**
+d'informations utiles à l'utilisateur — modèle réellement utilisé, provider
+actif, débit de génération (tokens/s), temps de chargement du modèle,
+progression d'un `pull` — sans dégrader l'affichage existant pour les
+providers qui n'exposent pas ces données (Anthropic, OpenAI, Qwen, Azure).
+
 ## 2. Pourquoi un provider natif, alors qu'Ollama fonctionne déjà ?
 
 Le shim OpenAI-compatible (`src/llm/provider/openai.rs`) couvre déjà le chat,
@@ -36,11 +42,13 @@ le streaming, les tool calls et la détection heuristique de vision. Ce qu'il
 | Embeddings (`/api/embeddings`)                     | ❌ | ✅ |
 | Images en entrée (multimodal) sans base64 manuel   | partiel | ✅ (typed) |
 | Structured output (`format: <json schema>`)        | partiel (`response_format`) | ✅ |
+| **Métriques de performance** (durées de chargement, prefill, génération) | ❌ (absentes de la réponse OpenAI-compat) | ✅ (`total_duration`, `load_duration`, `prompt_eval_duration`, `eval_duration`, `eval_count`) |
 
-L'intérêt de `ollama-rs` est donc de débloquer la **gestion de modèles** (pull
-depuis Crustly, liste des modèles installés, suppression) et les
-**embeddings**, tout en gardant une implémentation plus fidèle au protocole
-natif qu'un mapping OpenAI approximatif.
+L'intérêt de `ollama-rs` est donc double : débloquer la **gestion de
+modèles** (pull depuis Crustly, liste des modèles installés, suppression) et
+les **embeddings**, et exposer des **métriques de performance natives** que
+le shim OpenAI-compatible ne renvoie jamais (Ollama ne les inclut pas dans sa
+réponse au format `/v1/chat/completions`, seulement dans `/api/chat`).
 
 ## 3. Contraintes de compatibilité (non négociables)
 
@@ -54,9 +62,13 @@ natif qu'un mapping OpenAI approximatif.
 4. `ollama-rs` est ajouté comme dépendance **optionnelle**, activée par une
    feature Cargo (`ollama`), cohérente avec le pattern existant
    (`openai`, `aws-bedrock`, `all-llm`).
-5. Tous les tests existants (`cargo test`) doivent continuer à passer.
+5. Tous les champs ajoutés à `LLMResponse`/`AgentResponse`/`DisplayMessage`/DB
+   sont des `Option<T>` avec valeur par défaut `None` : un provider qui ne les
+   renseigne pas (Anthropic, OpenAI, Qwen, Azure) n'a **aucun changement de
+   comportement ni d'affichage**.
+6. Tous les tests existants (`cargo test`) doivent continuer à passer.
 
-## 4. Ce qui va changer / être ajouté
+## 4. Architecture du provider
 
 ### 4.1 Dépendances (`Cargo.toml`)
 
@@ -94,16 +106,20 @@ Implémente `Provider` pour `OllamaProvider`, sur le modèle de
     réponse pour les modèles type DeepSeek-R1/QwQ (réutiliser la fonction
     existante dans `types.rs`, ne pas la dupliquer)
 - Mapping réponse `ChatMessageResponse -> LLMResponse`, y compris
-  `ContentBlock::ToolUse` pour les tool calls et `TokenUsage` depuis
-  `prompt_eval_count` / `eval_count`
+  `ContentBlock::ToolUse` pour les tool calls, `TokenUsage` depuis
+  `prompt_eval_count` / `eval_count`, **et `PerfMetrics` depuis les champs de
+  durée natifs** (voir §5.2)
 - `stream()` : consommer le stream natif d'`ollama-rs` et le traduire vers
   `StreamEvent` (`MessageStart` → `ContentBlockDelta` → `MessageStop`), en
   suivant le même séquencement que celui déjà présent dans `openai.rs`
-  (accumulation des fragments de tool calls avant de les émettre)
+  (accumulation des fragments de tool calls avant de les émettre). Le dernier
+  chunk du stream Ollama porte les mêmes champs de durée/compteurs que la
+  réponse non-streamée — à capturer dans le `MessageDelta`/`usage` final pour
+  alimenter `PerfMetrics` aussi en mode streaming.
 - `supports_vision()` : réutiliser la même liste de motifs de noms de modèles
-  que `openai.rs` (`llava`, `vision`, `minicpm-v`, etc.), potentiellement
-  extraite dans une fonction partagée `super::model_hints::is_vision_model()`
-  pour éviter la duplication entre les deux providers
+  que `openai.rs` (`llava`, `vision`, `minicpm-v`, etc.), extraite dans une
+  fonction partagée `super::model_hints::is_vision_model()` pour éviter la
+  duplication entre les deux providers
 - Erreurs `ollama-rs::error::OllamaError` → `ProviderError` existant
   (`ApiError`, `HttpError`, `Timeout`, …)
 
@@ -157,12 +173,15 @@ comportement 100 % identique à aujourd'hui.
 Ajouter un module utilitaire optionnel `src/llm/provider/ollama_models.rs`
 (derrière la feature `ollama`) exposant :
 
-- `list_models()`, `pull_model(name, on_progress)`, `delete_model(name)`
+- `list_models()`, `pull_model(name, on_progress)`, `show_model(name)`,
+  `delete_model(name)`
 
-Exposés via une sous-commande CLI `crustly ollama <list|pull|rm>` dans
+`pull_model` accepte un callback/canal de progression (voir §5.4) — c'est ce
+qui permet d'afficher une vraie barre de progression dans la TUI plutôt qu'un
+simple spinner.
+
+Exposés via une sous-commande CLI `crustly ollama <list|pull|rm|show>` dans
 `src/cli/mod.rs` (nouveau, additif — n'affecte pas les commandes existantes).
-Cette partie est **optionnelle** pour une v1 : elle peut être livrée dans une
-seconde phase.
 
 ### 4.6 Documentation
 
@@ -175,43 +194,270 @@ seconde phase.
   - `providers.openai.base_url = "http://localhost:11434/v1"` (existant,
     compatible tool calling actuel)
   - `providers.ollama.host = "http://localhost:11434"` (nouveau, gestion de
-    modèles + embeddings)
+    modèles + embeddings + métriques de performance dans la TUI)
 
-## 5. Ce qui NE change PAS
+## 5. Remontée d'informations dans la TUI
+
+### 5.1 Ce que l'API native d'Ollama expose (et que `ollama-rs` typera)
+
+Chaque réponse `/api/chat` (non-streamée et dernier chunk en streaming)
+contient, en nanosecondes :
+
+| Champ Ollama          | Signification                                   |
+|------------------------|--------------------------------------------------|
+| `total_duration`       | Durée totale de la requête                        |
+| `load_duration`        | Temps de chargement du modèle en mémoire (0 si déjà chargé — "warm") |
+| `prompt_eval_count` / `prompt_eval_duration` | Tokens et durée du prefill (lecture du prompt) |
+| `eval_count` / `eval_duration`               | Tokens et durée de la génération (sortie) |
+
+À partir de ces champs on calcule directement une métrique très parlante pour
+l'utilisateur : **le débit de génération en tokens/seconde**
+(`eval_count / (eval_duration / 1e9)`), ainsi que le **temps de chargement du
+modèle** (utile pour diagnostiquer un premier appel lent après un
+"cold start", ou un modèle qui se décharge trop vite faute de `keep_alive`).
+
+### 5.2 Extension des types de données (additive, `Option<T>` partout)
+
+**`src/llm/provider/types.rs`** — nouveau type, réutilisable par n'importe
+quel provider futur (pas seulement Ollama) :
+
+```rust
+/// Runtime performance metrics reported by local inference backends.
+/// `None` for providers that don't expose this level of detail
+/// (Anthropic, OpenAI, Qwen, Azure) — purely additive, no behavior change.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PerfMetrics {
+    /// Time to load/warm the model into memory (ms). `Some(0)` when the
+    /// model was already resident ("warm" — see `model_was_loaded`).
+    pub load_duration_ms: Option<u64>,
+    /// Prefill duration — time spent evaluating the input prompt (ms).
+    pub prompt_eval_duration_ms: Option<u64>,
+    /// Generation duration — time spent producing the output (ms).
+    pub eval_duration_ms: Option<u64>,
+    /// Total wall-clock duration for the request (ms).
+    pub total_duration_ms: Option<u64>,
+    /// `true` if the model was already loaded (warm start), `false` if it
+    /// had to be loaded first (cold start), `None` if unknown/unsupported.
+    pub model_was_loaded: Option<bool>,
+}
+
+impl PerfMetrics {
+    /// Generation throughput in tokens/second.
+    pub fn tokens_per_second(&self, output_tokens: u32) -> Option<f64> {
+        let ms = self.eval_duration_ms?;
+        (ms > 0).then(|| output_tokens as f64 / (ms as f64 / 1000.0))
+    }
+}
+```
+
+Ajout à `LLMResponse` (suit exactement le pattern déjà utilisé pour
+`cache_metrics: Option<CacheMetrics>`, spécifique Anthropic) :
+
+```rust
+#[serde(skip_serializing_if = "Option::is_none")]
+pub perf_metrics: Option<PerfMetrics>,
+```
+
+**`src/llm/agent/service.rs`** — `AgentResponse` gagne deux champs :
+
+```rust
+pub struct AgentResponse {
+    // ... champs existants inchangés ...
+    /// Name of the provider that served this response (e.g. "ollama",
+    /// "openai", "anthropic"). Lets the TUI show which backend answered,
+    /// useful once several providers are configured side by side.
+    pub provider_name: String,
+    /// Performance metrics, if the provider exposes them.
+    pub perf_metrics: Option<crate::llm::provider::PerfMetrics>,
+}
+```
+
+`provider_name` vient de `Provider::name()` (méthode déjà présente sur la
+trait) — il suffit de la propager depuis le point d'appel dans
+`service.rs` où `AgentResponse` est construit, au lieu de se limiter au nom du
+modèle comme aujourd'hui.
+
+**`src/tui/app.rs`** — `DisplayMessage` gagne les mêmes deux champs
+(`provider_name: Option<String>`, `perf_metrics: Option<PerfMetrics>`),
+peuplés dans `complete_response()` à côté de `token_count`/`cost` déjà
+présents (lignes ~715-726).
+
+`Session` (`src/db/models.rs`) gagne `pub provider: Option<String>`, peuplé
+en lazy comme `model` l'est déjà :
+
+```rust
+// app.rs complete_response(), à côté du bloc existant :
+if session.model.is_none() { session.model = Some(response.model.clone()); }
+// nouveau :
+if session.provider.is_none() { session.provider = Some(response.provider_name.clone()); }
+```
+
+**Migration DB** (`migrations/2026XXXX_add_provider_perf_metrics.sql`) :
+
+```sql
+ALTER TABLE sessions ADD COLUMN provider TEXT;
+ALTER TABLE messages ADD COLUMN provider_name TEXT;
+ALTER TABLE messages ADD COLUMN perf_metrics_json TEXT; -- PerfMetrics sérialisé en JSON
+```
+
+Colonnes nullables, aucune donnée existante affectée, aucun changement pour
+les sessions/messages déjà en base (elles auront simplement `NULL`).
+
+### 5.3 Pipeline de propagation
+
+```
+OllamaProvider::complete()/stream()
+    → LLMResponse { usage, perf_metrics: Some(..), .. }
+        → llm/agent/service.rs (construit AgentResponse)
+            → AgentResponse { provider_name, perf_metrics, .. }
+                → tui/app.rs::complete_response()
+                    → DisplayMessage { provider_name, perf_metrics, .. }
+                    → Session.provider (lazy, une fois par session)
+                        → tui/render.rs (affichage, §5.4)
+                        → session_service / message repo (persistance DB, §5.2)
+```
+
+Aucun de ces types n'est modifié de façon incompatible : ce sont uniquement
+des champs ajoutés, initialisés à `None`/valeur par défaut pour tous les
+chemins existants (Anthropic, OpenAI, Qwen, Azure).
+
+### 5.4 Nouveaux éléments d'interface (TUI)
+
+Concrètement, dans `src/tui/render.rs` :
+
+1. **Ligne d'en-tête (`render_header`, actuellement lignes 72-130)** : ajout
+   d'un badge provider et, si `perf_metrics` est disponible sur le dernier
+   message assistant, du débit courant :
+
+   ```
+   📝 Session: my-session │ 🦙 ollama · qwen2.5-coder:7b │ 💬 Tokens: 1234 │ 💰 Cost: $0.0000 │ ⚡ 42 tok/s
+   ```
+
+   L'icône provider est choisie par une petite fonction `provider_icon(name)`
+   (`🦙 ollama`, `🏠 lm-studio/openai-local`, `🤖 anthropic`, `🌀 qwen`,
+   `☁️ azure`) — purement cosmétique, aucun impact fonctionnel.
+   Quand `perf_metrics` est `None` (Anthropic, OpenAI, Qwen, Azure), le
+   segment `⚡ tok/s` est simplement omis — pas de `0 tok/s` trompeur.
+
+2. **Pied de message assistant** (dans la boucle `render_chat`, après le
+   bloc `[Thinking]` existant, ~ligne 250) : une ligne discrète optionnelle
+   sous chaque réponse d'un modèle Ollama :
+
+   ```
+   🤖 qwen2.5-coder:7b (14:32:10)
+   ... contenu de la réponse ...
+   ⏱ 812 ms génération · 46 tok/s · 🧊 cold start (modèle chargé en 1.2 s)
+   ```
+
+   Rendue uniquement si `msg.perf_metrics.is_some()`.
+
+3. **Panneau "Model Info"** (nouveau, sur le modèle des dialogs existants
+   dans `src/tui/components/dialogs/mod.rs`, qui utilisent déjà
+   `Clear` + `Block` en overlay pour le panel de progression de plan) :
+   overlay déclenché par un raccourci (`Ctrl+M` par exemple, à confirmer côté
+   UX), affichant les infos de `ollama_models::show_model()` : famille,
+   taille de paramètres, quantization, longueur de contexte du Modelfile,
+   `keep_alive` effectif, VRAM approximative. Nécessite un nouveau variant
+   `AppMode::ModelInfo` dans `src/tui/events.rs` (même pattern que
+   `AppMode::ToolApproval`/`FilePicker`).
+
+4. **Barre de progression `pull`** : overlay analogue au
+   `render_auto_exec_progress` déjà présent pour l'exécution de plans
+   (`components/dialogs/mod.rs`). `pull_model()` (§4.5) pousse des
+   évènements de progression (`{ digest, total, completed }`) sur un
+   `mpsc::UnboundedSender`, consommé par la boucle d'évènements TUI
+   (`src/tui/events.rs`, même mécanisme que `ToolApprovalRequested`) pour
+   mettre à jour une barre `completed/total` en temps réel pendant le
+   téléchargement d'un modèle lancé depuis `crustly ollama pull`.
+
+5. **Barre de statut** (`render_status_bar`, ligne ~1381) : en cas d'erreur
+   spécifique Ollama (modèle non trouvé, Ollama non démarré), afficher un
+   message actionnable au lieu du message générique, par ex. :
+   `Ollama unreachable at http://localhost:11434 — run 'ollama serve'`.
+
+### 5.5 Compatibilité et dégradation gracieuse
+
+- Sessions utilisant Anthropic/OpenAI/Qwen/Azure : `provider_name` est
+  quand même renseigné (ex. `"anthropic"`, déjà retourné par
+  `Provider::name()`), donc le badge provider dans l'en-tête profite à
+  **tous** les providers, pas seulement Ollama — amélioration transverse
+  cohérente avec l'objectif multi-provider du projet.
+- `perf_metrics` reste `None` pour ces providers ⇒ aucune ligne de
+  métriques de performance n'apparaît pour eux ⇒ zéro régression visuelle.
+- Le panneau "Model Info" et la barre de progression `pull` ne sont
+  accessibles/pertinents que lorsque le provider actif est Ollama —
+  raccourcis/dialogs no-op (ou masqués) sinon.
+
+### 5.6 Configuration utilisateur
+
+Nouveau champ optionnel, non-bloquant, sous la section TUI existante de
+`config.toml` (à localiser précisément dans `src/config/mod.rs` lors de
+l'implémentation) :
+
+```toml
+[tui]
+show_performance_metrics = true   # défaut : true : masque le segment tok/s
+                                   # si mis à false, même quand disponible
+```
+
+## 6. Ce qui NE change PAS
 
 - `OpenAIProvider`, `AnthropicProvider`, `QwenProvider`, `AzureOpenAIProvider` :
-  aucune modification de comportement.
+  aucune modification de comportement ni de rendu.
 - Le trait `Provider` : signature inchangée.
 - `crabrace` (registry de providers) : pas de dépendance croisée avec ce plan
   sauf si l'on souhaite y déclarer Ollama comme provider connu (à évaluer
   séparément, hors scope v1).
 - Comportement par défaut de `create_provider()` sans config `ollama` :
   identique bit-à-bit à l'existant.
+- Rendu TUI existant pour les sessions/messages déjà en base (colonnes
+  `NULL` sur les nouveaux champs) : identique à l'existant.
 
-## 6. Plan de test
+## 7. Plan de test
 
 1. Tests unitaires (offline, sans dépendre d'un serveur Ollama réel) :
    - construction du provider, mapping requête/réponse, mapping d'erreurs —
      même style que les tests déjà présents dans `openai.rs`/`qwen.rs`.
-2. Tests de non-régression : `cargo test --no-default-features` et
+   - `PerfMetrics::tokens_per_second()` : cas nominal, `eval_duration_ms =
+     0`/`None` (pas de division par zéro, retourne `None`).
+   - Mapping des durées ns → ms depuis des fixtures `ChatMessageResponse`.
+2. Tests de rendu TUI (snapshot avec `insta`, déjà utilisé dans le projet en
+   dev-dependency) :
+   - en-tête avec `perf_metrics: None` (Anthropic/OpenAI/Qwen/Azure) → rendu
+     identique aux snapshots existants (non-régression).
+   - en-tête avec `perf_metrics: Some(..)` → nouveau snapshot avec le
+     segment tok/s.
+3. Tests de non-régression : `cargo test --no-default-features` et
    `cargo test --features all-llm` doivent tous les deux passer.
-3. Test manuel local (nécessite un Ollama réel, non exécutable en CI) :
+4. Test de migration DB : appliquer la migration sur une base existante
+   (fixture avec des lignes `sessions`/`messages` préexistantes) et vérifier
+   que les colonnes ajoutées sont bien `NULL` sans erreur.
+5. Test manuel local (nécessite un Ollama réel, non exécutable en CI) :
    - `ollama pull llama3.2` puis validation chat/stream/tool-call/pull via
-     `providers.ollama`.
-4. Vérifier que la configuration existante (`providers.openai.base_url =
+     `providers.ollama`, et vérification visuelle du badge provider, du
+     débit tok/s et du panneau Model Info dans la TUI.
+6. Vérifier que la configuration existante (`providers.openai.base_url =
    "http://localhost:11434/v1"`) continue de fonctionner à l'identique en
-   parallèle (non-régression LM Studio/Ollama-compat).
+   parallèle (non-régression LM Studio/Ollama-compat), y compris pour
+   l'affichage TUI (pas de segment tok/s puisque le shim OpenAI-compat ne
+   renvoie pas ces données).
 
-## 7. Phasage proposé
+## 8. Phasage proposé
 
-- **Phase 1 (MVP)** : dépendance optionnelle + `OllamaProvider` (chat,
-  streaming, tool calls, vision) + config + factory + doc. Livrable testable
-  isolément, sans toucher aux autres providers.
-- **Phase 2** : gestion de modèles (`list`/`pull`/`rm`) + sous-commande CLI.
-- **Phase 3** : embeddings natifs Ollama, exposés à la couche RAG/recherche
+- **Phase 1 (MVP provider)** : dépendance optionnelle + `OllamaProvider`
+  (chat, streaming, tool calls, vision) + config + factory + doc. Livrable
+  testable isolément, sans toucher aux autres providers ni à la TUI.
+- **Phase 2 (observabilité TUI)** : `PerfMetrics`, propagation
+  `LLMResponse → AgentResponse → DisplayMessage → Session`, migration DB,
+  badge provider + segment tok/s dans l'en-tête, pied de message avec durée
+  de génération. C'est la partie qui bénéficie **aussi** aux providers déjà
+  en place (badge provider transverse).
+- **Phase 3 (gestion de modèles)** : `list`/`pull`/`rm`/`show` + sous-commande
+  CLI + panneau "Model Info" + barre de progression `pull` dans la TUI.
+- **Phase 4** : embeddings natifs Ollama, exposés à la couche RAG/recherche
   interne si Crustly en a une (à confirmer selon le code existant).
 
-## 8. Points ouverts à trancher avant implémentation
+## 9. Points ouverts à trancher avant implémentation
 
 1. Nom de la variable d'environnement : `OLLAMA_HOST` (convention officielle
    Ollama) vs `OLLAMA_BASE_URL` (cohérence avec `OPENAI_BASE_URL`/`QWEN_BASE_URL`
@@ -221,3 +467,11 @@ seconde phase.
 3. Faut-il, à terme, migrer le tool-parsing Ollama actuel (via le shim OpenAI)
    vers le provider natif, ou garder les deux indéfiniment ? → recommandation :
    garder les deux, laisser l'utilisateur choisir via sa config.
+4. Raccourci clavier exact pour le panneau "Model Info" (`Ctrl+M` proposé,
+   à confirmer — vérifier qu'il n'entre pas en conflit avec un raccourci
+   existant dans `src/tui/events.rs`).
+5. Stocker `PerfMetrics` en JSON (`perf_metrics_json TEXT`, plus simple, une
+   seule migration) ou en colonnes séparées (plus interrogeable en SQL, mais
+   plus de colonnes à faire évoluer) — recommandation : JSON, cohérent avec
+   le fait que ces métriques sont avant tout informatives/TUI et non
+   utilisées dans des requêtes analytiques pour l'instant.

--- a/ollama-rs-integration-plan.md
+++ b/ollama-rs-integration-plan.md
@@ -1,8 +1,7 @@
 # Plan d'intégration de `ollama-rs`
 
-Statut : **Phases 1, 2 et 3 implémentées et testées** (le panneau "Model
-Info" dans la TUI reste à faire, cf. tableau). **Phase 4 partiellement
-implémentée** (voir détail ci-dessous).
+Statut : **Phases 1, 2, 3 et 4 implémentées et testées** (le panneau "Model
+Info" dans la TUI reste à faire, cf. tableau — seul écart connu restant).
 Branche : `claude/ollama-rs-integration-8an4bc`
 Dépendance : [`ollama-rs`](https://github.com/pepperoni21/ollama-rs) 0.3.5 (crates.io)
 
@@ -13,7 +12,7 @@ Dépendance : [`ollama-rs`](https://github.com/pepperoni21/ollama-rs) 0.3.5 (cra
 | 1 — Provider natif | ✅ Fait | `src/llm/provider/ollama.rs` (`OllamaProvider`), config, factory, tests unitaires. Testé avec `cargo test --features ollama` (418 tests, 0 échec) et sans la feature (403 tests, 0 échec). `cargo clippy --features ollama` et sans la feature : 0 warning. |
 | 2 — Métriques TUI | ✅ Fait | `PerfMetrics` sur `LLMResponse`, propagé via `AgentResponse` → `DisplayMessage`/`Session` → `render.rs` (badge provider + tok/s en en-tête, ligne de métriques sous chaque réponse). Persisté en base (migration `20260701000001_provider_perf_metrics.sql`). |
 | 3 — Gestion de modèles | ✅ Fait (sauf panneau Model Info TUI) | `src/llm/provider/ollama_models.rs` (list/pull/delete/show) + sous-commande CLI `crustly ollama list\|pull\|rm\|show` avec barre de progression terminal. **Dialog interactif dans la TUI** (`Ctrl+D` en mode Chat, `src/tui/ollama_download.rs` + `AppMode::ModelDownload`) : saisie du nom de modèle avec suggestions filtrées (modèles déjà installés + liste curatée), navigation ↑↓, `Tab` pour reprendre une suggestion, `Enter` pour lancer le pull, barre de progression live rendue dans l'interface, `Esc` annule le téléchargement en cours (`JoinHandle::abort()`). Le panneau "Model Info" dans la TUI (§5.4 point 3) n'est pas fait — `crustly ollama show` en CLI reste le seul accès. |
-| 4 — Embeddings | 🟡 Partiel | `ollama_models::generate_embeddings()` + `crustly ollama embed <model> <text>`. **Pas de couche RAG/retrieval à brancher dessus : Crustly n'en a pas** (vérifié — aucune référence à "embedding" dans le code avant cette phase). La capacité brute est exposée pour un usage futur. |
+| 4 — Embeddings | ✅ Fait (capacité brute) | `ollama_models::generate_embeddings()` + `crustly ollama embed <model> <text>`, avec tests de sérialisation de la requête (`EmbeddingsInput::Single` vs `Multiple`). **Pas de couche RAG/retrieval à brancher dessus : Crustly n'en a pas** (vérifié — aucune référence à "embedding" dans le code avant cette phase) ; c'est donc le plafond raisonnable de cette phase tant qu'un tel système n'existe pas ou n'est pas demandé séparément. |
 
 Écarts connus par rapport au plan technique ci-dessous (à noter avant toute
 implémentation ultérieure) :
@@ -601,10 +600,12 @@ pas créer d'attente erronée.
   en direct, sans quitter Crustly. Reste non fait : le panneau "Model Info"
   dans la TUI décrit en §5.4 point 3 (`crustly ollama show` en CLI reste
   le seul moyen de voir license/parameters/template/capabilities).
-- **Phase 4** : ✅ (partiel) `generate_embeddings()` + `crustly ollama embed`
-  exposés comme capacité brute — pas de couche RAG/recherche interne à y
-  brancher, Crustly n'en a pas (vérifié, aucune référence à "embedding"
-  dans le code avant cette phase).
+- **Phase 4 (embeddings)** : ✅ `generate_embeddings()` + `crustly ollama
+  embed <model> <text>`, testé (sérialisation de la requête `Single` vs
+  `Multiple`). Capacité brute exposée, pas branchée sur une couche
+  RAG/recherche interne — Crustly n'en a pas (vérifié, aucune référence à
+  "embedding" dans le code avant cette phase) ; à réévaluer si un tel
+  système est demandé séparément.
 
 ## 9. Points ouverts à trancher avant implémentation
 

--- a/ollama-rs-integration-plan.md
+++ b/ollama-rs-integration-plan.md
@@ -1,8 +1,35 @@
 # Plan d'intégration de `ollama-rs`
 
-Statut : proposition — non implémenté
+Statut : **Phases 1 et 2 implémentées et testées. Phases 3 et 4 partiellement
+implémentées** (voir détail ci-dessous).
 Branche : `claude/ollama-rs-integration-8an4bc`
-Dépendance visée : [`ollama-rs`](https://github.com/pepperoni21/ollama-rs) (crates.io)
+Dépendance : [`ollama-rs`](https://github.com/pepperoni21/ollama-rs) 0.3.5 (crates.io)
+
+## 0. État d'implémentation (résumé honnête)
+
+| Phase | Statut | Détail |
+|---|---|---|
+| 1 — Provider natif | ✅ Fait | `src/llm/provider/ollama.rs` (`OllamaProvider`), config, factory, tests unitaires. Testé avec `cargo test --features ollama` (415 tests, 0 échec) et sans la feature (400 tests, 0 échec). |
+| 2 — Métriques TUI | ✅ Fait | `PerfMetrics` sur `LLMResponse`, propagé via `AgentResponse` → `DisplayMessage`/`Session` → `render.rs` (badge provider + tok/s en en-tête, ligne de métriques sous chaque réponse). Persisté en base (migration `20260701000001_provider_perf_metrics.sql`). |
+| 3 — Gestion de modèles | 🟡 Partiel | `src/llm/provider/ollama_models.rs` (list/pull/delete/show) + sous-commande CLI `crustly ollama list\|pull\|rm\|show` avec barre de progression **en terminal**. **Le dialog interactif dans la TUI décrit en §5.7 (saisie/sélection à l'écran, barre de progression rendue dans l'interface, annulation, suggestions curatées) n'est PAS implémenté** — seul l'équivalent CLI existe à ce stade. |
+| 4 — Embeddings | 🟡 Partiel | `ollama_models::generate_embeddings()` + `crustly ollama embed <model> <text>`. **Pas de couche RAG/retrieval à brancher dessus : Crustly n'en a pas** (vérifié — aucune référence à "embedding" dans le code avant cette phase). La capacité brute est exposée pour un usage futur. |
+
+Écarts connus par rapport au plan technique ci-dessous (à noter avant toute
+implémentation ultérieure) :
+- **Pas de retry automatique** sur `OllamaProvider::complete()`/`stream()` :
+  `ollama-rs` est bâti sur `reqwest` 0.12, incompatible avec le
+  `ProviderError::HttpError(reqwest 0.11)` du reste du crate, donc les
+  erreurs réseau sont mappées en `ApiError{status:0,..}`, jamais retryable
+  par `retry_with_backoff`. Voir le commentaire de module dans `ollama.rs`.
+- Les métriques de performance (`PerfMetrics`) ne sont propagées que sur le
+  chemin **non-streamé** (`complete()`). En streaming, les durées finales
+  sont calculées mais pas encore attachées à un `StreamEvent` (pas de champ
+  prévu dans ce type) — capturées en interne puis ignorées (`let _ =
+  final_perf;` dans `ollama.rs`).
+- `tokens_per_second` sur un message affiché redevient `None` après un
+  rechargement de session depuis la base (la colonne `token_count` stocke
+  input+output combinés, pas le nombre de tokens de sortie seul nécessaire
+  au calcul).
 
 ## 1. Objectif
 

--- a/ollama-rs-integration-plan.md
+++ b/ollama-rs-integration-plan.md
@@ -361,14 +361,9 @@ Concrètement, dans `src/tui/render.rs` :
    `AppMode::ModelInfo` dans `src/tui/events.rs` (même pattern que
    `AppMode::ToolApproval`/`FilePicker`).
 
-4. **Barre de progression `pull`** : overlay analogue au
-   `render_auto_exec_progress` déjà présent pour l'exécution de plans
-   (`components/dialogs/mod.rs`). `pull_model()` (§4.5) pousse des
-   évènements de progression (`{ digest, total, completed }`) sur un
-   `mpsc::UnboundedSender`, consommé par la boucle d'évènements TUI
-   (`src/tui/events.rs`, même mécanisme que `ToolApprovalRequested`) pour
-   mettre à jour une barre `completed/total` en temps réel pendant le
-   téléchargement d'un modèle lancé depuis `crustly ollama pull`.
+4. **Téléchargement de modèle interactif** : voir §5.7 — dialog dédié pour
+   saisir/choisir un modèle et le télécharger sans quitter la TUI, avec barre
+   de progression en temps réel.
 
 5. **Barre de statut** (`render_status_bar`, ligne ~1381) : en cas d'erreur
    spécifique Ollama (modèle non trouvé, Ollama non démarré), afficher un
@@ -399,6 +394,117 @@ l'implémentation) :
 show_performance_metrics = true   # défaut : true : masque le segment tok/s
                                    # si mis à false, même quand disponible
 ```
+
+### 5.7 Téléchargement de modèle LLM depuis la TUI (`pull` interactif)
+
+Objectif : l'utilisateur ne doit **pas** avoir besoin de sortir de Crustly
+vers un terminal pour faire `ollama pull <model>` — il choisit et télécharge
+le modèle qu'il veut directement depuis la TUI, avec suivi de progression en
+direct.
+
+#### 5.7.1 Contrainte réelle de l'API Ollama (à documenter pour l'utilisateur)
+
+Ollama **n'expose aucune API locale pour parcourir/rechercher le catalogue en
+ligne** (la recherche façon "Ollama Library" n'existe que sur le site
+ollama.com). `ollama-rs` ne peut donc pas offrir de recherche catalogue côté
+API — seulement :
+
+- `list_local_models()` (`GET /api/tags`) → modèles déjà installés localement
+- `pull_model(name, allow_insecure)` (`POST /api/pull`) → télécharge un modèle
+  **si son nom `repo:tag` est déjà connu** (ex. `llama3.2:3b`,
+  `qwen2.5-coder:7b`, `mistral:latest`)
+
+Le "choix du modèle" dans la TUI est donc une **saisie/sélection du nom de
+modèle** (comme le ferait l'utilisateur en CLI avec `ollama pull <name>`),
+assistée par une liste de suggestions, **pas** une recherche plein texte sur
+le hub Ollama. Ce point sera documenté explicitement dans le README pour ne
+pas créer d'attente erronée.
+
+#### 5.7.2 Flux utilisateur (UX)
+
+1. Raccourci dédié en mode `Chat` (proposé : `Ctrl+D` pour "Download" — à
+   confirmer, doit être libre dans `src/tui/events.rs`) ou commande slash
+   `/pull` dans la barre de saisie existante (cohérent avec le reste de la
+   TUI si des commandes slash existent déjà — à vérifier à l'implémentation).
+2. Ouverture d'un nouveau dialog **Model Download**, sur le modèle du
+   `FilePicker` déjà existant (réutilise `tui-textarea`, déjà une dépendance
+   du projet, pour le champ de saisie) :
+   - Un champ texte pour taper librement `repo:tag` (ex. `deepseek-r1:14b`).
+   - Une liste de suggestions au-dessus/à côté, préremplie avec :
+     a) les modèles **déjà installés** (via `list_local_models()`, marqués
+        "✅ installed" et non re-téléchargeables sans confirmation), et
+     b) une liste **curatée statique** reprise du README existant
+        (`qwen2.5-coder:7b`, `gemma3:12b`, `llama3.1:8b`, `mistral`, …,
+        section "Recommended Local Models for Coding") embarquée en constante
+        Rust (`const CURATED_MODELS: &[(&str, &str)]` = nom + courte
+        description), filtrable en tapant (fuzzy-match simple, style
+        `FilePicker`).
+   - Navigation haut/bas pour sélectionner une suggestion, `Tab`/`Enter` pour
+     la copier dans le champ de saisie, `Enter` à nouveau (ou sur champ
+     libre) pour lancer le téléchargement.
+   - `Esc` ferme le dialog sans rien télécharger.
+3. Validation légère avant lancement : format `nom[:tag]` non vide ; si le
+   modèle est déjà dans `list_local_models()`, demander confirmation
+   ("Re-pull llama3.2:3b ? (y/n)") plutôt que de retélécharger silencieusement.
+4. Lancement du pull ⇒ bascule vers un overlay de progression (même famille
+   que `render_auto_exec_progress`) :
+
+   ```
+   ┌─ Downloading qwen2.5-coder:7b ───────────────────────────────┐
+   │ pulling manifest                                              │
+   │ pulling 8934d96d3f08... [████████████████░░░░░░░░]  64%      │
+   │   2.9 GB / 4.5 GB · 38 MB/s · ETA 42s                         │
+   │ verifying sha256 digest                                       │
+   │                                                                │
+   │                              (Esc annule le téléchargement)   │
+   └────────────────────────────────────────────────────────────────┘
+   ```
+
+5. À la fin : message de succès dans le fil de chat/toast
+   (`✅ qwen2.5-coder:7b downloaded — 4.5 GB in 1m58s`), et proposition
+   optionnelle "utiliser ce modèle pour la session courante ?" (met à jour
+   `session.model` + `providers.ollama.default_model` en mémoire, sans
+   redémarrer l'app).
+6. En cas d'échec (nom introuvable côté registre Ollama → 404, disque plein,
+   réseau coupé) : message d'erreur clair dans l'overlay, dialog reste ouvert
+   pour corriger et relancer.
+
+#### 5.7.3 Détails techniques
+
+- **`src/llm/provider/ollama_models.rs`** (§4.5) : `pull_model` prend un
+  `tokio::sync::mpsc::UnboundedSender<PullProgressEvent>` et streame les
+  évènements de progression natifs d'`ollama-rs` (`PullModelStatus { status,
+  digest, total, completed }`) au fur et à mesure. Agrégation multi-couches :
+  Ollama télécharge plusieurs "layers" (blobs) séquentiellement pour un même
+  modèle ; l'overlay doit combiner `completed`/`total` de la couche courante
+  ET une estimation globale (somme des tailles de couches déjà connues, si
+  disponible dans la réponse `/api/pull`, sinon se limiter à la couche
+  courante + un indicateur "couche X").
+- **Annulation** : le pull tourne dans une `tokio::task::JoinHandle` dédiée ;
+  `Esc` envoie un signal d'annulation via un `CancellationToken`
+  (déjà utilisé ailleurs dans le projet ? à vérifier — sinon `tokio_util
+  ::sync::CancellationToken`, `tokio-util` est déjà une dépendance du
+  projet) qui interrompt proprement le stream HTTP en cours.
+- **Concurrence** : un seul pull actif à la fois depuis la TUI (verrou
+  applicatif simple, ex. `app.active_pull: Option<PullHandle>`) — lancer un
+  second téléchargement pendant qu'un premier est en cours affiche un
+  message plutôt que de les empiler.
+- **Nouveau variant** `AppMode::ModelDownload` dans `src/tui/events.rs`
+  (même famille que `FilePicker`/`ToolApproval`), plus un évènement applicatif
+  `AppEvent::PullProgress(PullProgressEvent)` et `AppEvent::PullFinished { ok:
+  bool, model: String }` traités dans la boucle d'évènements existante
+  (à côté de `ToolApprovalRequested`).
+- **Rendu** : nouvelle fonction `render_model_download(f, app, area)` dans
+  `src/tui/components/dialogs/mod.rs`, suivant exactement le style
+  `Clear` + `Block` + `Borders::ALL` déjà utilisé par
+  `render_auto_exec_progress`.
+- **Persistance** : aucune — l'historique des téléchargements n'a pas besoin
+  d'être stocké en base ; seul l'état du modèle localement installé compte,
+  et il est déjà source de vérité côté disque/Ollama (`list_local_models()`
+  interrogé à chaque ouverture du dialog).
+- **CLI équivalente conservée** : `crustly ollama pull <name>` (§4.5) reste
+  disponible pour scripts/CI — le dialog TUI est une surface supplémentaire
+  au-dessus de la même fonction `pull_model()`, pas une réimplémentation.
 
 ## 6. Ce qui NE change PAS
 
@@ -452,8 +558,11 @@ show_performance_metrics = true   # défaut : true : masque le segment tok/s
   badge provider + segment tok/s dans l'en-tête, pied de message avec durée
   de génération. C'est la partie qui bénéficie **aussi** aux providers déjà
   en place (badge provider transverse).
-- **Phase 3 (gestion de modèles)** : `list`/`pull`/`rm`/`show` + sous-commande
-  CLI + panneau "Model Info" + barre de progression `pull` dans la TUI.
+- **Phase 3 (gestion de modèles + téléchargement interactif)** :
+  `list`/`pull`/`rm`/`show` + sous-commande CLI + panneau "Model Info" +
+  **dialog "Model Download" dans la TUI** (§5.7) permettant à l'utilisateur
+  de choisir/saisir un modèle et de le télécharger avec barre de progression
+  en direct, sans quitter Crustly.
 - **Phase 4** : embeddings natifs Ollama, exposés à la couche RAG/recherche
   interne si Crustly en a une (à confirmer selon le code existant).
 
@@ -475,3 +584,17 @@ show_performance_metrics = true   # défaut : true : masque le segment tok/s
    plus de colonnes à faire évoluer) — recommandation : JSON, cohérent avec
    le fait que ces métriques sont avant tout informatives/TUI et non
    utilisées dans des requêtes analytiques pour l'instant.
+6. Raccourci/entrée exacte pour ouvrir le dialog "Model Download" (`Ctrl+D`
+   proposé en §5.7.2, à vérifier vs raccourcis existants dans
+   `src/tui/events.rs`) et son alternative en commande slash (`/pull`,
+   `/download`) — à aligner sur les conventions déjà en place dans la barre
+   de saisie de Crustly (à confirmer si des commandes slash existent déjà).
+7. Faut-il permettre l'annulation propre d'un `pull` en cours (`Esc` →
+   `CancellationToken`), ou accepter que l'utilisateur laisse le
+   téléchargement se terminer en arrière-plan tout en revenant au chat
+   (moins de complexité, mais moins de contrôle utilisateur) ?
+8. La liste curatée de modèles suggérés (§5.7.2) doit-elle être codée en dur
+   dans le binaire (simple, nécessite une recompilation pour la mettre à
+   jour) ou chargée depuis un fichier de config/JSON embarqué modifiable par
+   l'utilisateur (plus flexible, légère complexité en plus) — recommandation :
+   codée en dur pour la v1, réévaluable si demande utilisateur.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -774,6 +774,7 @@ async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -
     // Create TUI app first (so we can get the event sender)
     tracing::debug!("Creating TUI app");
     let mut app = tui::App::new(agent_service, service_context.clone());
+    app.set_ollama_host(ollama_host(config));
 
     // Get event sender from app
     let event_sender = app.event_sender();
@@ -1063,7 +1064,8 @@ async fn cmd_keyring(operation: KeyringCommands) -> Result<()> {
 }
 
 /// Resolve the configured Ollama host, falling back to the local default.
-#[cfg(feature = "ollama")]
+/// Used both by `crustly ollama <...>` and to point the TUI's Model
+/// Download dialog (Ctrl+D) at the right instance.
 fn ollama_host(config: &crate::config::Config) -> String {
     config
         .providers

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1153,8 +1153,16 @@ async fn cmd_ollama(config: &crate::config::Config, operation: OllamaCommands) -
                 .next()
                 .context("Ollama returned no embedding vector")?;
 
-            println!("🦙 Embedding from '{}' ({} dimensions)\n", model, embedding.len());
-            let preview: Vec<String> = embedding.iter().take(8).map(|v| format!("{v:.4}")).collect();
+            println!(
+                "🦙 Embedding from '{}' ({} dimensions)\n",
+                model,
+                embedding.len()
+            );
+            let preview: Vec<String> = embedding
+                .iter()
+                .take(8)
+                .map(|v| format!("{v:.4}"))
+                .collect();
             println!("[{}, ...]", preview.join(", "));
             Ok(())
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1377,4 +1377,34 @@ mod tests {
         use clap::CommandFactory;
         Cli::command().debug_assert();
     }
+
+    #[test]
+    fn test_ollama_host_defaults_when_unconfigured() {
+        let config = crate::config::Config::default();
+        assert_eq!(ollama_host(&config), "http://localhost:11434");
+    }
+
+    #[test]
+    fn test_ollama_host_uses_configured_value() {
+        let mut config = crate::config::Config::default();
+        config.providers.ollama = Some(crate::config::OllamaProviderConfig {
+            enabled: true,
+            host: "http://my-ollama-box:11434".to_string(),
+            default_model: None,
+            keep_alive: None,
+            num_ctx: None,
+        });
+        assert_eq!(ollama_host(&config), "http://my-ollama-box:11434");
+    }
+
+    #[test]
+    fn test_ollama_command_parses() {
+        let cli = Cli::parse_from(["crustly", "ollama", "pull", "qwen2.5-coder:7b"]);
+        match cli.command {
+            Some(Commands::Ollama {
+                operation: OllamaCommands::Pull { model },
+            }) => assert_eq!(model, "qwen2.5-coder:7b"),
+            other => panic!("expected Ollama Pull command, got {other:?}"),
+        }
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -186,6 +186,42 @@ pub enum Commands {
         #[arg(short, long, default_value = "20")]
         max_iterations: u32,
     },
+
+    /// Manage local Ollama models (native provider, requires the crate's
+    /// 'ollama' build feature)
+    Ollama {
+        #[command(subcommand)]
+        operation: OllamaCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum OllamaCommands {
+    /// List models already pulled/installed locally
+    List,
+    /// Pull (download) a model by name, e.g. `qwen2.5-coder:7b`
+    Pull {
+        /// Model name/tag, exactly as understood by `ollama pull <name>`
+        model: String,
+    },
+    /// Delete a locally-installed model
+    Rm {
+        /// Model name/tag to delete
+        model: String,
+    },
+    /// Show details about a model (license, parameters, template, capabilities)
+    Show {
+        /// Model name/tag to inspect
+        model: String,
+    },
+    /// Generate an embedding vector for a piece of text using an
+    /// embedding-capable model (e.g. `nomic-embed-text`)
+    Embed {
+        /// Embedding model name/tag
+        model: String,
+        /// Text to embed
+        text: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -289,6 +325,7 @@ pub async fn run() -> Result<()> {
             goal,
             max_iterations,
         }) => cmd_autoplan(&config, goal, max_iterations).await,
+        Some(Commands::Ollama { operation }) => cmd_ollama(&config, operation).await,
     }
 }
 
@@ -1023,6 +1060,111 @@ async fn cmd_keyring(operation: KeyringCommands) -> Result<()> {
             Ok(())
         }
     }
+}
+
+/// Resolve the configured Ollama host, falling back to the local default.
+#[cfg(feature = "ollama")]
+fn ollama_host(config: &crate::config::Config) -> String {
+    config
+        .providers
+        .ollama
+        .as_ref()
+        .map(|c| c.host.clone())
+        .unwrap_or_else(|| "http://localhost:11434".to_string())
+}
+
+#[cfg(feature = "ollama")]
+async fn cmd_ollama(config: &crate::config::Config, operation: OllamaCommands) -> Result<()> {
+    use crate::llm::provider::ollama_models;
+
+    let host = ollama_host(config);
+
+    match operation {
+        OllamaCommands::List => {
+            println!("🦙 Models installed at {}\n", host);
+            let models = ollama_models::list_models(&host).await?;
+
+            if models.is_empty() {
+                println!("  (none) - pull one with: crustly ollama pull <model>");
+            } else {
+                for m in models {
+                    let size_gb = m.size_bytes as f64 / 1_073_741_824.0;
+                    println!("  {:<30} {:>7.2} GB   {}", m.name, size_gb, m.modified_at);
+                }
+            }
+            Ok(())
+        }
+
+        OllamaCommands::Pull { model } => {
+            println!("🦙 Pulling '{}' from {}...\n", model, host);
+
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let host_clone = host.clone();
+            let model_clone = model.clone();
+            let pull_task = tokio::spawn(async move {
+                ollama_models::pull_model(&host_clone, &model_clone, tx).await
+            });
+
+            let mut last_status = String::new();
+            while let Some(progress) = rx.recv().await {
+                if progress.status != last_status {
+                    println!("  {}", progress.status);
+                    last_status = progress.status.clone();
+                }
+                if let Some(fraction) = progress.fraction() {
+                    print!("\r  {:.0}%", fraction * 100.0);
+                    use std::io::Write as _;
+                    let _ = std::io::stdout().flush();
+                }
+            }
+            println!();
+
+            pull_task
+                .await
+                .context("Pull task panicked")?
+                .with_context(|| format!("Failed to pull model '{}'", model))?;
+
+            println!("✅ Pulled '{}'", model);
+            Ok(())
+        }
+
+        OllamaCommands::Rm { model } => {
+            ollama_models::delete_model(&host, &model).await?;
+            println!("✅ Deleted '{}'", model);
+            Ok(())
+        }
+
+        OllamaCommands::Show { model } => {
+            let info = ollama_models::show_model(&host, &model).await?;
+            println!("🦙 {}\n", model);
+            println!("License:\n{}\n", info.license);
+            println!("Parameters:\n{}\n", info.parameters);
+            println!("Template:\n{}\n", info.template);
+            println!("Capabilities: {}", info.capabilities.join(", "));
+            Ok(())
+        }
+
+        OllamaCommands::Embed { model, text } => {
+            let embeddings = ollama_models::generate_embeddings(&host, &model, vec![text]).await?;
+            let embedding = embeddings
+                .into_iter()
+                .next()
+                .context("Ollama returned no embedding vector")?;
+
+            println!("🦙 Embedding from '{}' ({} dimensions)\n", model, embedding.len());
+            let preview: Vec<String> = embedding.iter().take(8).map(|v| format!("{v:.4}")).collect();
+            println!("[{}, ...]", preview.join(", "));
+            Ok(())
+        }
+    }
+}
+
+#[cfg(not(feature = "ollama"))]
+async fn cmd_ollama(_config: &crate::config::Config, _operation: OllamaCommands) -> Result<()> {
+    anyhow::bail!(
+        "This build of crustly was compiled without the 'ollama' feature. \
+         Rebuild with `--features ollama` (or `all-llm`) to use `crustly ollama`."
+    );
 }
 
 /// FullAuto plan mode: no approval gates, runs to completion or max_iterations.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -283,6 +283,13 @@ pub struct ProviderConfigs {
     /// VertexAI configuration
     #[serde(default)]
     pub vertex: Option<ProviderConfig>,
+
+    /// Native Ollama configuration (via `ollama-rs`, `/api/chat`). Distinct
+    /// from `providers.openai.base_url` pointed at Ollama's OpenAI-compatible
+    /// `/v1` shim - both can be configured, this one unlocks keep_alive,
+    /// num_ctx and runtime performance metrics.
+    #[serde(default)]
+    pub ollama: Option<OllamaProviderConfig>,
 }
 
 /// Individual provider configuration
@@ -339,6 +346,47 @@ pub struct QwenProviderConfig {
     /// DashScope region: "intl" (Singapore) or "cn" (Beijing)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
+}
+
+/// Native Ollama provider configuration (`/api/chat`, via `ollama-rs`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OllamaProviderConfig {
+    /// Provider enabled
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    /// Ollama host, e.g. "http://localhost:11434"
+    #[serde(default = "default_ollama_host")]
+    pub host: String,
+
+    /// Default model to use (e.g. "qwen2.5-coder:7b")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_model: Option<String>,
+
+    /// How long to keep the model loaded in memory: "-1" (indefinitely),
+    /// "0" (unload immediately), or a duration like "5m"/"30s"/"2h".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_alive: Option<String>,
+
+    /// Context window size (num_ctx) to request from the model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_ctx: Option<u32>,
+}
+
+impl Default for OllamaProviderConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            host: default_ollama_host(),
+            default_model: None,
+            keep_alive: None,
+            num_ctx: None,
+        }
+    }
+}
+
+fn default_ollama_host() -> String {
+    "http://localhost:11434".to_string()
 }
 
 fn default_enabled() -> bool {
@@ -689,6 +737,26 @@ impl Config {
                 region: None,
             });
             provider.enable_thinking = thinking.parse().unwrap_or(false);
+        }
+
+        // Ollama native provider (distinct from OPENAI_BASE_URL pointed at
+        // Ollama's OpenAI-compatible shim). OLLAMA_HOST matches the official
+        // Ollama CLI's own env var convention.
+        if let Ok(host) = std::env::var("OLLAMA_HOST").or_else(|_| std::env::var("OLLAMA_BASE_URL"))
+        {
+            let provider = config
+                .providers
+                .ollama
+                .get_or_insert_with(OllamaProviderConfig::default);
+            provider.host = host;
+        }
+
+        if let Ok(model) = std::env::var("OLLAMA_MODEL") {
+            let provider = config
+                .providers
+                .ollama
+                .get_or_insert_with(OllamaProviderConfig::default);
+            provider.default_model = Some(model);
         }
 
         Ok(())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -947,6 +947,54 @@ enabled = false
     }
 
     #[test]
+    fn test_ollama_config_from_env() {
+        // Both OLLAMA_HOST-precedence and the OLLAMA_BASE_URL fallback are
+        // exercised in a single test (rather than two separate #[test] fns)
+        // because Rust runs tests in parallel by default and env vars are
+        // process-global - two tests toggling OLLAMA_HOST/OLLAMA_BASE_URL
+        // concurrently would race each other.
+        std::env::remove_var("OLLAMA_HOST");
+        std::env::remove_var("OLLAMA_BASE_URL");
+        std::env::remove_var("OLLAMA_MODEL");
+
+        std::env::set_var("OLLAMA_HOST", "http://ollama-box:11434");
+        std::env::set_var("OLLAMA_MODEL", "qwen2.5-coder:7b");
+
+        let config_with_env = Config::apply_env_overrides(Config::default()).unwrap();
+        let ollama = config_with_env
+            .providers
+            .ollama
+            .as_ref()
+            .expect("OLLAMA_HOST should populate providers.ollama");
+        assert_eq!(ollama.host, "http://ollama-box:11434");
+        assert_eq!(ollama.default_model, Some("qwen2.5-coder:7b".to_string()));
+
+        std::env::remove_var("OLLAMA_HOST");
+        std::env::remove_var("OLLAMA_MODEL");
+
+        // OLLAMA_BASE_URL is accepted when OLLAMA_HOST isn't set, for
+        // consistency with OPENAI_BASE_URL/QWEN_BASE_URL.
+        std::env::set_var("OLLAMA_BASE_URL", "http://remote-ollama:11434");
+        let config_with_env = Config::apply_env_overrides(Config::default()).unwrap();
+        assert_eq!(
+            config_with_env.providers.ollama.as_ref().unwrap().host,
+            "http://remote-ollama:11434"
+        );
+
+        std::env::remove_var("OLLAMA_BASE_URL");
+    }
+
+    #[test]
+    fn test_ollama_provider_config_default() {
+        let cfg = OllamaProviderConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.host, "http://localhost:11434");
+        assert_eq!(cfg.default_model, None);
+        assert_eq!(cfg.keep_alive, None);
+        assert_eq!(cfg.num_ctx, None);
+    }
+
+    #[test]
     fn test_system_config_path() {
         let path = Config::system_config_path();
         assert!(path.is_some());

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -18,6 +18,9 @@ pub struct Session {
     pub archived_at: Option<DateTime<Utc>>,
     pub token_count: i32,
     pub total_cost: f64,
+    /// Name of the LLM provider used (e.g. "ollama", "anthropic"), set lazily
+    /// on the first assistant response, mirroring `model`.
+    pub provider: Option<String>,
 }
 
 /// Message model
@@ -31,6 +34,11 @@ pub struct Message {
     pub created_at: DateTime<Utc>,
     pub token_count: Option<i32>,
     pub cost: Option<f64>,
+    /// Name of the provider that generated this message, if known.
+    pub provider_name: Option<String>,
+    /// Runtime performance metrics (`PerfMetrics`), JSON-serialized. `None`
+    /// for providers that don't expose this level of detail.
+    pub perf_metrics_json: Option<String>,
 }
 
 /// File model
@@ -183,6 +191,7 @@ impl Session {
             archived_at: None,
             token_count: 0,
             total_cost: 0.0,
+            provider: None,
         }
     }
 
@@ -204,6 +213,8 @@ impl Message {
             created_at: Utc::now(),
             token_count: None,
             cost: None,
+            provider_name: None,
+            perf_metrics_json: None,
         }
     }
 }
@@ -242,6 +253,7 @@ impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for Session {
                 .and_then(|ts| DateTime::from_timestamp(ts, 0)),
             token_count: row.try_get("token_count")?,
             total_cost: row.try_get("total_cost")?,
+            provider: row.try_get("provider")?,
         })
     }
 }
@@ -262,6 +274,8 @@ impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for Message {
                 .ok_or_else(|| sqlx::Error::Decode("Invalid timestamp for created_at".into()))?,
             token_count: row.try_get("token_count")?,
             cost: row.try_get("cost")?,
+            provider_name: row.try_get("provider_name")?,
+            perf_metrics_json: row.try_get("perf_metrics_json")?,
         })
     }
 }

--- a/src/db/repository/message.rs
+++ b/src/db/repository/message.rs
@@ -48,8 +48,8 @@ impl MessageRepository {
         sqlx::query(
             r#"
             INSERT INTO messages (id, session_id, role, content, sequence,
-                                 created_at, token_count, cost)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                                 created_at, token_count, cost, provider_name, perf_metrics_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(message.id.to_string())
@@ -60,6 +60,8 @@ impl MessageRepository {
         .bind(message.created_at.timestamp())
         .bind(message.token_count)
         .bind(message.cost)
+        .bind(&message.provider_name)
+        .bind(&message.perf_metrics_json)
         .execute(&self.pool)
         .await
         .context("Failed to create message")?;
@@ -77,13 +79,15 @@ impl MessageRepository {
         sqlx::query(
             r#"
             UPDATE messages
-            SET content = ?, token_count = ?, cost = ?
+            SET content = ?, token_count = ?, cost = ?, provider_name = ?, perf_metrics_json = ?
             WHERE id = ?
             "#,
         )
         .bind(&message.content)
         .bind(message.token_count)
         .bind(message.cost)
+        .bind(&message.provider_name)
+        .bind(&message.perf_metrics_json)
         .bind(message.id.to_string())
         .execute(&self.pool)
         .await

--- a/src/db/repository/session.rs
+++ b/src/db/repository/session.rs
@@ -47,8 +47,8 @@ impl SessionRepository {
         sqlx::query(
             r#"
             INSERT INTO sessions (id, title, model, created_at, updated_at,
-                                 archived_at, token_count, total_cost)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                                 archived_at, token_count, total_cost, provider)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(session.id.to_string())
@@ -59,6 +59,7 @@ impl SessionRepository {
         .bind(session.archived_at.map(|dt| dt.timestamp()))
         .bind(session.token_count)
         .bind(session.total_cost)
+        .bind(&session.provider)
         .execute(&self.pool)
         .await
         .context("Failed to create session")?;
@@ -73,7 +74,7 @@ impl SessionRepository {
             r#"
             UPDATE sessions
             SET title = ?, model = ?, updated_at = ?,
-                archived_at = ?, token_count = ?, total_cost = ?
+                archived_at = ?, token_count = ?, total_cost = ?, provider = ?
             WHERE id = ?
             "#,
         )
@@ -83,6 +84,7 @@ impl SessionRepository {
         .bind(session.archived_at.map(|dt| dt.timestamp()))
         .bind(session.token_count)
         .bind(session.total_cost)
+        .bind(&session.provider)
         .bind(session.id.to_string())
         .execute(&self.pool)
         .await

--- a/src/llm/agent/service.rs
+++ b/src/llm/agent/service.rs
@@ -267,6 +267,7 @@ async fn drain_stream_to_response(
         stop_reason,
         usage,
         cache_metrics: None,
+        perf_metrics: None,
     })
 }
 
@@ -404,6 +405,17 @@ impl AgentService {
             .await
             .map_err(|e| AgentError::Database(e.to_string()))?;
 
+        // Record which provider answered and, if available, its perf metrics
+        // (load/prefill/generation durations) - currently only Ollama.
+        message_service
+            .update_message_metrics(
+                assistant_db_msg.id,
+                self.provider.name(),
+                response.perf_metrics.as_ref(),
+            )
+            .await
+            .map_err(|e| AgentError::Database(e.to_string()))?;
+
         // Update session token usage
         session_service
             .update_session_usage(session_id, total_tokens as i32, cost)
@@ -418,6 +430,8 @@ impl AgentService {
             usage: response.usage,
             cost,
             model: response.model,
+            provider_name: self.provider.name().to_string(),
+            perf_metrics: response.perf_metrics,
         })
     }
 
@@ -1159,6 +1173,16 @@ impl AgentService {
             .await
             .map_err(|e| AgentError::Database(e.to_string()))?;
 
+        // Record which provider answered and, if available, its perf metrics.
+        message_service
+            .update_message_metrics(
+                assistant_db_msg.id,
+                self.provider.name(),
+                response.perf_metrics.as_ref(),
+            )
+            .await
+            .map_err(|e| AgentError::Database(e.to_string()))?;
+
         // Update session token usage
         session_service
             .update_session_usage(session_id, total_tokens as i32, cost)
@@ -1176,6 +1200,8 @@ impl AgentService {
             },
             cost,
             model: response.model,
+            provider_name: self.provider.name().to_string(),
+            perf_metrics: response.perf_metrics,
         })
     }
 
@@ -1325,6 +1351,14 @@ pub struct AgentResponse {
 
     /// Model used
     pub model: String,
+
+    /// Name of the provider that served this response (e.g. "ollama",
+    /// "openai", "anthropic"). Lets the TUI show which backend answered.
+    pub provider_name: String,
+
+    /// Runtime performance metrics, if the provider exposes them
+    /// (currently only the native Ollama provider).
+    pub perf_metrics: Option<crate::llm::provider::PerfMetrics>,
 }
 
 /// Streaming response from the agent
@@ -1452,6 +1486,7 @@ mod tests {
                     output_tokens: 20,
                 },
                 cache_metrics: None,
+                perf_metrics: None,
             })
         }
 
@@ -1582,6 +1617,7 @@ mod tests {
                         output_tokens: 20,
                     },
                     cache_metrics: None,
+                    perf_metrics: None,
                 })
             } else {
                 // Second call: final response after tool execution
@@ -1597,6 +1633,7 @@ mod tests {
                         output_tokens: 25,
                     },
                     cache_metrics: None,
+                    perf_metrics: None,
                 })
             }
         }

--- a/src/llm/provider/anthropic.rs
+++ b/src/llm/provider/anthropic.rs
@@ -106,6 +106,7 @@ impl AnthropicProvider {
                 output_tokens: response.usage.output_tokens,
             },
             cache_metrics,
+            perf_metrics: None,
         }
     }
 

--- a/src/llm/provider/factory.rs
+++ b/src/llm/provider/factory.rs
@@ -120,11 +120,21 @@ impl Provider for FailoverProvider {
 ///
 /// Priority order:
 /// 1. Qwen (if configured with credentials)
-/// 2. OpenAI (if configured with credentials)
-/// 3. Anthropic (default fallback)
+/// 2. Ollama native (if `providers.ollama` is configured)
+/// 3. OpenAI / OpenAI-compatible local (LM Studio, Ollama via `/v1`, LocalAI)
+/// 4. Anthropic (default fallback)
+///
+/// Ollama sits between Qwen and OpenAI so that existing setups using only
+/// `providers.openai.base_url` (LM Studio, Ollama-via-compat) keep resolving
+/// exactly as before when `providers.ollama` is absent.
 pub fn create_provider(config: &Config) -> Result<Arc<dyn Provider>> {
     // Try Qwen first
     if let Some(provider) = try_create_qwen(config)? {
+        return Ok(provider);
+    }
+
+    // Try native Ollama
+    if let Some(provider) = try_create_ollama(config)? {
         return Ok(provider);
     }
 
@@ -135,6 +145,49 @@ pub fn create_provider(config: &Config) -> Result<Arc<dyn Provider>> {
 
     // Fall back to Anthropic
     create_anthropic(config)
+}
+
+/// Try to create the native Ollama provider if `providers.ollama` is configured.
+#[cfg(feature = "ollama")]
+fn try_create_ollama(config: &Config) -> Result<Option<Arc<dyn Provider>>> {
+    use super::ollama::OllamaProvider;
+
+    let ollama_config = match &config.providers.ollama {
+        Some(cfg) if cfg.enabled => cfg,
+        _ => return Ok(None),
+    };
+
+    tracing::info!("Using native Ollama at: {}", ollama_config.host);
+    println!("🦙 Using native Ollama at: {}\n", ollama_config.host);
+
+    let mut provider = OllamaProvider::new(ollama_config.host.clone());
+    if let Some(model) = &ollama_config.default_model {
+        tracing::info!("Using custom default model: {}", model);
+        println!("📦 Model: {}\n", model);
+        provider = provider.with_default_model(model.clone());
+    }
+    if let Some(keep_alive) = &ollama_config.keep_alive {
+        provider = provider.with_keep_alive(keep_alive);
+    }
+    if let Some(num_ctx) = ollama_config.num_ctx {
+        provider = provider.with_num_ctx(num_ctx);
+    }
+
+    Ok(Some(Arc::new(provider)))
+}
+
+/// Without the `ollama` feature compiled in, a configured `providers.ollama`
+/// section is not silently ignored - it's a clear error pointing at the
+/// missing feature, rather than an unexplained fallback to another provider.
+#[cfg(not(feature = "ollama"))]
+fn try_create_ollama(config: &Config) -> Result<Option<Arc<dyn Provider>>> {
+    if config.providers.ollama.is_some() {
+        anyhow::bail!(
+            "providers.ollama is configured, but this build of crustly was compiled \
+             without the 'ollama' feature. Rebuild with `--features ollama` (or `all-llm`)."
+        );
+    }
+    Ok(None)
 }
 
 /// Try to create Qwen provider if configured
@@ -335,6 +388,7 @@ mod tests {
                     output_tokens: 1,
                 },
                 cache_metrics: None,
+                perf_metrics: None,
             })
         }
         async fn stream(&self, _req: LLMRequest) -> ProviderResult<ProviderStream> {

--- a/src/llm/provider/mod.rs
+++ b/src/llm/provider/mod.rs
@@ -3,6 +3,7 @@
 //! Provides a unified interface for interacting with different LLM providers.
 
 pub mod error;
+pub mod model_hints;
 pub mod retry;
 pub mod router;
 #[allow(clippy::module_inception)]
@@ -18,11 +19,17 @@ pub use types::*;
 pub mod anthropic;
 pub mod azure;
 pub mod factory;
+#[cfg(feature = "ollama")]
+pub mod ollama;
+#[cfg(feature = "ollama")]
+pub mod ollama_models;
 pub mod openai;
 pub mod qwen;
 
 pub use anthropic::AnthropicProvider;
 pub use azure::AzureOpenAIProvider;
 pub use factory::create_provider;
+#[cfg(feature = "ollama")]
+pub use ollama::OllamaProvider;
 pub use openai::OpenAIProvider;
 pub use qwen::{QwenProvider, ThinkingConfig, ToolCallParser};

--- a/src/llm/provider/model_hints.rs
+++ b/src/llm/provider/model_hints.rs
@@ -1,0 +1,45 @@
+//! Shared heuristics for guessing model capabilities from their name.
+//!
+//! Local model servers (Ollama, LM Studio, LocalAI, ...) don't expose a
+//! structured "supports vision" flag over their OpenAI-compatible or native
+//! chat APIs, so providers fall back to matching well-known substrings in
+//! the model name/tag (e.g. `llava:13b`, `llama3.2-vision:11b-instruct-fp16`).
+
+/// Returns `true` if `model_name` looks like a vision-capable model, based on
+/// a case-insensitive substring match against known model families.
+pub fn is_vision_model(model_name: &str) -> bool {
+    let model_lc = model_name.to_lowercase();
+    const VISION_PATTERNS: &[&str] = &[
+        "llava",
+        "vision",
+        "minicpm-v",
+        "bakllava",
+        "moondream",
+        "cogvlm",
+        "qwen-vl",
+        "qwenvl",
+        "internvl",
+        "phi-3-vision",
+        "phi3-vision",
+        "idefics",
+    ];
+    VISION_PATTERNS.iter().any(|p| model_lc.contains(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_known_vision_models() {
+        assert!(is_vision_model("llava:13b"));
+        assert!(is_vision_model("llama3.2-vision:11b-instruct-fp16"));
+        assert!(is_vision_model("MiniCPM-V-2.6"));
+    }
+
+    #[test]
+    fn rejects_non_vision_models() {
+        assert!(!is_vision_model("llama3.2:8b"));
+        assert!(!is_vision_model(""));
+    }
+}

--- a/src/llm/provider/ollama.rs
+++ b/src/llm/provider/ollama.rs
@@ -230,6 +230,7 @@ impl OllamaProvider {
 
     /// Convert an `ollama-rs` response into our generic `LLMResponse`,
     /// including `PerfMetrics` derived from the final-chunk timing data.
+    #[allow(clippy::wrong_self_convention)]
     fn from_ollama_response(&self, response: ChatMessageResponse) -> LLMResponse {
         let mut content_blocks = Vec::new();
 

--- a/src/llm/provider/ollama.rs
+++ b/src/llm/provider/ollama.rs
@@ -210,8 +210,7 @@ impl OllamaProvider {
             _ => ThinkType::High,
         });
 
-        let mut ollama_request =
-            ChatMessageRequest::new(request.model, messages).options(options);
+        let mut ollama_request = ChatMessageRequest::new(request.model, messages).options(options);
         if !tools.is_empty() {
             ollama_request = ollama_request.tools(tools);
         }
@@ -238,11 +237,7 @@ impl OllamaProvider {
         // Priority: explicit `message.thinking` field (native reasoning
         // models); fall back to `<think>...</think>` tags embedded in the
         // visible text (DeepSeek-R1/QwQ served through Ollama).
-        let explicit_thinking = response
-            .message
-            .thinking
-            .clone()
-            .filter(|t| !t.is_empty());
+        let explicit_thinking = response.message.thinking.clone().filter(|t| !t.is_empty());
         let (tag_thinking, visible_text) = match &explicit_thinking {
             Some(_) => (String::new(), response.message.content.clone()),
             None => extract_think_tags(&response.message.content),

--- a/src/llm/provider/ollama.rs
+++ b/src/llm/provider/ollama.rs
@@ -729,4 +729,244 @@ mod tests {
         assert_eq!(ollama_request.messages[0].role, MessageRole::System);
         assert_eq!(ollama_request.messages[1].role, MessageRole::User);
     }
+
+    fn mock_response(message: ChatMessage, done: bool) -> ChatMessageResponse {
+        ChatMessageResponse {
+            model: "llama3.2".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            message,
+            logprobs: None,
+            done,
+            final_data: None,
+        }
+    }
+
+    #[test]
+    fn from_ollama_response_plain_text_with_final_data() {
+        let provider = OllamaProvider::default_local();
+        let mut response = mock_response(ChatMessage::assistant("hello there".to_string()), true);
+        response.final_data = Some(ChatMessageFinalResponseData {
+            total_duration: 2_000_000_000,
+            load_duration: 0,
+            prompt_eval_count: 10,
+            prompt_eval_duration: 100_000_000,
+            eval_count: 20,
+            eval_duration: 1_000_000_000,
+        });
+
+        let llm_response = provider.from_ollama_response(response);
+        assert_eq!(llm_response.model, "llama3.2");
+        assert_eq!(llm_response.stop_reason, Some(StopReason::EndTurn));
+        assert_eq!(llm_response.usage.input_tokens, 10);
+        assert_eq!(llm_response.usage.output_tokens, 20);
+        assert!(llm_response.perf_metrics.is_some());
+        assert_eq!(llm_response.content.len(), 1);
+        assert!(matches!(
+            &llm_response.content[0],
+            ContentBlock::Text { text } if text == "hello there"
+        ));
+    }
+
+    #[test]
+    fn from_ollama_response_without_final_data_has_zero_usage_and_no_perf() {
+        let provider = OllamaProvider::default_local();
+        // Mid-stream chunk: done=false, no final_data yet.
+        let response = mock_response(ChatMessage::assistant("partial".to_string()), false);
+
+        let llm_response = provider.from_ollama_response(response);
+        assert_eq!(llm_response.stop_reason, None);
+        assert_eq!(llm_response.usage.input_tokens, 0);
+        assert_eq!(llm_response.usage.output_tokens, 0);
+        assert!(llm_response.perf_metrics.is_none());
+    }
+
+    #[test]
+    fn from_ollama_response_extracts_tool_calls() {
+        let provider = OllamaProvider::default_local();
+        let mut message = ChatMessage::assistant(String::new());
+        message.tool_calls = vec![ToolCall {
+            function: ToolCallFunction {
+                name: "read_file".to_string(),
+                arguments: serde_json::json!({"path": "src/main.rs"}),
+            },
+        }];
+        let response = mock_response(message, true);
+
+        let llm_response = provider.from_ollama_response(response);
+        assert_eq!(llm_response.stop_reason, Some(StopReason::ToolUse));
+        assert_eq!(llm_response.content.len(), 1);
+        match &llm_response.content[0] {
+            ContentBlock::ToolUse { name, input, .. } => {
+                assert_eq!(name, "read_file");
+                assert_eq!(input["path"], "src/main.rs");
+            }
+            other => panic!("expected ToolUse block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_ollama_response_uses_explicit_thinking_field() {
+        let provider = OllamaProvider::default_local();
+        let mut message = ChatMessage::assistant("the answer is 42".to_string());
+        message.thinking = Some("reasoning about the question".to_string());
+        let response = mock_response(message, true);
+
+        let llm_response = provider.from_ollama_response(response);
+        assert_eq!(llm_response.content.len(), 2);
+        assert!(matches!(
+            &llm_response.content[0],
+            ContentBlock::Thinking { thinking } if thinking == "reasoning about the question"
+        ));
+        assert!(matches!(
+            &llm_response.content[1],
+            ContentBlock::Text { text } if text == "the answer is 42"
+        ));
+    }
+
+    #[test]
+    fn from_ollama_response_falls_back_to_think_tags() {
+        let provider = OllamaProvider::default_local();
+        // No explicit `thinking` field - reasoning embedded as <think> tags
+        // in the visible text (DeepSeek-R1/QwQ style models via Ollama).
+        let message =
+            ChatMessage::assistant("<think>let me work this out</think>final answer".to_string());
+        let response = mock_response(message, true);
+
+        let llm_response = provider.from_ollama_response(response);
+        assert!(matches!(
+            &llm_response.content[0],
+            ContentBlock::Thinking { thinking } if thinking == "let me work this out"
+        ));
+        assert!(matches!(
+            &llm_response.content[1],
+            ContentBlock::Text { text } if text == "final answer"
+        ));
+    }
+
+    #[test]
+    fn to_ollama_tool_converts_valid_schema() {
+        let tool = Tool {
+            name: "read_file".to_string(),
+            description: "Reads a file".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": { "path": { "type": "string" } }
+            }),
+        };
+
+        let info = to_ollama_tool(&tool);
+        assert_eq!(info.function.name, "read_file");
+        assert_eq!(info.function.description, "Reads a file");
+    }
+
+    #[test]
+    fn to_ollama_tool_falls_back_on_invalid_schema() {
+        // A bare string is neither a JSON object nor a bool, so
+        // `Schema::try_from` fails and we fall back to an empty schema
+        // instead of propagating the error.
+        let tool = Tool {
+            name: "broken".to_string(),
+            description: "d".to_string(),
+            input_schema: serde_json::json!("not a schema"),
+        };
+
+        let info = to_ollama_tool(&tool);
+        assert_eq!(info.function.name, "broken");
+    }
+
+    #[test]
+    fn to_ollama_format_json_object_marker() {
+        let value = serde_json::json!({"type": "json_object"});
+        assert!(matches!(to_ollama_format(&value), Some(FormatType::Json)));
+    }
+
+    #[test]
+    fn to_ollama_format_structured_schema() {
+        let value = serde_json::json!({
+            "type": "object",
+            "properties": { "answer": { "type": "string" } }
+        });
+        assert!(matches!(
+            to_ollama_format(&value),
+            Some(FormatType::StructuredJson(_))
+        ));
+    }
+
+    #[test]
+    fn to_ollama_request_maps_tool_messages() {
+        let provider = OllamaProvider::default_local();
+        let request = LLMRequest::new(
+            "llama3.2",
+            vec![
+                Message {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::ToolUse {
+                        id: "call_1".to_string(),
+                        name: "read_file".to_string(),
+                        input: serde_json::json!({"path": "a.rs"}),
+                    }],
+                },
+                Message {
+                    role: Role::User,
+                    content: vec![ContentBlock::ToolResult {
+                        tool_use_id: "call_1".to_string(),
+                        content: "file contents".to_string(),
+                        is_error: None,
+                    }],
+                },
+            ],
+        );
+
+        let ollama_request = provider.to_ollama_request(request);
+        assert_eq!(ollama_request.messages.len(), 2);
+        assert_eq!(ollama_request.messages[0].tool_calls.len(), 1);
+        assert_eq!(
+            ollama_request.messages[0].tool_calls[0].function.name,
+            "read_file"
+        );
+        assert_eq!(ollama_request.messages[1].role, MessageRole::Tool);
+        assert_eq!(ollama_request.messages[1].content, "file contents");
+    }
+
+    #[test]
+    fn to_ollama_request_maps_thinking_and_response_format() {
+        let provider = OllamaProvider::default_local();
+        let request = LLMRequest::new("llama3.2", vec![Message::user("hi")])
+            .with_thinking(4_000)
+            .with_response_format(serde_json::json!({"type": "json_object"}));
+
+        let ollama_request = provider.to_ollama_request(request);
+        assert!(matches!(ollama_request.think, Some(ThinkType::Medium)));
+        assert!(matches!(ollama_request.format, Some(FormatType::Json)));
+    }
+
+    #[test]
+    fn to_ollama_request_embeds_base64_image() {
+        let provider = OllamaProvider::default_local();
+        let request = LLMRequest::new(
+            "llava:13b",
+            vec![Message {
+                role: Role::User,
+                content: vec![
+                    ContentBlock::Text {
+                        text: "what is this?".to_string(),
+                    },
+                    ContentBlock::Image {
+                        source: ImageSource::Base64 {
+                            media_type: "image/png".to_string(),
+                            data: "aGVsbG8=".to_string(),
+                        },
+                    },
+                ],
+            }],
+        );
+
+        let ollama_request = provider.to_ollama_request(request);
+        let images = ollama_request.messages[0]
+            .images
+            .as_ref()
+            .expect("image should be attached");
+        assert_eq!(images.len(), 1);
+        assert_eq!(images[0].to_base64(), "aGVsbG8=");
+    }
 }

--- a/src/llm/provider/ollama.rs
+++ b/src/llm/provider/ollama.rs
@@ -1,0 +1,736 @@
+//! Ollama Provider Implementation (native API, via `ollama-rs`)
+//!
+//! Implements the `Provider` trait against Ollama's native `/api/chat`
+//! protocol (as opposed to `OpenAIProvider::local()`, which talks to
+//! Ollama's OpenAI-compatible `/v1/chat/completions` shim). Both providers
+//! can be used side by side; this one additionally exposes:
+//!
+//! - `keep_alive` / `num_ctx` control
+//! - Runtime performance metrics (`PerfMetrics`): model load time, prefill
+//!   and generation durations, derived tokens/second — none of these are
+//!   present in Ollama's OpenAI-compatible response format.
+//!
+//! ## Note on error handling
+//!
+//! `ollama-rs` is built against `reqwest` 0.12, while the rest of this crate
+//! (and `super::error::ProviderError::HttpError`) uses `reqwest` 0.11 — the
+//! two major versions are distinct, incompatible Rust types and coexist in
+//! the dependency tree without being shared. Because of this, network-level
+//! errors from `ollama-rs` cannot be wrapped in `ProviderError::HttpError`
+//! and are mapped to `ProviderError::ApiError` instead (see
+//! `map_ollama_error`). As a consequence this provider does not go through
+//! `retry::retry_with_backoff` in this initial version: `ApiError { status:
+//! 0, .. }` is not classified as retryable, so a manual retry wrapper would
+//! be a no-op. Revisit if/when `ollama-rs` migrates to `reqwest` 0.11 or
+//! `ProviderError` grows a transport-agnostic "network error" variant.
+
+use super::error::{ProviderError, Result};
+use super::r#trait::{Provider, ProviderStream};
+use super::types::*;
+use async_trait::async_trait;
+use ollama_rs::{
+    error::OllamaError,
+    generation::chat::{
+        request::ChatMessageRequest, ChatMessage, ChatMessageFinalResponseData,
+        ChatMessageResponse, MessageRole,
+    },
+    generation::images::Image,
+    generation::parameters::{FormatType, JsonStructure, KeepAlive, ThinkType, TimeUnit},
+    generation::tools::{ToolCall, ToolCallFunction, ToolFunctionInfo, ToolInfo, ToolType},
+    models::ModelOptions,
+    Ollama,
+};
+
+/// Default local Ollama host, matching the `OLLAMA_HOST` CLI convention.
+const DEFAULT_OLLAMA_HOST: &str = "http://127.0.0.1:11434";
+
+/// Ollama provider using the native `/api/chat` protocol.
+#[derive(Clone)]
+pub struct OllamaProvider {
+    client: Ollama,
+    custom_default_model: Option<String>,
+    keep_alive: Option<KeepAlive>,
+    num_ctx: Option<u64>,
+}
+
+impl OllamaProvider {
+    /// Create a provider pointing at the default local Ollama instance
+    /// (`http://127.0.0.1:11434`).
+    pub fn default_local() -> Self {
+        Self::new(DEFAULT_OLLAMA_HOST)
+    }
+
+    /// Create a provider pointing at a custom Ollama host, e.g.
+    /// `http://localhost:11434` or a remote instance.
+    ///
+    /// Falls back to the default local host if `host` fails to parse as a
+    /// URL, to avoid a hard panic on a malformed config value.
+    pub fn new(host: impl Into<String>) -> Self {
+        let host = host.into();
+        let client = Ollama::try_new(host.clone()).unwrap_or_else(|e| {
+            tracing::warn!(
+                "Invalid Ollama host '{}' ({e}); falling back to {}",
+                host,
+                DEFAULT_OLLAMA_HOST
+            );
+            Ollama::default()
+        });
+
+        Self {
+            client,
+            custom_default_model: None,
+            keep_alive: None,
+            num_ctx: None,
+        }
+    }
+
+    /// Set custom default model (e.g. `qwen2.5-coder:7b`).
+    pub fn with_default_model(mut self, model: String) -> Self {
+        self.custom_default_model = Some(model);
+        self
+    }
+
+    /// Control how long the model stays loaded in memory after this
+    /// request. Accepts Ollama's own syntax: `"-1"` (indefinitely), `"0"`
+    /// (unload immediately), or a duration like `"5m"`/`"30s"`/`"2h"`.
+    /// Invalid values are ignored (logged, no `keep_alive` sent).
+    pub fn with_keep_alive(mut self, keep_alive: &str) -> Self {
+        match parse_keep_alive(keep_alive) {
+            Some(ka) => self.keep_alive = Some(ka),
+            None => tracing::warn!("Invalid keep_alive value '{}', ignoring", keep_alive),
+        }
+        self
+    }
+
+    /// Override the context window size (`num_ctx`) sent with every request.
+    pub fn with_num_ctx(mut self, num_ctx: u32) -> Self {
+        self.num_ctx = Some(num_ctx as u64);
+        self
+    }
+
+    /// Convert our generic request into an `ollama-rs` `ChatMessageRequest`.
+    fn to_ollama_request(&self, request: LLMRequest) -> ChatMessageRequest {
+        let mut messages: Vec<ChatMessage> = Vec::new();
+
+        if let Some(system) = &request.system {
+            messages.push(ChatMessage::system(system.clone()));
+        }
+
+        for msg in request.messages {
+            let role = match msg.role {
+                Role::User => MessageRole::User,
+                Role::Assistant => MessageRole::Assistant,
+                Role::System => MessageRole::System,
+            };
+
+            let mut text_parts = Vec::new();
+            let mut tool_uses = Vec::new();
+            let mut tool_results = Vec::new();
+            let mut images = Vec::new();
+
+            for block in msg.content {
+                match block {
+                    ContentBlock::Text { text } => text_parts.push(text),
+                    ContentBlock::ToolUse { name, input, .. } => tool_uses.push((name, input)),
+                    ContentBlock::ToolResult { content, .. } => tool_results.push(content),
+                    ContentBlock::Image { source } => match source {
+                        ImageSource::Base64 { data, .. } => images.push(Image::from_base64(data)),
+                        ImageSource::Url { url } => {
+                            tracing::warn!(
+                                "Ollama's native chat API only accepts base64-embedded images; \
+                                 skipping URL image: {}",
+                                url
+                            );
+                        }
+                    },
+                    ContentBlock::Thinking { .. } => {
+                        // Anthropic-specific extended-thinking block; not replayed to Ollama.
+                    }
+                }
+            }
+
+            if !tool_uses.is_empty() {
+                // Ollama's native tool_calls carry no id; ordering alone
+                // correlates them with the `tool` role messages that follow.
+                let mut chat_msg = ChatMessage::new(role, text_parts.join("\n"));
+                chat_msg.tool_calls = tool_uses
+                    .into_iter()
+                    .map(|(name, arguments)| ToolCall {
+                        function: ToolCallFunction { name, arguments },
+                    })
+                    .collect();
+                messages.push(chat_msg);
+            } else if !tool_results.is_empty() {
+                for content in tool_results {
+                    messages.push(ChatMessage::tool(content));
+                }
+            } else {
+                let mut chat_msg = ChatMessage::new(role, text_parts.join("\n"));
+                if !images.is_empty() {
+                    chat_msg = chat_msg.with_images(images);
+                }
+                messages.push(chat_msg);
+            }
+        }
+
+        let mut options = ModelOptions::default();
+        if let Some(t) = request.temperature {
+            options = options.temperature(t);
+        }
+        if let Some(p) = request.top_p {
+            options = options.top_p(p);
+        }
+        if let Some(seed) = request.seed.and_then(|s| i32::try_from(s).ok()) {
+            options = options.seed(seed);
+        }
+        if let Some(stop) = request.stop.clone() {
+            options = options.stop(stop);
+        }
+        if let Some(max_tokens) = request.max_tokens.and_then(|m| i32::try_from(m).ok()) {
+            options = options.num_predict(max_tokens);
+        }
+        if let Some(ctx) = self.num_ctx {
+            options = options.num_ctx(ctx);
+        }
+        // NOTE: Ollama's ModelOptions has no frequency_penalty/presence_penalty
+        // equivalent (only `repeat_penalty`, a different knob) - silently
+        // dropped rather than approximated.
+
+        let tools: Vec<ToolInfo> = request
+            .tools
+            .as_ref()
+            .map(|ts| ts.iter().map(to_ollama_tool).collect())
+            .unwrap_or_default();
+
+        let format = request.response_format.as_ref().and_then(to_ollama_format);
+
+        let think = request.thinking.as_ref().map(|t| match t.budget_tokens {
+            0..=2_000 => ThinkType::Low,
+            2_001..=8_000 => ThinkType::Medium,
+            _ => ThinkType::High,
+        });
+
+        let mut ollama_request =
+            ChatMessageRequest::new(request.model, messages).options(options);
+        if !tools.is_empty() {
+            ollama_request = ollama_request.tools(tools);
+        }
+        if let Some(format) = format {
+            ollama_request = ollama_request.format(format);
+        }
+        if let Some(think) = think {
+            ollama_request = ollama_request.think(think);
+        }
+        if let Some(ka) = self.keep_alive.clone() {
+            ollama_request = ollama_request.keep_alive(ka);
+        }
+
+        ollama_request
+    }
+
+    /// Convert an `ollama-rs` response into our generic `LLMResponse`,
+    /// including `PerfMetrics` derived from the final-chunk timing data.
+    fn from_ollama_response(&self, response: ChatMessageResponse) -> LLMResponse {
+        let mut content_blocks = Vec::new();
+
+        // --- Reasoning / thinking block ---
+        // Priority: explicit `message.thinking` field (native reasoning
+        // models); fall back to `<think>...</think>` tags embedded in the
+        // visible text (DeepSeek-R1/QwQ served through Ollama).
+        let explicit_thinking = response
+            .message
+            .thinking
+            .clone()
+            .filter(|t| !t.is_empty());
+        let (tag_thinking, visible_text) = match &explicit_thinking {
+            Some(_) => (String::new(), response.message.content.clone()),
+            None => extract_think_tags(&response.message.content),
+        };
+
+        if let Some(thinking) = explicit_thinking {
+            content_blocks.push(ContentBlock::Thinking { thinking });
+        } else if !tag_thinking.is_empty() {
+            content_blocks.push(ContentBlock::Thinking {
+                thinking: tag_thinking,
+            });
+        }
+
+        if !visible_text.is_empty() {
+            content_blocks.push(ContentBlock::Text { text: visible_text });
+        }
+
+        for tool_call in &response.message.tool_calls {
+            content_blocks.push(ContentBlock::ToolUse {
+                id: uuid::Uuid::new_v4().to_string(),
+                name: tool_call.function.name.clone(),
+                input: tool_call.function.arguments.clone(),
+            });
+        }
+
+        let stop_reason = if !response.message.tool_calls.is_empty() {
+            Some(StopReason::ToolUse)
+        } else if response.done {
+            Some(StopReason::EndTurn)
+        } else {
+            None
+        };
+
+        let (usage, perf_metrics) = match &response.final_data {
+            Some(final_data) => (
+                TokenUsage {
+                    input_tokens: final_data.prompt_eval_count as u32,
+                    output_tokens: final_data.eval_count as u32,
+                },
+                Some(perf_metrics_from_final_data(final_data)),
+            ),
+            None => (
+                TokenUsage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                },
+                None,
+            ),
+        };
+
+        LLMResponse {
+            id: format!("ollama-{}", uuid::Uuid::new_v4()),
+            model: response.model,
+            content: content_blocks,
+            stop_reason,
+            usage,
+            cache_metrics: None,
+            perf_metrics,
+        }
+    }
+}
+
+#[async_trait]
+impl Provider for OllamaProvider {
+    async fn complete(&self, request: LLMRequest) -> Result<LLMResponse> {
+        let model = request.model.clone();
+        let ollama_request = self.to_ollama_request(request);
+
+        tracing::info!(
+            "Ollama API request: model={}, tools={}",
+            model,
+            ollama_request.tools.len()
+        );
+
+        let response = self
+            .client
+            .send_chat_messages(ollama_request)
+            .await
+            .map_err(map_ollama_error)?;
+
+        let llm_response = self.from_ollama_response(response);
+        tracing::info!(
+            "Ollama API response: input_tokens={}, output_tokens={}, stop_reason={:?}",
+            llm_response.usage.input_tokens,
+            llm_response.usage.output_tokens,
+            llm_response.stop_reason
+        );
+
+        Ok(llm_response)
+    }
+
+    async fn stream(&self, request: LLMRequest) -> Result<ProviderStream> {
+        let model = request.model.clone();
+        let ollama_request = self.to_ollama_request(request);
+
+        tracing::info!("Ollama streaming request: model={}", model);
+
+        let mut chunk_stream = self
+            .client
+            .send_chat_messages_stream(ollama_request)
+            .await
+            .map_err(map_ollama_error)?;
+
+        let message_id = format!("ollama-{}", uuid::Uuid::new_v4());
+        let mut events: Vec<StreamEvent> = vec![StreamEvent::MessageStart {
+            message: StreamMessage {
+                id: message_id,
+                model: model.clone(),
+                role: Role::Assistant,
+                usage: TokenUsage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                },
+            },
+        }];
+
+        let mut text_block_started = false;
+        let mut final_tool_calls: Vec<(String, serde_json::Value)> = Vec::new();
+        let mut final_usage = TokenUsage {
+            input_tokens: 0,
+            output_tokens: 0,
+        };
+        let mut final_perf: Option<PerfMetrics> = None;
+        let mut stop_reason: Option<StopReason> = None;
+
+        {
+            use futures::StreamExt as _;
+            while let Some(item) = chunk_stream.next().await {
+                let chunk = match item {
+                    Ok(c) => c,
+                    Err(()) => {
+                        return Err(ProviderError::StreamError(
+                            "Ollama stream terminated with an error".to_string(),
+                        ));
+                    }
+                };
+
+                if let Some(thinking) = chunk.message.thinking.as_ref().filter(|t| !t.is_empty()) {
+                    events.push(StreamEvent::ContentBlockDelta {
+                        index: 0,
+                        delta: ContentDelta::ThinkingDelta {
+                            thinking: thinking.clone(),
+                        },
+                    });
+                }
+
+                if !chunk.message.content.is_empty() {
+                    if !text_block_started {
+                        text_block_started = true;
+                        events.push(StreamEvent::ContentBlockStart {
+                            index: 0,
+                            content_block: ContentBlock::Text {
+                                text: String::new(),
+                            },
+                        });
+                    }
+                    events.push(StreamEvent::ContentBlockDelta {
+                        index: 0,
+                        delta: ContentDelta::TextDelta {
+                            text: chunk.message.content.clone(),
+                        },
+                    });
+                }
+
+                if chunk.done {
+                    if !chunk.message.tool_calls.is_empty() {
+                        stop_reason = Some(StopReason::ToolUse);
+                        final_tool_calls = chunk
+                            .message
+                            .tool_calls
+                            .iter()
+                            .map(|tc| (tc.function.name.clone(), tc.function.arguments.clone()))
+                            .collect();
+                    } else {
+                        stop_reason = Some(StopReason::EndTurn);
+                    }
+
+                    if let Some(final_data) = &chunk.final_data {
+                        final_usage = TokenUsage {
+                            input_tokens: final_data.prompt_eval_count as u32,
+                            output_tokens: final_data.eval_count as u32,
+                        };
+                        final_perf = Some(perf_metrics_from_final_data(final_data));
+                    }
+                }
+            }
+        }
+
+        if text_block_started {
+            events.push(StreamEvent::ContentBlockStop { index: 0 });
+        }
+
+        for (i, (name, input)) in final_tool_calls.into_iter().enumerate() {
+            let index = if text_block_started { i + 1 } else { i };
+            events.push(StreamEvent::ContentBlockStart {
+                index,
+                content_block: ContentBlock::ToolUse {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    name,
+                    input,
+                },
+            });
+            events.push(StreamEvent::ContentBlockStop { index });
+        }
+
+        if stop_reason.is_some() {
+            events.push(StreamEvent::MessageDelta {
+                delta: MessageDelta {
+                    stop_reason,
+                    stop_sequence: None,
+                },
+                usage: final_usage,
+            });
+        }
+        // `perf_metrics` from `final_perf` isn't threaded onto `StreamEvent`
+        // today (no slot for it); non-streaming `complete()` is the primary
+        // path for surfacing PerfMetrics in the TUI (see agent/service.rs).
+        let _ = final_perf;
+        events.push(StreamEvent::MessageStop);
+
+        let event_stream = futures::stream::iter(events.into_iter().map(Ok::<_, ProviderError>));
+        Ok(Box::pin(event_stream))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_tools(&self) -> bool {
+        true
+    }
+
+    fn supports_vision(&self) -> bool {
+        super::model_hints::is_vision_model(self.default_model())
+    }
+
+    fn name(&self) -> &str {
+        "ollama"
+    }
+
+    fn default_model(&self) -> &str {
+        self.custom_default_model.as_deref().unwrap_or("llama3.2")
+    }
+
+    fn supported_models(&self) -> Vec<String> {
+        // Non-exhaustive: Ollama's model catalog is whatever the user has
+        // pulled locally. This is a curated list of common picks, used only
+        // as a hint; `validate_model` below always accepts any model name.
+        vec![
+            "llama3.2:3b".to_string(),
+            "llama3.1:8b".to_string(),
+            "qwen2.5-coder:7b".to_string(),
+            "gemma3:12b".to_string(),
+            "mistral:latest".to_string(),
+            "deepseek-r1:14b".to_string(),
+        ]
+    }
+
+    fn validate_model(&self, _model: &str) -> bool {
+        // Accept any locally-installed model name/tag.
+        true
+    }
+
+    fn context_window(&self, _model: &str) -> Option<u32> {
+        // If the caller configured a custom num_ctx, that's the actual
+        // running context window regardless of model. Otherwise fall back
+        // to a conservative default (most current local models support at
+        // least 8K), matching OpenAIProvider::local()'s behavior.
+        Some(self.num_ctx.map(|c| c as u32).unwrap_or(8_192))
+    }
+
+    fn calculate_cost(&self, _model: &str, _input_tokens: u32, _output_tokens: u32) -> f64 {
+        // Local inference: no per-token API cost.
+        0.0
+    }
+}
+
+/// Convert our generic `Tool` (name/description/JSON-Schema) into the
+/// `ToolInfo` shape `ollama-rs` sends over the wire.
+fn to_ollama_tool(tool: &Tool) -> ToolInfo {
+    let schema = schemars::Schema::try_from(tool.input_schema.clone()).unwrap_or_else(|e| {
+        tracing::warn!(
+            "Tool '{}' has an invalid JSON Schema ({e}); sending an empty schema",
+            tool.name
+        );
+        schemars::Schema::from(serde_json::Map::new())
+    });
+
+    ToolInfo {
+        tool_type: ToolType::Function,
+        function: ToolFunctionInfo {
+            name: tool.name.clone(),
+            description: tool.description.clone(),
+            parameters: schema,
+        },
+    }
+}
+
+/// Map our generic `response_format` (JSON mode marker or a raw JSON Schema)
+/// to Ollama's `FormatType`.
+fn to_ollama_format(value: &serde_json::Value) -> Option<FormatType> {
+    if value.get("type").and_then(|t| t.as_str()) == Some("json_object") {
+        return Some(FormatType::Json);
+    }
+    schemars::Schema::try_from(value.clone())
+        .ok()
+        .map(|schema| FormatType::StructuredJson(Box::new(JsonStructure::from(schema))))
+}
+
+/// Parse a `keep_alive` config string using Ollama's own syntax:
+/// `"-1"` (indefinitely), `"0"` (unload immediately), or `"<n><unit>"`
+/// with unit `s`/`m`/`h` (e.g. `"5m"`).
+fn parse_keep_alive(s: &str) -> Option<KeepAlive> {
+    match s {
+        "-1" => Some(KeepAlive::Indefinitely),
+        "0" => Some(KeepAlive::UnloadOnCompletion),
+        other => {
+            let last_char = other.chars().next_back()?;
+            let unit = match last_char {
+                's' => TimeUnit::Seconds,
+                'm' => TimeUnit::Minutes,
+                'h' => TimeUnit::Hours,
+                _ => return None,
+            };
+            let time = other[..other.len() - last_char.len_utf8()]
+                .parse::<u64>()
+                .ok()?;
+            Some(KeepAlive::Until { time, unit })
+        }
+    }
+}
+
+/// Convert Ollama's nanosecond-resolution timing data into `PerfMetrics`
+/// (millisecond resolution, plus derived warm/cold-start flag).
+fn perf_metrics_from_final_data(final_data: &ChatMessageFinalResponseData) -> PerfMetrics {
+    const NS_PER_MS: u64 = 1_000_000;
+    PerfMetrics {
+        load_duration_ms: Some(final_data.load_duration / NS_PER_MS),
+        prompt_eval_duration_ms: Some(final_data.prompt_eval_duration / NS_PER_MS),
+        eval_duration_ms: Some(final_data.eval_duration / NS_PER_MS),
+        total_duration_ms: Some(final_data.total_duration / NS_PER_MS),
+        model_was_loaded: Some(final_data.load_duration == 0),
+    }
+}
+
+/// Map `ollama-rs`'s error type to our provider-agnostic `ProviderError`.
+///
+/// See the module-level doc comment for why `OllamaError::ReqwestError`
+/// cannot become `ProviderError::HttpError` here.
+fn map_ollama_error(err: OllamaError) -> ProviderError {
+    match err {
+        OllamaError::JsonError(e) => ProviderError::JsonError(e),
+        OllamaError::ToolCallError(e) => ProviderError::InvalidRequest(e.to_string()),
+        OllamaError::InternalError(inner) => ProviderError::ApiError {
+            status: 0,
+            message: inner.message,
+            error_type: None,
+        },
+        OllamaError::ReqwestError(e) => ProviderError::ApiError {
+            status: 0,
+            message: format!("Ollama network error: {e}"),
+            error_type: Some("network_error".to_string()),
+        },
+        OllamaError::Other(msg) => {
+            if msg.to_lowercase().contains("not found") {
+                ProviderError::ModelNotFound(msg)
+            } else {
+                ProviderError::ApiError {
+                    status: 0,
+                    message: msg,
+                    error_type: None,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ollama_provider_creation() {
+        let provider = OllamaProvider::default_local();
+        assert_eq!(provider.name(), "ollama");
+        assert_eq!(provider.default_model(), "llama3.2");
+    }
+
+    #[test]
+    fn test_with_default_model() {
+        let provider =
+            OllamaProvider::default_local().with_default_model("qwen2.5-coder:7b".to_string());
+        assert_eq!(provider.default_model(), "qwen2.5-coder:7b");
+    }
+
+    #[test]
+    fn test_invalid_host_falls_back_to_default() {
+        // Not a valid URL - must not panic, falls back to the default host.
+        let provider = OllamaProvider::new("not a url");
+        assert_eq!(provider.name(), "ollama");
+    }
+
+    #[test]
+    fn test_validate_model_always_true() {
+        let provider = OllamaProvider::default_local();
+        assert!(provider.validate_model("anything-the-user-pulled:latest"));
+    }
+
+    #[test]
+    fn test_context_window_default_and_custom() {
+        let provider = OllamaProvider::default_local();
+        assert_eq!(provider.context_window("llama3.2"), Some(8_192));
+
+        let custom = OllamaProvider::default_local().with_num_ctx(32_768);
+        assert_eq!(custom.context_window("llama3.2"), Some(32_768));
+    }
+
+    #[test]
+    fn test_calculate_cost_is_always_zero() {
+        let provider = OllamaProvider::default_local();
+        assert_eq!(provider.calculate_cost("llama3.2", 10_000, 10_000), 0.0);
+    }
+
+    #[test]
+    fn test_supports_vision_detection() {
+        let vision = OllamaProvider::default_local().with_default_model("llava:13b".to_string());
+        assert!(vision.supports_vision());
+
+        let plain = OllamaProvider::default_local().with_default_model("llama3.2:8b".to_string());
+        assert!(!plain.supports_vision());
+    }
+
+    #[test]
+    fn test_parse_keep_alive() {
+        assert_eq!(parse_keep_alive("-1"), Some(KeepAlive::Indefinitely));
+        assert_eq!(parse_keep_alive("0"), Some(KeepAlive::UnloadOnCompletion));
+        assert_eq!(
+            parse_keep_alive("5m"),
+            Some(KeepAlive::Until {
+                time: 5,
+                unit: TimeUnit::Minutes
+            })
+        );
+        assert_eq!(parse_keep_alive("garbage"), None);
+    }
+
+    #[test]
+    fn test_perf_metrics_from_final_data() {
+        let final_data = ChatMessageFinalResponseData {
+            total_duration: 5_000_000_000,
+            load_duration: 0,
+            prompt_eval_count: 50,
+            prompt_eval_duration: 500_000_000,
+            eval_count: 200,
+            eval_duration: 4_000_000_000,
+        };
+        let perf = perf_metrics_from_final_data(&final_data);
+        assert_eq!(perf.total_duration_ms, Some(5_000));
+        assert_eq!(perf.load_duration_ms, Some(0));
+        assert_eq!(perf.prompt_eval_duration_ms, Some(500));
+        assert_eq!(perf.eval_duration_ms, Some(4_000));
+        assert_eq!(perf.model_was_loaded, Some(true));
+        assert_eq!(perf.tokens_per_second(200), Some(50.0));
+    }
+
+    #[test]
+    fn test_map_ollama_error_not_found() {
+        let err = map_ollama_error(OllamaError::Other(
+            "model \"bogus\" not found, try pulling it first".to_string(),
+        ));
+        assert!(matches!(err, ProviderError::ModelNotFound(_)));
+    }
+
+    #[test]
+    fn test_to_ollama_request_maps_common_fields() {
+        let provider = OllamaProvider::default_local();
+        let request = LLMRequest::new("llama3.2", vec![Message::user("hi")])
+            .with_system("be terse")
+            .with_temperature(0.5)
+            .with_top_p(0.9)
+            .with_seed(42)
+            .with_stop(vec!["STOP".to_string()])
+            .with_max_tokens(100);
+
+        let ollama_request = provider.to_ollama_request(request);
+        assert_eq!(ollama_request.model_name, "llama3.2");
+        // system message + user message
+        assert_eq!(ollama_request.messages.len(), 2);
+        assert_eq!(ollama_request.messages[0].role, MessageRole::System);
+        assert_eq!(ollama_request.messages[1].role, MessageRole::User);
+    }
+}

--- a/src/llm/provider/ollama_models.rs
+++ b/src/llm/provider/ollama_models.rs
@@ -1,0 +1,207 @@
+//! Ollama model management (list/pull/delete/show).
+//!
+//! Thin wrapper around `ollama-rs`'s `/api/tags`, `/api/pull`, `/api/delete`
+//! and `/api/show` endpoints, decoupled from `ollama-rs`'s own types so
+//! callers (CLI, TUI) depend on a small, stable surface.
+//!
+//! Note: Ollama has no API to *search* its online model library - only to
+//! pull a model whose `repo:tag` name is already known (exactly like
+//! `ollama pull <name>` on the CLI). Callers are responsible for supplying
+//! (or letting the user type/pick) a valid name.
+
+use anyhow::{Context, Result};
+use futures::StreamExt as _;
+use ollama_rs::generation::embeddings::request::{EmbeddingsInput, GenerateEmbeddingsRequest};
+use ollama_rs::Ollama;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// A locally-installed model, as reported by `/api/tags`.
+#[derive(Debug, Clone)]
+pub struct LocalModelInfo {
+    pub name: String,
+    pub size_bytes: u64,
+    pub modified_at: String,
+}
+
+/// One progress update from an in-flight `pull_model` download.
+#[derive(Debug, Clone)]
+pub struct PullProgress {
+    /// Human-readable status, e.g. "pulling manifest", "pulling <digest>",
+    /// "verifying sha256 digest", "success".
+    pub status: String,
+    /// Digest of the layer currently being downloaded, if applicable.
+    pub digest: Option<String>,
+    /// Total bytes for the current layer.
+    pub total: Option<u64>,
+    /// Bytes downloaded so far for the current layer.
+    pub completed: Option<u64>,
+}
+
+impl PullProgress {
+    /// Whether this update indicates the pull has finished successfully.
+    pub fn is_success(&self) -> bool {
+        self.status.eq_ignore_ascii_case("success")
+    }
+
+    /// Completion fraction for the current layer (0.0-1.0), if known.
+    pub fn fraction(&self) -> Option<f64> {
+        let total = self.total.filter(|t| *t > 0)? as f64;
+        let completed = self.completed? as f64;
+        Some((completed / total).clamp(0.0, 1.0))
+    }
+}
+
+/// Details about a model, as reported by `/api/show`.
+#[derive(Debug, Clone)]
+pub struct ModelDetails {
+    pub license: String,
+    pub parameters: String,
+    pub template: String,
+    pub capabilities: Vec<String>,
+}
+
+fn client_for(host: &str) -> Result<Ollama> {
+    Ollama::try_new(host).with_context(|| format!("Invalid Ollama host: {host}"))
+}
+
+/// List models already pulled/installed on the target Ollama instance.
+pub async fn list_models(host: &str) -> Result<Vec<LocalModelInfo>> {
+    let client = client_for(host)?;
+    let models = client
+        .list_local_models()
+        .await
+        .context("Failed to list local Ollama models")?;
+
+    Ok(models
+        .into_iter()
+        .map(|m| LocalModelInfo {
+            name: m.name,
+            size_bytes: m.size,
+            modified_at: m.modified_at,
+        })
+        .collect())
+}
+
+/// Show details about a model (license, parameters, template, capabilities).
+pub async fn show_model(host: &str, model_name: &str) -> Result<ModelDetails> {
+    let client = client_for(host)?;
+    let info = client
+        .show_model_info(model_name.to_string())
+        .await
+        .with_context(|| format!("Failed to show info for model '{model_name}'"))?;
+
+    Ok(ModelDetails {
+        license: info.license,
+        parameters: info.parameters,
+        template: info.template,
+        capabilities: info.capabilities,
+    })
+}
+
+/// Delete a locally-installed model.
+pub async fn delete_model(host: &str, model_name: &str) -> Result<()> {
+    let client = client_for(host)?;
+    client
+        .delete_model(model_name.to_string())
+        .await
+        .with_context(|| format!("Failed to delete model '{model_name}'"))?;
+    Ok(())
+}
+
+/// Pull (download) a model, streaming progress updates through `progress_tx`.
+///
+/// Used by both the `crustly ollama pull` CLI command and the TUI's
+/// "Model Download" dialog - callers own how progress is consumed (printed
+/// to stdout, or rendered as a live progress bar).
+pub async fn pull_model(
+    host: &str,
+    model_name: &str,
+    progress_tx: UnboundedSender<PullProgress>,
+) -> Result<()> {
+    let client = client_for(host)?;
+    let mut stream = client
+        .pull_model_stream(model_name.to_string(), false)
+        .await
+        .with_context(|| format!("Failed to start pulling model '{model_name}'"))?;
+
+    while let Some(item) = stream.next().await {
+        let status = item.with_context(|| format!("Error while pulling model '{model_name}'"))?;
+        // Ignore send errors: the receiver (CLI printer / TUI dialog) may
+        // have been dropped if the user cancelled or the view closed.
+        let _ = progress_tx.send(PullProgress {
+            status: status.message,
+            digest: status.digest,
+            total: status.total,
+            completed: status.completed,
+        });
+    }
+
+    Ok(())
+}
+
+/// Generate embedding vectors for one or more input strings using an
+/// embedding-capable Ollama model (e.g. `nomic-embed-text`, `mxbai-embed-large`).
+///
+/// Not wired into a RAG/retrieval layer - Crustly doesn't have one yet. This
+/// exposes the raw capability (one embedding vector per input string, same
+/// order) for future callers (semantic search, codebase indexing, etc.).
+pub async fn generate_embeddings(
+    host: &str,
+    model_name: &str,
+    input: Vec<String>,
+) -> Result<Vec<Vec<f32>>> {
+    let client = client_for(host)?;
+    let request =
+        GenerateEmbeddingsRequest::new(model_name.to_string(), EmbeddingsInput::Multiple(input));
+
+    let response = client
+        .generate_embeddings(request)
+        .await
+        .with_context(|| format!("Failed to generate embeddings with model '{model_name}'"))?;
+
+    Ok(response.embeddings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pull_progress_fraction() {
+        let p = PullProgress {
+            status: "pulling abc123".to_string(),
+            digest: Some("abc123".to_string()),
+            total: Some(1000),
+            completed: Some(250),
+        };
+        assert_eq!(p.fraction(), Some(0.25));
+    }
+
+    #[test]
+    fn pull_progress_fraction_missing_data() {
+        let p = PullProgress {
+            status: "pulling manifest".to_string(),
+            digest: None,
+            total: None,
+            completed: None,
+        };
+        assert_eq!(p.fraction(), None);
+    }
+
+    #[test]
+    fn pull_progress_is_success() {
+        let p = PullProgress {
+            status: "success".to_string(),
+            digest: None,
+            total: None,
+            completed: None,
+        };
+        assert!(p.is_success());
+    }
+
+    #[test]
+    fn invalid_host_returns_error() {
+        let result = client_for("not a url");
+        assert!(result.is_err());
+    }
+}

--- a/src/llm/provider/ollama_models.rs
+++ b/src/llm/provider/ollama_models.rs
@@ -204,4 +204,29 @@ mod tests {
         let result = client_for("not a url");
         assert!(result.is_err());
     }
+
+    #[test]
+    fn embeddings_request_serializes_model_and_input() {
+        // Mirrors what `generate_embeddings()` builds internally - verifies
+        // the wire shape without needing a live Ollama server.
+        let request = GenerateEmbeddingsRequest::new(
+            "nomic-embed-text".to_string(),
+            EmbeddingsInput::Multiple(vec!["hello".to_string(), "world".to_string()]),
+        );
+        let value = serde_json::to_value(&request).expect("serialize request");
+        assert_eq!(value["model"], "nomic-embed-text");
+        assert_eq!(value["input"], serde_json::json!(["hello", "world"]));
+    }
+
+    #[test]
+    fn embeddings_request_single_input_is_not_wrapped_in_array() {
+        // EmbeddingsInput::Single serializes as a bare string, not a
+        // one-element array - Ollama's API distinguishes the two shapes.
+        let request = GenerateEmbeddingsRequest::new(
+            "nomic-embed-text".to_string(),
+            EmbeddingsInput::Single("hello".to_string()),
+        );
+        let value = serde_json::to_value(&request).expect("serialize request");
+        assert_eq!(value["input"], serde_json::json!("hello"));
+    }
 }

--- a/src/llm/provider/ollama_models.rs
+++ b/src/llm/provider/ollama_models.rs
@@ -229,4 +229,121 @@ mod tests {
         let value = serde_json::to_value(&request).expect("serialize request");
         assert_eq!(value["input"], serde_json::json!("hello"));
     }
+
+    /// Spin up a one-shot local HTTP server that replies with a fixed body
+    /// to the first request it receives, then closes. Mirrors the raw-TCP
+    /// mocking technique `ollama-rs` itself uses in its own test suite, so
+    /// no extra HTTP-mocking dependency is needed here.
+    async fn mock_server(body: String) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+
+            let mut request = Vec::new();
+            let mut buf = [0u8; 1024];
+            loop {
+                let n = socket.read(&mut buf).await.expect("read request");
+                if n == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn list_models_parses_tags_response() {
+        let host = mock_server(
+            r#"{"models":[{"name":"qwen2.5-coder:7b","modified_at":"2026-01-01T00:00:00Z","size":4500000000}]}"#
+                .to_string(),
+        )
+        .await;
+
+        let models = list_models(&host).await.expect("list_models succeeds");
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].name, "qwen2.5-coder:7b");
+        assert_eq!(models[0].size_bytes, 4_500_000_000);
+    }
+
+    #[tokio::test]
+    async fn show_model_parses_minimal_response() {
+        let host = mock_server(
+            r#"{"license":"MIT","parameters":"num_ctx 4096","template":"{{ .Prompt }}","capabilities":["completion"]}"#
+                .to_string(),
+        )
+        .await;
+
+        let info = show_model(&host, "qwen2.5-coder:7b")
+            .await
+            .expect("show_model succeeds");
+        assert_eq!(info.license, "MIT");
+        assert_eq!(info.capabilities, vec!["completion".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn delete_model_succeeds_on_2xx() {
+        let host = mock_server("{}".to_string()).await;
+        delete_model(&host, "qwen2.5-coder:7b")
+            .await
+            .expect("delete_model succeeds");
+    }
+
+    #[tokio::test]
+    async fn pull_model_forwards_progress_and_completes() {
+        let body = concat!(
+            r#"{"status":"pulling manifest"}"#,
+            "\n",
+            r#"{"status":"pulling abc123","digest":"abc123","total":100,"completed":50}"#,
+            "\n",
+            r#"{"status":"success"}"#,
+            "\n",
+        );
+        let host = mock_server(body.to_string()).await;
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        pull_model(&host, "qwen2.5-coder:7b", tx)
+            .await
+            .expect("pull_model succeeds");
+
+        let mut updates = Vec::new();
+        while let Ok(update) = rx.try_recv() {
+            updates.push(update);
+        }
+
+        assert_eq!(updates.len(), 3);
+        assert_eq!(updates[0].status, "pulling manifest");
+        assert_eq!(updates[1].fraction(), Some(0.5));
+        assert!(updates[2].is_success());
+    }
+
+    #[tokio::test]
+    async fn generate_embeddings_parses_response() {
+        let host = mock_server(r#"{"embeddings":[[0.1,0.2,0.3]]}"#.to_string()).await;
+
+        let embeddings = generate_embeddings(&host, "nomic-embed-text", vec!["hello".to_string()])
+            .await
+            .expect("generate_embeddings succeeds");
+        assert_eq!(embeddings, vec![vec![0.1, 0.2, 0.3]]);
+    }
 }

--- a/src/llm/provider/openai.rs
+++ b/src/llm/provider/openai.rs
@@ -401,6 +401,7 @@ impl OpenAIProvider {
                     .unwrap_or(0),
             },
             cache_metrics: None,
+            perf_metrics: None,
         }
     }
 
@@ -818,29 +819,9 @@ impl Provider for OpenAIProvider {
 
     fn supports_vision(&self) -> bool {
         // Detect common vision-capable model names served through Ollama and
-        // other OpenAI-compatible backends.  The check is intentionally broad
-        // (substring match, case-insensitive) to handle tag variants like
-        // "llava:13b", "llama3.2-vision:11b-instruct-fp16", etc.
-        let model_lc = self
-            .custom_default_model
-            .as_deref()
-            .unwrap_or("")
-            .to_lowercase();
-        let vision_patterns = [
-            "llava",
-            "vision",
-            "minicpm-v",
-            "bakllava",
-            "moondream",
-            "cogvlm",
-            "qwen-vl",
-            "qwenvl",
-            "internvl",
-            "phi-3-vision",
-            "phi3-vision",
-            "idefics",
-        ];
-        vision_patterns.iter().any(|p| model_lc.contains(p))
+        // other OpenAI-compatible backends. Shared with OllamaProvider so both
+        // stay in sync (see `model_hints::is_vision_model`).
+        super::model_hints::is_vision_model(self.custom_default_model.as_deref().unwrap_or(""))
     }
 
     fn name(&self) -> &str {

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -810,6 +810,7 @@ impl QwenProvider {
                 output_tokens: response.usage.completion_tokens,
             },
             cache_metrics: None,
+            perf_metrics: None,
         }
     }
 

--- a/src/llm/provider/types.rs
+++ b/src/llm/provider/types.rs
@@ -304,6 +304,38 @@ pub struct LLMResponse {
     /// Optional prompt cache metrics (Anthropic only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_metrics: Option<CacheMetrics>,
+    /// Optional runtime performance metrics (local inference backends, e.g. Ollama).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub perf_metrics: Option<PerfMetrics>,
+}
+
+/// Runtime performance metrics reported by local inference backends.
+///
+/// `None` for providers that don't expose this level of detail (Anthropic,
+/// OpenAI, Qwen, Azure) — purely additive, no behavior change for them.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PerfMetrics {
+    /// Time to load/warm the model into memory (ms). `Some(0)` when the
+    /// model was already resident (warm start).
+    pub load_duration_ms: Option<u64>,
+    /// Prefill duration — time spent evaluating the input prompt (ms).
+    pub prompt_eval_duration_ms: Option<u64>,
+    /// Generation duration — time spent producing the output (ms).
+    pub eval_duration_ms: Option<u64>,
+    /// Total wall-clock duration for the request (ms).
+    pub total_duration_ms: Option<u64>,
+    /// `true` if the model was already loaded (warm start), `false` if it
+    /// had to be loaded first (cold start), `None` if unknown/unsupported.
+    pub model_was_loaded: Option<bool>,
+}
+
+impl PerfMetrics {
+    /// Generation throughput in tokens/second, derived from the output
+    /// token count and the measured generation duration.
+    pub fn tokens_per_second(&self, output_tokens: u32) -> Option<f64> {
+        let ms = self.eval_duration_ms?;
+        (ms > 0).then(|| output_tokens as f64 / (ms as f64 / 1000.0))
+    }
 }
 
 /// Reason why the model stopped generating
@@ -509,6 +541,30 @@ mod tests {
         assert!((cm.hit_rate() - 0.8).abs() < 0.001);
         let empty = CacheMetrics::default();
         assert_eq!(empty.hit_rate(), 0.0);
+    }
+
+    #[test]
+    fn perf_metrics_tokens_per_second() {
+        let pm = PerfMetrics {
+            eval_duration_ms: Some(2_000),
+            ..Default::default()
+        };
+        assert_eq!(pm.tokens_per_second(100), Some(50.0));
+    }
+
+    #[test]
+    fn perf_metrics_tokens_per_second_missing_duration() {
+        let pm = PerfMetrics::default();
+        assert_eq!(pm.tokens_per_second(100), None);
+    }
+
+    #[test]
+    fn perf_metrics_tokens_per_second_zero_duration() {
+        let pm = PerfMetrics {
+            eval_duration_ms: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(pm.tokens_per_second(100), None);
     }
 
     #[test]

--- a/src/services/message.rs
+++ b/src/services/message.rs
@@ -132,7 +132,11 @@ impl MessageService {
             .await
             .context("Failed to update message metrics")?;
 
-        tracing::debug!("Updated message metrics: {} (provider: {})", id, provider_name);
+        tracing::debug!(
+            "Updated message metrics: {} (provider: {})",
+            id,
+            provider_name
+        );
         Ok(())
     }
 

--- a/src/services/message.rs
+++ b/src/services/message.rs
@@ -310,6 +310,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_message_metrics_with_perf_data() {
+        use crate::llm::provider::PerfMetrics;
+
+        let (message_service, session_service) = create_test_service().await;
+        let session = session_service
+            .create_session(Some("Test".to_string()))
+            .await
+            .unwrap();
+        let message = message_service
+            .create_message(session.id, "assistant".to_string(), "Hi".to_string())
+            .await
+            .unwrap();
+
+        let perf = PerfMetrics {
+            load_duration_ms: Some(0),
+            prompt_eval_duration_ms: Some(50),
+            eval_duration_ms: Some(400),
+            total_duration_ms: Some(450),
+            model_was_loaded: Some(true),
+        };
+        message_service
+            .update_message_metrics(message.id, "ollama", Some(&perf))
+            .await
+            .unwrap();
+
+        let updated = message_service
+            .get_message_required(message.id)
+            .await
+            .unwrap();
+        assert_eq!(updated.provider_name, Some("ollama".to_string()));
+        let stored: PerfMetrics =
+            serde_json::from_str(&updated.perf_metrics_json.unwrap()).unwrap();
+        assert_eq!(stored.eval_duration_ms, Some(400));
+    }
+
+    #[tokio::test]
+    async fn test_update_message_metrics_without_perf_data() {
+        let (message_service, session_service) = create_test_service().await;
+        let session = session_service
+            .create_session(Some("Test".to_string()))
+            .await
+            .unwrap();
+        let message = message_service
+            .create_message(session.id, "assistant".to_string(), "Hi".to_string())
+            .await
+            .unwrap();
+
+        message_service
+            .update_message_metrics(message.id, "anthropic", None)
+            .await
+            .unwrap();
+
+        let updated = message_service
+            .get_message_required(message.id)
+            .await
+            .unwrap();
+        assert_eq!(updated.provider_name, Some("anthropic".to_string()));
+        assert_eq!(updated.perf_metrics_json, None);
+    }
+
+    #[tokio::test]
     async fn test_delete_message() {
         let (message_service, session_service) = create_test_service().await;
         let session = session_service

--- a/src/services/message.rs
+++ b/src/services/message.rs
@@ -41,6 +41,8 @@ impl MessageService {
             created_at: Utc::now(),
             token_count: None,
             cost: None,
+            provider_name: None,
+            perf_metrics_json: None,
         };
 
         repo.create(&message)
@@ -105,6 +107,32 @@ impl MessageService {
             token_count,
             cost
         );
+        Ok(())
+    }
+
+    /// Record which provider generated this message and, if available, its
+    /// runtime performance metrics (load/prefill/generation durations).
+    /// `perf_metrics` is only populated for providers that expose this level
+    /// of detail (currently the native Ollama provider).
+    pub async fn update_message_metrics(
+        &self,
+        id: Uuid,
+        provider_name: &str,
+        perf_metrics: Option<&crate::llm::provider::PerfMetrics>,
+    ) -> Result<()> {
+        let mut message = self.get_message_required(id).await?;
+        message.provider_name = Some(provider_name.to_string());
+        message.perf_metrics_json = perf_metrics
+            .map(serde_json::to_string)
+            .transpose()
+            .context("Failed to serialize perf_metrics")?;
+
+        let repo = MessageRepository::new(self.context.pool());
+        repo.update(&message)
+            .await
+            .context("Failed to update message metrics")?;
+
+        tracing::debug!("Updated message metrics: {} (provider: {})", id, provider_name);
         Ok(())
     }
 

--- a/src/services/session.rs
+++ b/src/services/session.rs
@@ -38,6 +38,7 @@ impl SessionService {
             model: None,
             token_count: 0,
             total_cost: 0.0,
+            provider: None,
         };
 
         repo.create(&session)

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -25,10 +25,26 @@ pub struct DisplayMessage {
     pub timestamp: chrono::DateTime<chrono::Utc>,
     pub token_count: Option<i32>,
     pub cost: Option<f64>,
+    /// Name of the provider that generated this message (e.g. "ollama"),
+    /// if known.
+    pub provider_name: Option<String>,
+    /// Runtime performance metrics (load/prefill/generation durations),
+    /// if the provider exposes them.
+    pub perf_metrics: Option<crate::llm::provider::PerfMetrics>,
+    /// Generation throughput in tokens/second, precomputed when the message
+    /// is created (needs the exact output-token count, which isn't
+    /// recoverable from the combined `token_count` stored in the DB - so
+    /// this is `None` again after a session reload).
+    pub tokens_per_second: Option<f64>,
 }
 
 impl From<Message> for DisplayMessage {
     fn from(msg: Message) -> Self {
+        let perf_metrics = msg
+            .perf_metrics_json
+            .as_deref()
+            .and_then(|json| serde_json::from_str(json).ok());
+
         Self {
             id: msg.id,
             role: msg.role,
@@ -38,6 +54,9 @@ impl From<Message> for DisplayMessage {
             timestamp: msg.created_at,
             token_count: msg.token_count,
             cost: msg.cost,
+            provider_name: msg.provider_name,
+            perf_metrics,
+            tokens_per_second: None,
         }
     }
 }
@@ -632,6 +651,9 @@ impl App {
                 timestamp: chrono::Utc::now(),
                 token_count: None,
                 cost: None,
+                provider_name: None,
+                perf_metrics: None,
+                tokens_per_second: None,
             };
             self.messages.push(user_msg);
 
@@ -723,16 +745,30 @@ impl App {
                 response.usage.input_tokens as i32 + response.usage.output_tokens as i32,
             ),
             cost: Some(response.cost),
+            provider_name: Some(response.provider_name.clone()),
+            tokens_per_second: response
+                .perf_metrics
+                .as_ref()
+                .and_then(|pm| pm.tokens_per_second(response.usage.output_tokens)),
+            perf_metrics: response.perf_metrics.clone(),
         };
         self.messages.push(assistant_msg);
 
-        // Update session model if not already set
+        // Update session model/provider if not already set
         if let Some(session) = &mut self.current_session {
+            let mut needs_save = false;
             if session.model.is_none() {
                 session.model = Some(response.model.clone());
+                needs_save = true;
+            }
+            if session.provider.is_none() {
+                session.provider = Some(response.provider_name.clone());
+                needs_save = true;
+            }
+            if needs_save {
                 // Save the updated session to database
                 if let Err(e) = self.session_service.update_session(session).await {
-                    tracing::warn!("Failed to update session model: {}", e);
+                    tracing::warn!("Failed to update session model/provider: {}", e);
                 }
             }
         }
@@ -756,6 +792,9 @@ impl App {
                     timestamp: chrono::Utc::now(),
                     token_count: None,
                     cost: None,
+                    provider_name: None,
+                    perf_metrics: None,
+                    tokens_per_second: None,
                 };
                 self.messages.push(error_msg);
             } else {
@@ -940,6 +979,9 @@ impl App {
                             timestamp: chrono::Utc::now(),
                             token_count: None,
                             cost: None,
+                            provider_name: None,
+                            perf_metrics: None,
+                            tokens_per_second: None,
                         };
 
                         self.messages.push(notification);
@@ -1010,6 +1052,9 @@ impl App {
                                     timestamp: chrono::Utc::now(),
                                     token_count: None,
                                     cost: None,
+                                    provider_name: None,
+                                    perf_metrics: None,
+                                    tokens_per_second: None,
                                 };
 
                                 self.messages.push(notification);
@@ -1249,6 +1294,9 @@ impl App {
                 timestamp: chrono::Utc::now(),
                 token_count: None,
                 cost: None,
+                provider_name: None,
+                perf_metrics: None,
+                tokens_per_second: None,
             };
             self.messages.push(completion_msg);
         } else if let Some(message) = task_message {
@@ -1447,6 +1495,8 @@ mod tests {
             created_at: chrono::Utc::now(),
             token_count: Some(10),
             cost: Some(0.001),
+            provider_name: None,
+            perf_metrics_json: None,
         };
 
         let display_msg: DisplayMessage = msg.into();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1685,4 +1685,216 @@ mod tests {
         assert_eq!(display_msg.role, "user");
         assert_eq!(display_msg.content, "Hello");
     }
+
+    use crate::db::Database;
+    use crate::llm::provider::{
+        LLMRequest, LLMResponse, Provider, ProviderStream, Result as ProviderResult,
+    };
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    /// Minimal `Provider` stub - these tests only exercise the Model
+    /// Download dialog's state machine, never an actual chat request.
+    struct DummyProvider;
+
+    #[async_trait::async_trait]
+    impl Provider for DummyProvider {
+        async fn complete(&self, _request: LLMRequest) -> ProviderResult<LLMResponse> {
+            unimplemented!("dialog tests never call complete()")
+        }
+        async fn stream(&self, _request: LLMRequest) -> ProviderResult<ProviderStream> {
+            unimplemented!("dialog tests never call stream()")
+        }
+        fn name(&self) -> &str {
+            "dummy"
+        }
+        fn default_model(&self) -> &str {
+            "dummy-model"
+        }
+        fn supported_models(&self) -> Vec<String> {
+            vec!["dummy-model".to_string()]
+        }
+        fn context_window(&self, _model: &str) -> Option<u32> {
+            Some(4096)
+        }
+        fn calculate_cost(&self, _model: &str, _input: u32, _output: u32) -> f64 {
+            0.0
+        }
+    }
+
+    async fn test_app() -> App {
+        let db = Database::connect_in_memory().await.expect("in-memory db");
+        db.run_migrations().await.expect("run migrations");
+        let context = ServiceContext::new(db.pool().clone());
+        let agent_service = Arc::new(AgentService::new(Arc::new(DummyProvider), context.clone()));
+        App::new(agent_service, context)
+    }
+
+    fn key(code: KeyCode) -> crossterm::event::KeyEvent {
+        crossterm::event::KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[tokio::test]
+    async fn open_model_download_switches_mode_and_seeds_suggestions() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+
+        assert_eq!(app.mode, AppMode::ModelDownload);
+        assert!(app.model_download_input.is_empty());
+        assert!(
+            !app.model_download_suggestions.is_empty(),
+            "curated models should seed the suggestion list immediately"
+        );
+    }
+
+    #[tokio::test]
+    async fn model_download_typing_filters_suggestions() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+
+        app.handle_model_download_key(key(KeyCode::Char('l')))
+            .await
+            .unwrap();
+        app.handle_model_download_key(key(KeyCode::Char('l')))
+            .await
+            .unwrap();
+
+        assert_eq!(app.model_download_input, "ll");
+        assert!(app
+            .model_download_suggestions
+            .iter()
+            .all(|s| s.to_lowercase().contains("ll")));
+    }
+
+    #[tokio::test]
+    async fn model_download_backspace_removes_last_char() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        app.handle_model_download_key(key(KeyCode::Char('a')))
+            .await
+            .unwrap();
+        app.handle_model_download_key(key(KeyCode::Backspace))
+            .await
+            .unwrap();
+        assert!(app.model_download_input.is_empty());
+    }
+
+    #[tokio::test]
+    async fn model_download_tab_adopts_highlighted_suggestion() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        let first_suggestion = app.model_download_suggestions[0].clone();
+
+        app.handle_model_download_key(key(KeyCode::Tab))
+            .await
+            .unwrap();
+
+        assert_eq!(app.model_download_input, first_suggestion);
+    }
+
+    #[tokio::test]
+    async fn model_download_esc_closes_dialog_without_running_pull() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+
+        app.handle_model_download_key(key(KeyCode::Esc))
+            .await
+            .unwrap();
+
+        assert_eq!(app.mode, AppMode::Chat);
+        assert!(!app.model_download_running);
+    }
+
+    #[tokio::test]
+    async fn model_download_enter_starts_pull_then_esc_aborts_it() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        app.model_download_input = "qwen2.5-coder:7b".to_string();
+
+        app.handle_model_download_key(key(KeyCode::Enter))
+            .await
+            .unwrap();
+        assert!(app.model_download_running);
+
+        // Esc while a pull is running must abort it and return to chat,
+        // rather than just closing the dialog.
+        app.handle_model_download_key(key(KeyCode::Esc))
+            .await
+            .unwrap();
+        assert!(!app.model_download_running);
+        assert_eq!(app.mode, AppMode::Chat);
+    }
+
+    #[tokio::test]
+    async fn handle_ollama_models_listed_updates_installed_list() {
+        let mut app = test_app().await;
+        app.handle_event(TuiEvent::OllamaModelsListed(vec![
+            "custom-model:1b".to_string()
+        ]))
+        .await
+        .unwrap();
+
+        assert_eq!(
+            app.model_download_installed,
+            vec!["custom-model:1b".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_ollama_pull_progress_updates_status_and_fraction() {
+        let mut app = test_app().await;
+        app.handle_event(TuiEvent::OllamaPullProgress(
+            super::super::ollama_download::ModelPullProgress {
+                status: "pulling abc123".to_string(),
+                total: Some(100),
+                completed: Some(50),
+            },
+        ))
+        .await
+        .unwrap();
+
+        assert_eq!(
+            app.model_download_status,
+            Some("pulling abc123".to_string())
+        );
+        assert_eq!(app.model_download_fraction, Some(0.5));
+    }
+
+    #[tokio::test]
+    async fn handle_ollama_pull_finished_success_posts_chat_message() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ModelDownload;
+        app.model_download_running = true;
+
+        app.handle_event(TuiEvent::OllamaPullFinished {
+            model: "qwen2.5-coder:7b".to_string(),
+            error: None,
+        })
+        .await
+        .unwrap();
+
+        assert!(!app.model_download_running);
+        assert_eq!(app.mode, AppMode::Chat);
+        assert!(app
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Pulled 'qwen2.5-coder:7b'")));
+    }
+
+    #[tokio::test]
+    async fn handle_ollama_pull_finished_failure_posts_error_message() {
+        let mut app = test_app().await;
+
+        app.handle_event(TuiEvent::OllamaPullFinished {
+            model: "bogus-model".to_string(),
+            error: Some("model not found".to_string()),
+        })
+        .await
+        .unwrap();
+
+        assert!(app
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Failed to pull 'bogus-model'")
+                && m.content.contains("model not found")));
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -102,6 +102,17 @@ pub struct App {
     pub file_picker_scroll_offset: usize,
     pub file_picker_current_dir: std::path::PathBuf,
 
+    // Model download dialog state (Ctrl+D, native Ollama provider)
+    pub model_download_input: String,
+    pub model_download_suggestions: Vec<String>,
+    pub model_download_selected: usize,
+    pub model_download_installed: Vec<String>,
+    pub model_download_running: bool,
+    pub model_download_status: Option<String>,
+    pub model_download_fraction: Option<f64>,
+    model_download_task: Option<tokio::task::JoinHandle<()>>,
+    ollama_host: String,
+
     // Working directory
     pub working_directory: std::path::PathBuf,
 
@@ -145,6 +156,15 @@ impl App {
             file_picker_selected: 0,
             file_picker_scroll_offset: 0,
             file_picker_current_dir: std::env::current_dir().unwrap_or_default(),
+            model_download_input: String::new(),
+            model_download_suggestions: Vec::new(),
+            model_download_selected: 0,
+            model_download_installed: Vec::new(),
+            model_download_running: false,
+            model_download_status: None,
+            model_download_fraction: None,
+            model_download_task: None,
+            ollama_host: "http://localhost:11434".to_string(),
             working_directory: std::env::current_dir().unwrap_or_default(),
             session_service: SessionService::new(context.clone()),
             message_service: MessageService::new(context.clone()),
@@ -199,6 +219,12 @@ impl App {
     /// Set agent service (used to inject configured agent after app creation)
     pub fn set_agent_service(&mut self, agent_service: Arc<AgentService>) {
         self.agent_service = agent_service;
+    }
+
+    /// Set the Ollama host used by the Model Download dialog (Ctrl+D).
+    /// Defaults to `http://localhost:11434` if never called.
+    pub fn set_ollama_host(&mut self, host: String) {
+        self.ollama_host = host;
     }
 
     /// Receive next event
@@ -288,6 +314,49 @@ impl App {
             TuiEvent::Resize(_, _) | TuiEvent::AgentProcessing => {
                 // These are handled by the render loop
             }
+            TuiEvent::OllamaModelsListed(models) => {
+                self.model_download_installed = models;
+                self.refresh_model_download_suggestions();
+            }
+            TuiEvent::OllamaPullProgress(progress) => {
+                self.model_download_fraction = progress.fraction();
+                self.model_download_status = Some(progress.status);
+            }
+            TuiEvent::OllamaPullFinished { model, error } => {
+                self.model_download_running = false;
+                self.model_download_task = None;
+                self.model_download_status = None;
+                self.model_download_fraction = None;
+
+                let content = match error {
+                    None => format!("✅ Pulled '{}' successfully.", model),
+                    Some(e) => format!("❌ Failed to pull '{}': {}", model, e),
+                };
+                let notification = DisplayMessage {
+                    id: Uuid::new_v4(),
+                    role: "system".to_string(),
+                    content,
+                    thinking_text: None,
+                    thinking_expanded: false,
+                    timestamp: chrono::Utc::now(),
+                    token_count: None,
+                    cost: None,
+                    provider_name: None,
+                    perf_metrics: None,
+                    tokens_per_second: None,
+                };
+                self.messages.push(notification);
+                self.switch_mode(AppMode::Chat).await?;
+
+                // Refresh the installed-models list in the background so the
+                // newly-pulled model shows up next time the dialog opens.
+                let host = self.ollama_host.clone();
+                let sender = self.event_sender();
+                tokio::spawn(async move {
+                    let models = super::ollama_download::fetch_installed_models(host).await;
+                    let _ = sender.send(TuiEvent::OllamaModelsListed(models));
+                });
+            }
         }
         Ok(())
     }
@@ -352,6 +421,11 @@ impl App {
             return Ok(());
         }
 
+        if keys::is_model_download(&event) && self.mode == AppMode::Chat {
+            self.open_model_download().await?;
+            return Ok(());
+        }
+
         // Mode-specific handling
         tracing::trace!("Current mode: {:?}", self.mode);
         match self.mode {
@@ -370,6 +444,7 @@ impl App {
             AppMode::Sessions => self.handle_sessions_key(event).await?,
             AppMode::ToolApproval => self.handle_approval_key(event).await?,
             AppMode::FilePicker => self.handle_file_picker_key(event).await?,
+            AppMode::ModelDownload => self.handle_model_download_key(event).await?,
             AppMode::Help | AppMode::Settings => {
                 if keys::is_cancel(&event) {
                     self.switch_mode(AppMode::Chat).await?;
@@ -1473,6 +1548,113 @@ impl App {
                     self.input_buffer.push_str(&path_str);
                     self.switch_mode(AppMode::Chat).await?;
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Open the Model Download dialog (Ctrl+D). Shows curated suggestions
+    /// immediately; the locally-installed list refreshes in the background
+    /// (network call to Ollama) and merges in once it arrives.
+    async fn open_model_download(&mut self) -> Result<()> {
+        self.model_download_input.clear();
+        self.model_download_selected = 0;
+        self.model_download_running = false;
+        self.model_download_status = None;
+        self.model_download_fraction = None;
+        self.refresh_model_download_suggestions();
+
+        let host = self.ollama_host.clone();
+        let sender = self.event_sender();
+        tokio::spawn(async move {
+            let models = super::ollama_download::fetch_installed_models(host).await;
+            let _ = sender.send(TuiEvent::OllamaModelsListed(models));
+        });
+
+        self.switch_mode(AppMode::ModelDownload).await
+    }
+
+    /// Recompute `model_download_suggestions` from the current input text.
+    fn refresh_model_download_suggestions(&mut self) {
+        self.model_download_suggestions = super::ollama_download::filter_suggestions(
+            &self.model_download_input,
+            &self.model_download_installed,
+        );
+        self.model_download_selected = 0;
+    }
+
+    /// Start pulling `model` in the background. No-op if a pull is already
+    /// running (only one at a time from this dialog).
+    async fn start_model_pull(&mut self, model: String) {
+        if self.model_download_running || model.trim().is_empty() {
+            return;
+        }
+
+        self.model_download_running = true;
+        self.model_download_status = Some("starting…".to_string());
+        self.model_download_fraction = None;
+
+        let host = self.ollama_host.clone();
+        let sender = self.event_sender();
+        let handle = super::ollama_download::spawn_pull(host, model, sender).await;
+        self.model_download_task = Some(handle);
+    }
+
+    /// Handle keys in the Model Download dialog.
+    async fn handle_model_download_key(&mut self, event: crossterm::event::KeyEvent) -> Result<()> {
+        use super::events::keys;
+        use crossterm::event::KeyCode;
+
+        if keys::is_cancel(&event) {
+            // Cancel an in-flight pull (if any) and close the dialog.
+            if let Some(handle) = self.model_download_task.take() {
+                handle.abort();
+            }
+            self.model_download_running = false;
+            self.model_download_status = None;
+            self.model_download_fraction = None;
+            self.switch_mode(AppMode::Chat).await?;
+            return Ok(());
+        }
+
+        // While a pull is running, only Esc (handled above) does anything.
+        if self.model_download_running {
+            return Ok(());
+        }
+
+        if keys::is_up(&event) {
+            self.model_download_selected = self.model_download_selected.saturating_sub(1);
+        } else if keys::is_down(&event) {
+            if !self.model_download_suggestions.is_empty() {
+                self.model_download_selected = (self.model_download_selected + 1)
+                    .min(self.model_download_suggestions.len() - 1);
+            }
+        } else if event.code == KeyCode::Tab {
+            // Copy the highlighted suggestion into the input for editing/confirmation.
+            if let Some(suggestion) = self
+                .model_download_suggestions
+                .get(self.model_download_selected)
+            {
+                self.model_download_input = suggestion.clone();
+                self.refresh_model_download_suggestions();
+            }
+        } else if keys::is_enter(&event) {
+            let model = self.model_download_input.trim().to_string();
+            if !model.is_empty() {
+                self.start_model_pull(model).await;
+            }
+        } else {
+            match event.code {
+                KeyCode::Char(c) => {
+                    self.model_download_input.push(c);
+                    self.refresh_model_download_suggestions();
+                }
+                KeyCode::Backspace => {
+                    self.model_download_input.pop();
+                    self.refresh_model_download_suggestions();
+                }
+                _ => {}
             }
         }
 

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -56,6 +56,19 @@ pub enum TuiEvent {
 
     /// Tool approval response
     ToolApprovalResponse(ToolApprovalResponse),
+
+    /// Locally-installed Ollama models were (re)loaded for the Model
+    /// Download dialog's suggestion list.
+    OllamaModelsListed(Vec<String>),
+
+    /// Progress update for an in-flight Ollama model pull.
+    OllamaPullProgress(super::ollama_download::ModelPullProgress),
+
+    /// An Ollama model pull finished (`error` is `None` on success).
+    OllamaPullFinished {
+        model: String,
+        error: Option<String>,
+    },
 }
 
 /// Tool approval request details
@@ -129,6 +142,9 @@ pub enum AppMode {
     ToolApproval,
     /// File picker dialog (triggered by @)
     FilePicker,
+    /// Model download dialog (triggered by Ctrl+D) - pick/type an Ollama
+    /// model name and pull it without leaving Crustly.
+    ModelDownload,
 }
 
 /// Event handler for the TUI
@@ -242,6 +258,11 @@ pub mod keys {
     /// Ctrl+P - Toggle Plan mode
     pub fn is_toggle_plan(event: &KeyEvent) -> bool {
         key_matches(event, KeyCode::Char('p'), KeyModifiers::CONTROL)
+    }
+
+    /// Ctrl+D - Open the Model Download dialog (Ollama)
+    pub fn is_model_download(event: &KeyEvent) -> bool {
+        key_matches(event, KeyCode::Char('d'), KeyModifiers::CONTROL)
     }
 
     /// Ctrl+Enter - Submit

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,6 +5,7 @@
 pub mod app;
 pub mod error;
 pub mod events;
+pub mod ollama_download;
 pub mod plan;
 pub mod prompt_analyzer;
 pub mod render;

--- a/src/tui/ollama_download.rs
+++ b/src/tui/ollama_download.rs
@@ -150,7 +150,13 @@ mod tests {
         // installed models first, deduplicated against curated overlap
         assert_eq!(suggestions[0], "qwen2.5-coder:7b");
         assert_eq!(suggestions[1], "llava:13b");
-        assert!(suggestions.iter().filter(|s| *s == "qwen2.5-coder:7b").count() == 1);
+        assert!(
+            suggestions
+                .iter()
+                .filter(|s| *s == "qwen2.5-coder:7b")
+                .count()
+                == 1
+        );
     }
 
     #[test]

--- a/src/tui/ollama_download.rs
+++ b/src/tui/ollama_download.rs
@@ -1,0 +1,173 @@
+//! Backend glue for the TUI's "Model Download" dialog (Ctrl+D in Chat mode).
+//!
+//! Lets the user type/pick an Ollama model name and pull it without leaving
+//! Crustly. Ollama has no API to *search* its online library - only to pull
+//! a model whose `repo:tag` name is already known (like `ollama pull <name>`
+//! on the CLI) - so suggestions here are a curated static list plus whatever
+//! is already installed locally, not a text search over a remote catalog.
+//!
+//! The actual pull only runs when this crate is built with `--features
+//! ollama`; otherwise `spawn_pull` immediately reports a clear error instead
+//! of silently doing nothing.
+
+use super::events::TuiEvent;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::task::JoinHandle;
+
+/// Curated list of models known to work well for coding, mirroring the
+/// "Recommended Local Models" section in the README. Purely a starting
+/// point for the suggestions list - the user can type any other name.
+pub const CURATED_MODELS: &[&str] = &[
+    "qwen2.5-coder:7b",
+    "gemma3:12b",
+    "llama3.1:8b",
+    "llama3.2:3b",
+    "mistral:latest",
+    "deepseek-r1:14b",
+];
+
+/// One progress update from an in-flight pull, decoupled from the `ollama`
+/// feature so it can live on the always-compiled `TuiEvent` enum.
+#[derive(Debug, Clone)]
+pub struct ModelPullProgress {
+    pub status: String,
+    pub total: Option<u64>,
+    pub completed: Option<u64>,
+}
+
+impl ModelPullProgress {
+    /// Completion fraction for the current layer (0.0-1.0), if known.
+    pub fn fraction(&self) -> Option<f64> {
+        let total = self.total.filter(|t| *t > 0)? as f64;
+        let completed = self.completed? as f64;
+        Some((completed / total).clamp(0.0, 1.0))
+    }
+}
+
+/// Build the suggestion list for the current query: locally-installed
+/// models first (already downloaded, marked separately by the caller),
+/// then curated picks, filtered by a case-insensitive substring match.
+/// Empty query returns the unfiltered combined list.
+pub fn filter_suggestions(query: &str, installed: &[String]) -> Vec<String> {
+    let query_lc = query.trim().to_lowercase();
+
+    let mut seen = std::collections::HashSet::new();
+    let mut suggestions = Vec::new();
+
+    for name in installed
+        .iter()
+        .cloned()
+        .chain(CURATED_MODELS.iter().map(|s| s.to_string()))
+    {
+        if !query_lc.is_empty() && !name.to_lowercase().contains(&query_lc) {
+            continue;
+        }
+        if seen.insert(name.clone()) {
+            suggestions.push(name);
+        }
+    }
+
+    suggestions
+}
+
+/// Fetch the list of locally-installed model names. Returns an empty list
+/// (rather than erroring) when Ollama is unreachable or the feature isn't
+/// compiled in - the suggestions list still works from the curated list.
+#[cfg(feature = "ollama")]
+pub async fn fetch_installed_models(host: String) -> Vec<String> {
+    crate::llm::provider::ollama_models::list_models(&host)
+        .await
+        .map(|models| models.into_iter().map(|m| m.name).collect())
+        .unwrap_or_default()
+}
+
+#[cfg(not(feature = "ollama"))]
+pub async fn fetch_installed_models(_host: String) -> Vec<String> {
+    Vec::new()
+}
+
+/// Start pulling `model` in the background, forwarding progress and the
+/// final result through `event_sender`. Returns the `JoinHandle` of the
+/// pull task itself so the caller can `.abort()` it (e.g. on Esc).
+#[cfg(feature = "ollama")]
+pub async fn spawn_pull(
+    host: String,
+    model: String,
+    event_sender: UnboundedSender<TuiEvent>,
+) -> JoinHandle<()> {
+    use crate::llm::provider::ollama_models;
+
+    let (progress_tx, mut progress_rx) =
+        tokio::sync::mpsc::unbounded_channel::<ollama_models::PullProgress>();
+
+    let forward_sender = event_sender.clone();
+    tokio::spawn(async move {
+        while let Some(p) = progress_rx.recv().await {
+            let _ = forward_sender.send(TuiEvent::OllamaPullProgress(ModelPullProgress {
+                status: p.status,
+                total: p.total,
+                completed: p.completed,
+            }));
+        }
+    });
+
+    let model_for_task = model.clone();
+    tokio::spawn(async move {
+        let result = ollama_models::pull_model(&host, &model_for_task, progress_tx).await;
+        let _ = event_sender.send(TuiEvent::OllamaPullFinished {
+            model: model_for_task,
+            error: result.err().map(|e| e.to_string()),
+        });
+    })
+}
+
+#[cfg(not(feature = "ollama"))]
+pub async fn spawn_pull(
+    _host: String,
+    model: String,
+    event_sender: UnboundedSender<TuiEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let _ = event_sender.send(TuiEvent::OllamaPullFinished {
+            model,
+            error: Some(
+                "This build of crustly was compiled without the 'ollama' feature. \
+                 Rebuild with `--features ollama` (or `all-llm`)."
+                    .to_string(),
+            ),
+        });
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_suggestions_empty_query_returns_all_deduped() {
+        let installed = vec!["qwen2.5-coder:7b".to_string(), "llava:13b".to_string()];
+        let suggestions = filter_suggestions("", &installed);
+        // installed models first, deduplicated against curated overlap
+        assert_eq!(suggestions[0], "qwen2.5-coder:7b");
+        assert_eq!(suggestions[1], "llava:13b");
+        assert!(suggestions.iter().filter(|s| *s == "qwen2.5-coder:7b").count() == 1);
+    }
+
+    #[test]
+    fn filter_suggestions_matches_substring_case_insensitive() {
+        let suggestions = filter_suggestions("LLAMA", &[]);
+        assert!(suggestions.contains(&"llama3.1:8b".to_string()));
+        assert!(suggestions.contains(&"llama3.2:3b".to_string()));
+        assert!(!suggestions.contains(&"mistral:latest".to_string()));
+    }
+
+    #[test]
+    fn pull_progress_fraction() {
+        let p = ModelPullProgress {
+            status: "pulling abc".to_string(),
+            total: Some(200),
+            completed: Some(50),
+        };
+        assert_eq!(p.fraction(), Some(0.25));
+    }
+}

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1664,3 +1664,147 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
 
     f.render_widget(status_bar, area);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use crate::llm::agent::AgentService;
+    use crate::llm::provider::{
+        LLMRequest, LLMResponse, Provider, ProviderStream, Result as ProviderResult,
+    };
+    use crate::services::ServiceContext;
+    use crate::tui::app::DisplayMessage;
+    use async_trait::async_trait;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use std::sync::Arc;
+
+    /// Minimal `Provider` stub - these tests only exercise rendering, never
+    /// an actual `complete()`/`stream()` call.
+    struct DummyProvider;
+
+    #[async_trait]
+    impl Provider for DummyProvider {
+        async fn complete(&self, _request: LLMRequest) -> ProviderResult<LLMResponse> {
+            unimplemented!("rendering tests never call complete()")
+        }
+        async fn stream(&self, _request: LLMRequest) -> ProviderResult<ProviderStream> {
+            unimplemented!("rendering tests never call stream()")
+        }
+        fn name(&self) -> &str {
+            "dummy"
+        }
+        fn default_model(&self) -> &str {
+            "dummy-model"
+        }
+        fn supported_models(&self) -> Vec<String> {
+            vec!["dummy-model".to_string()]
+        }
+        fn context_window(&self, _model: &str) -> Option<u32> {
+            Some(4096)
+        }
+        fn calculate_cost(&self, _model: &str, _input: u32, _output: u32) -> f64 {
+            0.0
+        }
+    }
+
+    async fn test_app() -> App {
+        let db = Database::connect_in_memory().await.expect("in-memory db");
+        db.run_migrations().await.expect("run migrations");
+        let context = ServiceContext::new(db.pool().clone());
+        let agent_service = Arc::new(AgentService::new(Arc::new(DummyProvider), context.clone()));
+        App::new(agent_service, context)
+    }
+
+    /// Render `app` into a small offscreen buffer and return its text
+    /// content as a single string, for substring assertions.
+    fn render_to_string(app: &App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("create terminal");
+        terminal.draw(|f| render(f, app)).expect("draw frame");
+
+        let buffer = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                out.push_str(buffer.get(x, y).symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn header_shows_ollama_provider_badge_and_tokens_per_second() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Chat;
+        app.current_session = Some(crate::db::models::Session {
+            id: uuid::Uuid::new_v4(),
+            title: Some("Test session".to_string()),
+            model: Some("qwen2.5-coder:7b".to_string()),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            archived_at: None,
+            token_count: 0,
+            total_cost: 0.0,
+            provider: Some("ollama".to_string()),
+        });
+        app.messages.push(DisplayMessage {
+            id: uuid::Uuid::new_v4(),
+            role: "assistant".to_string(),
+            content: "hi".to_string(),
+            thinking_text: None,
+            thinking_expanded: false,
+            timestamp: chrono::Utc::now(),
+            token_count: Some(30),
+            cost: Some(0.0),
+            provider_name: Some("ollama".to_string()),
+            perf_metrics: None,
+            tokens_per_second: Some(42.0),
+        });
+
+        // Wide terminal: the header is a single un-wrapped line, so it must
+        // be wide enough to fit session/model/tokens/cost/tok-per-sec.
+        let screen = render_to_string(&app, 160, 20);
+        assert!(screen.contains("qwen2.5-coder:7b"));
+        assert!(screen.contains("🦙"));
+        assert!(screen.contains("42 tok/s"));
+    }
+
+    #[tokio::test]
+    async fn header_omits_tokens_per_second_when_unavailable() {
+        // Non-Ollama providers (or providers without perf metrics) must not
+        // show a fabricated "0 tok/s".
+        let mut app = test_app().await;
+        app.mode = AppMode::Chat;
+        let screen = render_to_string(&app, 100, 20);
+        assert!(!screen.contains("tok/s"));
+    }
+
+    #[tokio::test]
+    async fn model_download_dialog_shows_prompt_and_suggestions() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ModelDownload;
+        app.model_download_suggestions = vec!["qwen2.5-coder:7b".to_string()];
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("Download an Ollama model"));
+        assert!(screen.contains("qwen2.5-coder:7b"));
+    }
+
+    #[tokio::test]
+    async fn model_download_progress_shows_status_and_bar() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ModelDownload;
+        app.model_download_input = "qwen2.5-coder:7b".to_string();
+        app.model_download_running = true;
+        app.model_download_status = Some("pulling abc123".to_string());
+        app.model_download_fraction = Some(0.5);
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("Downloading 'qwen2.5-coder:7b'"));
+        assert!(screen.contains("pulling abc123"));
+        assert!(screen.contains("50%"));
+    }
+}

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -68,6 +68,19 @@ pub fn render(f: &mut Frame, app: &App) {
     render_status_bar(f, app, chunks[3]);
 }
 
+/// Purely cosmetic icon shown next to the provider name in the header.
+/// Unknown provider names fall back to a generic robot.
+fn provider_icon(provider_name: &str) -> &'static str {
+    match provider_name {
+        "ollama" => "🦙",
+        "openai" => "🏠",
+        "anthropic" => "🤖",
+        "qwen" => "🌀",
+        "azure" => "☁️",
+        _ => "🤖",
+    }
+}
+
 /// Render the header with session info
 fn render_header(f: &mut Frame, app: &App, area: Rect) {
     let session_name = app
@@ -81,8 +94,20 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
         .as_ref()
         .and_then(|s| s.model.as_deref())
         .unwrap_or("unknown");
+    let provider = app
+        .current_session
+        .as_ref()
+        .and_then(|s| s.provider.as_deref());
     let tokens = app.total_tokens();
     let cost = app.total_cost();
+    // Throughput of the most recent assistant reply, if the active provider
+    // exposes it (currently only the native Ollama provider). Omitted
+    // entirely (not shown as "0 tok/s") when unavailable.
+    let tokens_per_second = app
+        .messages
+        .iter()
+        .rev()
+        .find_map(|m| m.tokens_per_second);
 
     // Format working directory - show relative or full path
     let working_dir = app.working_directory.to_string_lossy().to_string();
@@ -92,7 +117,7 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
         working_dir
     };
 
-    let header_line1 = Line::from(vec![
+    let mut header_spans = vec![
         Span::styled(" 📝 Session: ", Style::default().fg(Color::DarkGray)),
         Span::styled(
             session_name,
@@ -102,7 +127,15 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
         Span::styled("🤖 Model: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(model, Style::default().fg(Color::Green)),
+    ];
+    if let Some(provider) = provider {
+        header_spans.push(Span::styled(
+            format!("{} ", provider_icon(provider)),
+            Style::default().fg(Color::Green),
+        ));
+    }
+    header_spans.push(Span::styled(model, Style::default().fg(Color::Green)));
+    header_spans.extend([
         Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
         Span::styled("💬 Tokens: ", Style::default().fg(Color::DarkGray)),
         Span::styled(tokens.to_string(), Style::default().fg(Color::Yellow)),
@@ -110,6 +143,18 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
         Span::styled("💰 Cost: $", Style::default().fg(Color::DarkGray)),
         Span::styled(format!("{:.4}", cost), Style::default().fg(Color::Magenta)),
     ]);
+    if let Some(tps) = tokens_per_second {
+        header_spans.extend([
+            Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("⚡ ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("{:.0} tok/s", tps),
+                Style::default().fg(Color::Cyan),
+            ),
+        ]);
+    }
+
+    let header_line1 = Line::from(header_spans);
 
     let header_line2 = Line::from(vec![
         Span::styled(
@@ -254,6 +299,38 @@ fn render_chat(f: &mut Frame, app: &App, area: Rect) {
         // Parse and render message content as markdown
         let mut content_lines = parse_markdown(&msg.content);
         lines.append(&mut content_lines);
+
+        // Runtime performance metrics footer (currently Ollama only) - shown
+        // only when the provider actually reported them.
+        if let Some(ref perf) = msg.perf_metrics {
+            let mut spans = vec![Span::styled("  ⏱ ", Style::default().fg(Color::DarkGray))];
+            if let Some(eval_ms) = perf.eval_duration_ms {
+                spans.push(Span::styled(
+                    format!("{}ms generation", eval_ms),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            if let Some(tps) = msg.tokens_per_second {
+                spans.push(Span::styled(
+                    format!(" · {:.0} tok/s", tps),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            match perf.model_was_loaded {
+                Some(false) => {
+                    let load_ms = perf.load_duration_ms.unwrap_or(0);
+                    spans.push(Span::styled(
+                        format!(" · 🧊 cold start (model loaded in {}ms)", load_ms),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+                Some(true) => {
+                    spans.push(Span::styled(" · 🔥 warm", Style::default().fg(Color::DarkGray)));
+                }
+                None => {}
+            }
+            lines.push(Line::from(spans));
+        }
 
         // Add spacing between messages
         lines.push(Line::from(""));

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -63,6 +63,9 @@ pub fn render(f: &mut Frame, app: &App) {
         AppMode::FilePicker => {
             render_file_picker(f, app, chunks[1]);
         }
+        AppMode::ModelDownload => {
+            render_model_download(f, app, chunks[1]);
+        }
     }
 
     render_status_bar(f, app, chunks[3]);
@@ -1454,6 +1457,167 @@ fn render_file_picker(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(widget, area);
 }
 
+/// Render the Model Download dialog (Ctrl+D): either the model
+/// name input + suggestions list, or a live progress bar while a pull is
+/// in flight.
+fn render_model_download(f: &mut Frame, app: &App, area: Rect) {
+    if app.model_download_running {
+        render_model_download_progress(f, app, area);
+        return;
+    }
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    lines.push(Line::from(vec![
+        Span::styled("🦙 Download an Ollama model", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+    ]));
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("  > ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            if app.model_download_input.is_empty() {
+                "type a model name, e.g. qwen2.5-coder:7b"
+            } else {
+                app.model_download_input.as_str()
+            },
+            if app.model_download_input.is_empty() {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD)
+            },
+        ),
+    ]));
+    lines.push(Line::from(""));
+
+    if app.model_download_suggestions.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No matches - press Enter to pull this name anyway.",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        for (idx, name) in app.model_download_suggestions.iter().enumerate() {
+            let is_selected = idx == app.model_download_selected;
+            let is_installed = app.model_download_installed.iter().any(|m| m == name);
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let prefix = if is_selected { "▶ " } else { "  " };
+            let status = if is_installed { " (installed)" } else { "" };
+            lines.push(Line::from(vec![
+                Span::styled(prefix, style),
+                Span::styled(format!("{}{}", name, status), style),
+            ]));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(
+            "[↑↓]",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Navigate  ", Style::default().fg(Color::White)),
+        Span::styled(
+            "[Tab]",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Use suggestion  ", Style::default().fg(Color::White)),
+        Span::styled(
+            "[Enter]",
+            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Pull  ", Style::default().fg(Color::White)),
+        Span::styled(
+            "[Esc]",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Cancel", Style::default().fg(Color::White)),
+    ]));
+    lines.push(Line::from(Span::styled(
+        "Note: Ollama has no online search API - type any repo:tag you know, or pick a suggestion.",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let widget = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(Span::styled(
+                    " Download Model ",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )),
+        )
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(widget, area);
+}
+
+/// Render the live progress view of an in-flight model pull.
+fn render_model_download_progress(f: &mut Frame, app: &App, area: Rect) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    lines.push(Line::from(vec![Span::styled(
+        format!("🦙 Downloading '{}'", app.model_download_input),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )]));
+    lines.push(Line::from(""));
+
+    let status = app.model_download_status.as_deref().unwrap_or("working…");
+    lines.push(Line::from(vec![Span::styled(
+        format!("  {}", status),
+        Style::default().fg(Color::White),
+    )]));
+
+    if let Some(fraction) = app.model_download_fraction {
+        const BAR_WIDTH: usize = 30;
+        let filled = ((fraction * BAR_WIDTH as f64).round() as usize).min(BAR_WIDTH);
+        let bar = format!(
+            "[{}{}] {:>3.0}%",
+            "█".repeat(filled),
+            "░".repeat(BAR_WIDTH - filled),
+            fraction * 100.0
+        );
+        lines.push(Line::from(vec![Span::styled(
+            format!("  {}", bar),
+            Style::default().fg(Color::Green),
+        )]));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  (Esc cancels the download)",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let widget = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow))
+                .title(Span::styled(
+                    " Downloading… ",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )),
+        )
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(widget, area);
+}
+
 /// Render the status bar
 fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     let mode_text = match app.mode {
@@ -1465,6 +1629,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         AppMode::Settings => "SETTINGS",
         AppMode::ToolApproval => "PERMISSION",
         AppMode::FilePicker => "FILE PICKER",
+        AppMode::ModelDownload => "MODEL DOWNLOAD",
     };
 
     let status = if let Some(ref error) = app.error_message {
@@ -1473,7 +1638,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         format!(" [{}] Processing...", mode_text)
     } else {
         format!(
-            " [{}] Ready │ Ctrl+H: Help │ Ctrl+K: Clear │ Ctrl+L: Sessions │ Ctrl+N: New │ Ctrl+C: Quit",
+            " [{}] Ready │ Ctrl+H: Help │ Ctrl+D: Download Model │ Ctrl+K: Clear │ Ctrl+L: Sessions │ Ctrl+N: New │ Ctrl+C: Quit",
             mode_text
         )
     };

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -106,11 +106,7 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
     // Throughput of the most recent assistant reply, if the active provider
     // exposes it (currently only the native Ollama provider). Omitted
     // entirely (not shown as "0 tok/s") when unavailable.
-    let tokens_per_second = app
-        .messages
-        .iter()
-        .rev()
-        .find_map(|m| m.tokens_per_second);
+    let tokens_per_second = app.messages.iter().rev().find_map(|m| m.tokens_per_second);
 
     // Format working directory - show relative or full path
     let working_dir = app.working_directory.to_string_lossy().to_string();
@@ -328,7 +324,10 @@ fn render_chat(f: &mut Frame, app: &App, area: Rect) {
                     ));
                 }
                 Some(true) => {
-                    spans.push(Span::styled(" · 🔥 warm", Style::default().fg(Color::DarkGray)));
+                    spans.push(Span::styled(
+                        " · 🔥 warm",
+                        Style::default().fg(Color::DarkGray),
+                    ));
                 }
                 None => {}
             }
@@ -1468,9 +1467,12 @@ fn render_model_download(f: &mut Frame, app: &App, area: Rect) {
 
     let mut lines: Vec<Line> = Vec::new();
 
-    lines.push(Line::from(vec![
-        Span::styled("🦙 Download an Ollama model", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-    ]));
+    lines.push(Line::from(vec![Span::styled(
+        "🦙 Download an Ollama model",
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )]));
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("  > ", Style::default().fg(Color::DarkGray)),
@@ -1521,17 +1523,23 @@ fn render_model_download(f: &mut Frame, app: &App, area: Rect) {
     lines.push(Line::from(vec![
         Span::styled(
             "[↑↓]",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" Navigate  ", Style::default().fg(Color::White)),
         Span::styled(
             "[Tab]",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" Use suggestion  ", Style::default().fg(Color::White)),
         Span::styled(
             "[Enter]",
-            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" Pull  ", Style::default().fg(Color::White)),
         Span::styled(

--- a/tests/error_scenarios_test.rs
+++ b/tests/error_scenarios_test.rs
@@ -332,6 +332,7 @@ impl Provider for WorkingMockProvider {
                 output_tokens: 20,
             },
             cache_metrics: None,
+            perf_metrics: None,
         })
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -66,6 +66,7 @@ impl Provider for MockProvider {
                 output_tokens: 20,
             },
             cache_metrics: None,
+            perf_metrics: None,
         })
     }
 


### PR DESCRIPTION
Documents the design for a native Ollama provider built on ollama-rs,
kept fully additive alongside the existing OpenAI-compatible path used
by LM Studio, Ollama-via-/v1, OpenAI, Anthropic, Qwen and Azure.