### PR TITLE
fix: assemble streamed Anthropic tool-call arguments from input_json_delta

### DIFF
--- a/src/llm/agent/service.rs
+++ b/src/llm/agent/service.rs
@@ -166,6 +166,41 @@ fn route_text_delta(
     }
 }
 
+/// Apply accumulated `input_json_delta` fragments to a streamed tool-use block.
+///
+/// Anthropic streams tool-call arguments as `InputJsonDelta` fragments *after*
+/// the `ContentBlockStart`, which itself carries an empty `input: {}`. Without
+/// merging the assembled JSON back in, the tool would be executed with `{}`
+/// instead of its real arguments. A no-op for providers (OpenAI, Ollama) that
+/// deliver a fully-formed `input` in the `ContentBlockStart` and never emit
+/// `InputJsonDelta`.
+fn apply_streamed_tool_input(block: ContentBlock, json_buf: &str) -> ContentBlock {
+    if let ContentBlock::ToolUse { id, name, input } = block {
+        if json_buf.trim().is_empty() {
+            return ContentBlock::ToolUse { id, name, input };
+        }
+        let merged = match serde_json::from_str(json_buf) {
+            Ok(value) => value,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to parse streamed tool arguments for '{}': {} (raw: {})",
+                    name,
+                    e,
+                    json_buf.chars().take(200).collect::<String>()
+                );
+                input
+            }
+        };
+        ContentBlock::ToolUse {
+            id,
+            name,
+            input: merged,
+        }
+    } else {
+        block
+    }
+}
+
 /// Consume a [`ProviderStream`] and assemble a complete [`LLMResponse`].
 ///
 /// While consuming the stream, text deltas are optionally forwarded to
@@ -192,6 +227,9 @@ async fn drain_stream_to_response(
 
     // A ToolUse block assembled from ContentBlockStart + ContentBlockStop.
     let mut pending_tool: Option<ContentBlock> = None;
+    // Accumulates `input_json_delta` fragments for the currently-open tool-use
+    // block (Anthropic streams tool arguments this way). Applied on stop.
+    let mut pending_tool_json = String::new();
 
     // Tracks whether we are currently inside a `<think>…</think>` block while
     // routing TextDelta events from tag-based reasoning models (e.g. Ollama
@@ -207,11 +245,13 @@ async fn drain_stream_to_response(
             StreamEvent::ContentBlockStart { content_block, .. } => {
                 if matches!(content_block, ContentBlock::ToolUse { .. }) {
                     pending_tool = Some(content_block);
+                    pending_tool_json.clear();
                 }
             }
             StreamEvent::ContentBlockStop { .. } => {
                 if let Some(tool) = pending_tool.take() {
-                    tool_uses.push(tool);
+                    tool_uses.push(apply_streamed_tool_input(tool, &pending_tool_json));
+                    pending_tool_json.clear();
                 }
             }
             StreamEvent::ContentBlockDelta { delta, .. } => match delta {
@@ -228,6 +268,13 @@ async fn drain_stream_to_response(
                 }
                 ContentDelta::ThinkingDelta { ref thinking } if !thinking.is_empty() => {
                     thinking_buf.push_str(thinking);
+                }
+                // Tool-argument fragments for the open tool-use block
+                // (Anthropic). Accumulated and parsed at ContentBlockStop.
+                ContentDelta::InputJsonDelta { ref partial_json } => {
+                    if pending_tool.is_some() {
+                        pending_tool_json.push_str(partial_json);
+                    }
                 }
                 _ => {}
             },
@@ -252,7 +299,7 @@ async fn drain_stream_to_response(
     // Flush any tool use block that arrived without a matching ContentBlockStop
     // (e.g. stream truncated or provider omitted the stop event).
     if let Some(tool) = pending_tool.take() {
-        tool_uses.push(tool);
+        tool_uses.push(apply_streamed_tool_input(tool, &pending_tool_json));
     }
 
     // Fallback: if `route_text_delta` did not extract any thinking (no <think>
@@ -1996,5 +2043,71 @@ mod tests {
             .expect("perf metrics should survive draining the stream");
         assert_eq!(perf.eval_duration_ms, Some(200));
         assert_eq!(perf.model_was_loaded, Some(true));
+    }
+
+    #[tokio::test]
+    async fn drain_stream_assembles_anthropic_tool_input_from_json_deltas() {
+        use crate::llm::provider::types::MessageDelta;
+        use crate::llm::provider::ContentDelta;
+
+        // Anthropic streams a tool_use block with an empty `input`, then sends
+        // the real arguments as `input_json_delta` fragments before the stop.
+        let events: Vec<crate::llm::provider::Result<StreamEvent>> = vec![
+            Ok(StreamEvent::ContentBlockStart {
+                index: 0,
+                content_block: ContentBlock::ToolUse {
+                    id: "toolu_1".to_string(),
+                    name: "read_file".to_string(),
+                    input: serde_json::json!({}),
+                },
+            }),
+            Ok(StreamEvent::ContentBlockDelta {
+                index: 0,
+                delta: ContentDelta::InputJsonDelta {
+                    partial_json: "{\"file_path\":".to_string(),
+                },
+            }),
+            Ok(StreamEvent::ContentBlockDelta {
+                index: 0,
+                delta: ContentDelta::InputJsonDelta {
+                    partial_json: "\"src/main.rs\"}".to_string(),
+                },
+            }),
+            Ok(StreamEvent::ContentBlockStop { index: 0 }),
+            Ok(StreamEvent::MessageDelta {
+                delta: MessageDelta {
+                    stop_reason: Some(StopReason::ToolUse),
+                    stop_sequence: None,
+                },
+                usage: TokenUsage {
+                    input_tokens: 5,
+                    output_tokens: 10,
+                },
+                perf_metrics: None,
+            }),
+            Ok(StreamEvent::MessageStop),
+        ];
+        let stream: ProviderStream = Box::pin(futures::stream::iter(events));
+
+        let response = drain_stream_to_response(stream, None, "claude-3-5-sonnet")
+            .await
+            .unwrap();
+
+        // Regression: the streamed tool call must carry its assembled arguments
+        // instead of the empty `{}` from ContentBlockStart.
+        let tool = response
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
+                _ => None,
+            })
+            .expect("response must contain a tool use block");
+        assert_eq!(tool.0, "read_file");
+        assert_eq!(
+            tool.1,
+            serde_json::json!({"file_path": "src/main.rs"}),
+            "input_json_delta fragments must be assembled into the tool input"
+        );
     }
 }

--- a/src/llm/agent/service.rs
+++ b/src/llm/agent/service.rs
@@ -271,10 +271,8 @@ async fn drain_stream_to_response(
                 }
                 // Tool-argument fragments for the open tool-use block
                 // (Anthropic). Accumulated and parsed at ContentBlockStop.
-                ContentDelta::InputJsonDelta { ref partial_json } => {
-                    if pending_tool.is_some() {
-                        pending_tool_json.push_str(partial_json);
-                    }
+                ContentDelta::InputJsonDelta { ref partial_json } if pending_tool.is_some() => {
+                    pending_tool_json.push_str(partial_json);
                 }
                 _ => {}
             },

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -1075,7 +1075,9 @@ impl Provider for QwenProvider {
         let llm_response = self.from_qwen_response(synthetic);
 
         Ok(Box::pin(futures::stream::iter(
-            llm_response_to_stream_events(llm_response).into_iter().map(Ok),
+            llm_response_to_stream_events(llm_response)
+                .into_iter()
+                .map(Ok),
         )))
     }
 
@@ -1478,12 +1480,141 @@ mod tests {
             })
             .collect();
         assert_eq!(text, "Hello there!");
-        assert!(!events
-            .iter()
-            .any(|e| matches!(e, StreamEvent::ContentBlockStart {
+        assert!(!events.iter().any(|e| matches!(
+            e,
+            StreamEvent::ContentBlockStart {
                 content_block: ContentBlock::ToolUse { .. },
                 ..
-            })));
+            }
+        )));
+    }
+
+    /// Spin up a one-shot local HTTP server that replies to the first request
+    /// it receives with a fixed SSE body, then closes. Mirrors the raw-TCP
+    /// mocking technique used in `ollama_models::tests::mock_server`, so no
+    /// extra HTTP-mocking dependency is needed here.
+    async fn mock_sse_server(body: String) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+
+            let mut request = Vec::new();
+            let mut buf = [0u8; 1024];
+            loop {
+                let n = socket.read(&mut buf).await.expect("read request");
+                if n == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        format!("http://{addr}")
+    }
+
+    /// Regression: `stream()` itself (not just the buffered-content helper)
+    /// must assemble OpenAI-style `tool_calls` deltas — split across multiple
+    /// SSE chunks and indexed out of order with the id/name in one fragment
+    /// and the arguments in another — into a single `ToolUse` block, and
+    /// carry through the model, finish reason, and usage from later chunks.
+    #[tokio::test]
+    async fn stream_assembles_openai_style_tool_call_across_sse_chunks() {
+        let body = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"model\":\"qwen3-8b\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"src/main.rs\\\"}\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"index\":0,\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":12}}\n\n",
+            "data: [DONE]\n\n",
+        )
+        .to_string();
+        let host = mock_sse_server(body).await;
+
+        let provider = QwenProvider::local(host);
+        let request = LLMRequest::new("qwen3-8b", vec![Message::user("read src/main.rs")]);
+        let events: Vec<StreamEvent> = provider
+            .stream(request)
+            .await
+            .expect("stream() succeeds")
+            .map(|e| e.expect("stream event is Ok"))
+            .collect()
+            .await;
+
+        let tool = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::ContentBlockStart {
+                    content_block: ContentBlock::ToolUse { name, input, .. },
+                    ..
+                } => Some((name.clone(), input.clone())),
+                _ => None,
+            })
+            .expect("assembled tool call must surface as a ToolUse block");
+        assert_eq!(tool.0, "read_file");
+        assert_eq!(tool.1, serde_json::json!({"path": "src/main.rs"}));
+
+        let usage = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::MessageDelta { usage, .. } => Some(*usage),
+                _ => None,
+            })
+            .expect("usage must be present in the terminal MessageDelta");
+        assert_eq!(usage.input_tokens, 7);
+        assert_eq!(usage.output_tokens, 12);
+    }
+
+    /// A malformed SSE data line must be logged and skipped rather than
+    /// aborting the stream — subsequent valid chunks still get processed.
+    #[tokio::test]
+    async fn stream_skips_malformed_sse_chunk_and_continues() {
+        let body = concat!(
+            "data: {this is not valid json}\n\n",
+            "data: {\"id\":\"chatcmpl-2\",\"model\":\"qwen3-8b\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello there!\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        )
+        .to_string();
+        let host = mock_sse_server(body).await;
+
+        let provider = QwenProvider::local(host);
+        let request = LLMRequest::new("qwen3-8b", vec![Message::user("hi")]);
+        let events: Vec<StreamEvent> = provider
+            .stream(request)
+            .await
+            .expect("stream() succeeds despite a malformed chunk")
+            .map(|e| e.expect("stream event is Ok"))
+            .collect()
+            .await;
+
+        let text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::ContentBlockDelta {
+                    delta: ContentDelta::TextDelta { text },
+                    ..
+                } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "Hello there!");
     }
 
     #[test]

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -948,44 +948,135 @@ impl Provider for QwenProvider {
         )
         .await?;
 
-        // Parse Server-Sent Events stream
-        let byte_stream = response.bytes_stream();
-        let event_stream = byte_stream.map(|chunk_result| {
-            chunk_result
-                .map_err(|e| ProviderError::StreamError(e.to_string()))
-                .map(|chunk| {
-                    let text = String::from_utf8_lossy(&chunk);
+        // Collect the full SSE stream before emitting events.
+        //
+        // Qwen embeds tool calls inside the assistant text (Hermes
+        // `<tool_call>` blocks or native Qwen markers), so a call can't be
+        // recognised until its closing marker has been seen. Buffering the
+        // whole response — then reusing `from_qwen_response`, the same parser
+        // the non-streaming path uses — guarantees streaming and blocking
+        // requests detect tool calls identically. (Mirrors the OpenAI
+        // provider, which buffers for the analogous reason.)
+        let mut raw_bytes = Vec::<u8>::new();
+        {
+            let mut bs = response.bytes_stream();
+            while let Some(chunk_result) = bs.next().await {
+                match chunk_result {
+                    Ok(chunk) => raw_bytes.extend_from_slice(&chunk),
+                    Err(e) => return Err(ProviderError::StreamError(e.to_string())),
+                }
+            }
+        }
+        let text = String::from_utf8_lossy(&raw_bytes);
 
-                    for line in text.lines() {
-                        if let Some(json_str) = line.strip_prefix("data: ") {
-                            if json_str == "[DONE]" {
-                                return StreamEvent::MessageStop;
+        let mut full_content = String::new();
+        let mut response_id: Option<String> = None;
+        let mut stream_model: Option<String> = None;
+        let mut finish_reason: Option<String> = None;
+        let mut stream_usage: Option<QwenUsage> = None;
+        // OpenAI-style tool-call fragments, accumulated by index.
+        let mut tool_call_builders: Vec<QwenToolCall> = Vec::new();
+
+        for line in text.lines() {
+            let Some(json_str) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            if json_str == "[DONE]" {
+                break;
+            }
+            let chunk = match serde_json::from_str::<QwenStreamChunk>(json_str) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse Qwen stream chunk: {}. Data: {}",
+                        e,
+                        json_str.chars().take(200).collect::<String>()
+                    );
+                    continue;
+                }
+            };
+
+            if response_id.is_none() {
+                response_id = Some(chunk.id.clone());
+                stream_model = chunk.model.clone();
+            }
+            if chunk.usage.is_some() {
+                stream_usage = chunk.usage;
+            }
+
+            if let Some(choice) = chunk.choices.first() {
+                if let Some(ref reason) = choice.finish_reason {
+                    if !reason.is_empty() {
+                        finish_reason = Some(reason.clone());
+                    }
+                }
+                if let Some(ref delta) = choice.delta {
+                    if let Some(ref content) = delta.content {
+                        full_content.push_str(content);
+                    }
+                    for tc in &delta.tool_calls {
+                        if tc.index >= tool_call_builders.len() {
+                            tool_call_builders.resize_with(tc.index + 1, || QwenToolCall {
+                                id: String::new(),
+                                r#type: "function".to_string(),
+                                function: QwenFunctionCall {
+                                    name: String::new(),
+                                    arguments: String::new(),
+                                },
+                            });
+                        }
+                        let builder = &mut tool_call_builders[tc.index];
+                        if let Some(ref id) = tc.id {
+                            builder.id.clone_from(id);
+                        }
+                        if let Some(ref func) = tc.function {
+                            if let Some(ref name) = func.name {
+                                builder.function.name.clone_from(name);
                             }
-
-                            if let Ok(chunk) = serde_json::from_str::<QwenStreamChunk>(json_str) {
-                                if let Some(choice) = chunk.choices.first() {
-                                    if let Some(ref delta) = choice.delta {
-                                        if let Some(ref content) = delta.content {
-                                            if !content.is_empty() {
-                                                return StreamEvent::ContentBlockDelta {
-                                                    index: 0,
-                                                    delta: ContentDelta::TextDelta {
-                                                        text: content.clone(),
-                                                    },
-                                                };
-                                            }
-                                        }
-                                    }
-                                }
+                            if let Some(ref args) = func.arguments {
+                                builder.function.arguments.push_str(args);
                             }
                         }
                     }
+                }
+            }
+        }
 
-                    StreamEvent::Ping
-                })
-        });
+        // Drop tool-call fragments that never received an id/name (truncated).
+        let assembled_tool_calls: Vec<QwenToolCall> = tool_call_builders
+            .into_iter()
+            .filter(|tc| !tc.id.is_empty() && !tc.function.name.is_empty())
+            .collect();
 
-        Ok(Box::pin(event_stream))
+        // Reuse the shared parser so embedded (Hermes/native) and OpenAI-style
+        // tool calls are handled exactly as in the non-streaming path.
+        let synthetic = QwenResponse {
+            id: response_id.unwrap_or_else(|| format!("qwen-stream-{}", uuid::Uuid::new_v4())),
+            model: stream_model.unwrap_or_else(|| qwen_request.model.clone()),
+            choices: vec![QwenChoice {
+                index: 0,
+                message: QwenMessage {
+                    role: "assistant".to_string(),
+                    content: Some(full_content),
+                    tool_calls: if assembled_tool_calls.is_empty() {
+                        None
+                    } else {
+                        Some(assembled_tool_calls)
+                    },
+                    tool_call_id: None,
+                },
+                finish_reason,
+            }],
+            usage: stream_usage.unwrap_or(QwenUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+            }),
+        };
+        let llm_response = self.from_qwen_response(synthetic);
+
+        Ok(Box::pin(futures::stream::iter(
+            llm_response_to_stream_events(llm_response).into_iter().map(Ok),
+        )))
     }
 
     fn supports_streaming(&self) -> bool {
@@ -1085,6 +1176,88 @@ impl Provider for QwenProvider {
     }
 }
 
+/// Convert an assembled [`LLMResponse`] into the ordered [`StreamEvent`]
+/// sequence a consumer expects: `MessageStart`, one content block per
+/// response block (text/thinking streamed as deltas, tool use as start/stop),
+/// then `MessageDelta` (stop reason + usage) and the terminal `MessageStop`.
+///
+/// Used by the buffered Qwen streaming path so that tool calls parsed from the
+/// full response are surfaced as real `ToolUse` blocks instead of being lost.
+fn llm_response_to_stream_events(response: LLMResponse) -> Vec<StreamEvent> {
+    let mut events = vec![StreamEvent::MessageStart {
+        message: StreamMessage {
+            id: response.id.clone(),
+            model: response.model.clone(),
+            role: Role::Assistant,
+            usage: TokenUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        },
+    }];
+
+    let mut index = 0usize;
+    for block in &response.content {
+        match block {
+            ContentBlock::Text { text } => {
+                events.push(StreamEvent::ContentBlockStart {
+                    index,
+                    content_block: ContentBlock::Text {
+                        text: String::new(),
+                    },
+                });
+                if !text.is_empty() {
+                    events.push(StreamEvent::ContentBlockDelta {
+                        index,
+                        delta: ContentDelta::TextDelta { text: text.clone() },
+                    });
+                }
+                events.push(StreamEvent::ContentBlockStop { index });
+                index += 1;
+            }
+            ContentBlock::Thinking { thinking } => {
+                events.push(StreamEvent::ContentBlockStart {
+                    index,
+                    content_block: ContentBlock::Thinking {
+                        thinking: String::new(),
+                    },
+                });
+                if !thinking.is_empty() {
+                    events.push(StreamEvent::ContentBlockDelta {
+                        index,
+                        delta: ContentDelta::ThinkingDelta {
+                            thinking: thinking.clone(),
+                        },
+                    });
+                }
+                events.push(StreamEvent::ContentBlockStop { index });
+                index += 1;
+            }
+            other => {
+                // ToolUse / other blocks carry their full payload up front.
+                events.push(StreamEvent::ContentBlockStart {
+                    index,
+                    content_block: other.clone(),
+                });
+                events.push(StreamEvent::ContentBlockStop { index });
+                index += 1;
+            }
+        }
+    }
+
+    events.push(StreamEvent::MessageDelta {
+        delta: MessageDelta {
+            stop_reason: response.stop_reason,
+            stop_sequence: None,
+        },
+        usage: response.usage,
+        perf_metrics: None,
+    });
+    events.push(StreamEvent::MessageStop);
+
+    events
+}
+
 // ============================================================================
 // Qwen API Types (OpenAI-compatible)
 // ============================================================================
@@ -1166,7 +1339,12 @@ struct QwenUsage {
 #[allow(dead_code)]
 struct QwenStreamChunk {
     id: String,
+    #[serde(default)]
+    model: Option<String>,
     choices: Vec<QwenStreamChoice>,
+    /// Present only on the final chunk when the server includes usage.
+    #[serde(default)]
+    usage: Option<QwenUsage>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1182,6 +1360,30 @@ struct QwenStreamChoice {
 struct QwenMessageDelta {
     role: Option<String>,
     content: Option<String>,
+    /// OpenAI-style streamed tool-call fragments (DashScope with the OpenAI
+    /// tool parser). Accumulated by index across chunks.
+    #[serde(default)]
+    tool_calls: Vec<QwenToolCallDelta>,
+}
+
+/// A single fragment of an OpenAI-style streamed tool call. Fields arrive
+/// incrementally across SSE chunks and are assembled by `index`.
+#[derive(Debug, Clone, Deserialize)]
+struct QwenToolCallDelta {
+    #[serde(default)]
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<QwenFunctionCallDelta>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct QwenFunctionCallDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1199,6 +1401,90 @@ struct QwenError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build the synthetic `QwenResponse` the buffered streaming path assembles
+    /// from accumulated `delta.content`, then reuse the shared parser + event
+    /// conversion — exactly the chain `stream()` runs after draining the SSE
+    /// body. Returns the emitted stream events.
+    fn stream_events_from_buffered_content(
+        provider: &QwenProvider,
+        content: &str,
+    ) -> Vec<StreamEvent> {
+        let synthetic = QwenResponse {
+            id: "qwen-stream-test".to_string(),
+            model: "qwen3-8b".to_string(),
+            choices: vec![QwenChoice {
+                index: 0,
+                message: QwenMessage {
+                    role: "assistant".to_string(),
+                    content: Some(content.to_string()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: QwenUsage {
+                prompt_tokens: 5,
+                completion_tokens: 10,
+            },
+        };
+        let llm_response = provider.from_qwen_response(synthetic);
+        llm_response_to_stream_events(llm_response)
+    }
+
+    /// Regression: a Hermes `<tool_call>` block that arrives over the streaming
+    /// path must be surfaced as a real `ToolUse` block, not dropped as text.
+    #[test]
+    fn streaming_assembles_hermes_tool_call_from_buffered_text() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+        let content = "Let me read that.\n\
+             <tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"src/main.rs\"}}\n</tool_call>";
+
+        let events = stream_events_from_buffered_content(&provider, content);
+
+        let tool = events.iter().find_map(|e| match e {
+            StreamEvent::ContentBlockStart {
+                content_block: ContentBlock::ToolUse { name, input, .. },
+                ..
+            } => Some((name.clone(), input.clone())),
+            _ => None,
+        });
+        let (name, input) = tool.expect("streamed Hermes tool call must become a ToolUse block");
+        assert_eq!(name, "read_file");
+        assert_eq!(input, serde_json::json!({"path": "src/main.rs"}));
+
+        // The terminal stop reason must reflect the tool call.
+        let stop = events.iter().find_map(|e| match e {
+            StreamEvent::MessageDelta { delta, .. } => delta.stop_reason.clone(),
+            _ => None,
+        });
+        assert_eq!(stop, Some(StopReason::ToolUse));
+    }
+
+    /// Plain streamed text (no tool call) must still round-trip as a text block.
+    #[test]
+    fn streaming_plain_text_roundtrips_without_tool_calls() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+        let events = stream_events_from_buffered_content(&provider, "Hello there!");
+
+        let text: String = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::ContentBlockDelta {
+                    delta: ContentDelta::TextDelta { text },
+                    ..
+                } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text, "Hello there!");
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ContentBlockStart {
+                content_block: ContentBlock::ToolUse { .. },
+                ..
+            })));
+    }
 
     #[test]
     fn test_qwen_provider_creation() {


### PR DESCRIPTION
Anthropic streams a tool_use block as a content_block_start carrying an
empty `input: {}`, followed by the real arguments as input_json_delta
fragments, then a content_block_stop. drain_stream_to_response captured
the empty-input block on start but dropped every InputJsonDelta (the
ContentDelta match fell through to `_ => {}`), so every streamed Anthropic
tool call reached the executor with `{}` arguments. Because the TUI always
uses the streaming path, tool use with Anthropic was effectively broken.

Accumulate the input_json_delta fragments for the open tool-use block and
merge the assembled JSON into the tool input at content_block_stop (and at
the truncated-stream flush). No-op for OpenAI/Ollama, which already deliver
a fully-formed input in content_block_start and never emit InputJsonDelta.

Adds a regression test covering the empty-start + fragmented-delta sequence.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U6RsC6UBFoJAVgnsenzgae