### PR TITLE
Fix Qwen2.5-Coder tool calls silently dropping under Hermes parser

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -60,6 +60,16 @@ default_model = "qwen2.5-coder-7b-instruct"
 # - "native" or "qwen": Uses ✿FUNCTION✿ Unicode markers (official Qwen-Agent format)
 # - "openai": Uses standard OpenAI tool_calls format
 
+# Sampling overrides (optional). vLLM's OpenAI-compatible server does not
+# apply model-appropriate sampling itself and is prone to repetition/looping
+# output without them, so crustly sends Qwen's recommended defaults
+# automatically: top_p=0.8 + repetition_penalty=1.05 for Qwen2.5/Coder
+# models, top_p=0.8 + top_k=20 for Qwen3 (top_p=0.95 in thinking mode, no
+# repetition_penalty). Only set these to override that behavior:
+# top_p = 0.8
+# top_k = 20               # vLLM/LM Studio extension; local deployments only unless set here
+# repetition_penalty = 1.05  # vLLM/LM Studio extension; local deployments only unless set here
+
 # For DashScope cloud API:
 # [providers.qwen]
 # enabled = true

--- a/docs/guides/QWEN_INTEGRATION.md
+++ b/docs/guides/QWEN_INTEGRATION.md
@@ -270,6 +270,18 @@ default_model = "qwen2.5-coder-7b-instruct"
 2. **Verify vLLM settings**: Ensure `--tool-call-parser hermes` is set
 3. **Enable debug mode**: `crustly -d` to see detailed logs
 
+**Qwen2.5-Coder specifically:** unlike Qwen3, Qwen2.5-Coder models were not
+trained on Hermes `<tool_call>` tokens (see vLLM issues
+[#10952](https://github.com/vllm-project/vllm/issues/10952),
+[#29192](https://github.com/vllm-project/vllm/issues/29192)), so they often
+reply with a bare JSON object or a ```` ```json ```` fenced block instead of
+the wrapped tag format — even with `tool_parser = "hermes"` and
+`--tool-call-parser hermes` set correctly on the vLLM side. Crustly's Hermes
+parser automatically falls back to detecting that shape (`{"name": ...,
+"arguments": {...}}`, tagged or bare) when no `<tool_call>` tags are found,
+so no configuration change is needed — just make sure you're on a build that
+includes this fallback if tool calls with a Coder model still aren't firing.
+
 ### Thinking Mode Not Working
 
 1. Ensure `enable_thinking = true` in config

--- a/docs/guides/QWEN_INTEGRATION.md
+++ b/docs/guides/QWEN_INTEGRATION.md
@@ -306,11 +306,14 @@ trained on Hermes `<tool_call>` tokens (see vLLM issues
 [#29192](https://github.com/vllm-project/vllm/issues/29192)), so they often
 reply with a bare JSON object or a ```` ```json ```` fenced block instead of
 the wrapped tag format — even with `tool_parser = "hermes"` and
-`--tool-call-parser hermes` set correctly on the vLLM side. Crustly's Hermes
-parser automatically falls back to detecting that shape (`{"name": ...,
-"arguments": {...}}`, tagged or bare) when no `<tool_call>` tags are found,
-so no configuration change is needed — just make sure you're on a build that
-includes this fallback if tool calls with a Coder model still aren't firing.
+`--tool-call-parser hermes` set correctly on the vLLM side. Crustly
+automatically falls back to detecting that shape (`{"name": ...,
+"arguments": {...}}`, tagged or bare) whenever no `<tool_call>` tags are
+found — under both `tool_parser = "hermes"` and `tool_parser = "openai"` —
+so no configuration change is needed. A match is only accepted when `name`
+is one of the tools offered in the request, so an unrelated JSON example
+the model prints while explaining something isn't misdetected as a real
+tool call.
 
 ### Repetitive or Looping Output
 

--- a/docs/guides/QWEN_INTEGRATION.md
+++ b/docs/guides/QWEN_INTEGRATION.md
@@ -114,6 +114,36 @@ Standard OpenAI-compatible format with `tool_calls` array in response.
 - Compatibility with existing tools
 - LM Studio with auto-parsing enabled
 
+## Sampling Parameters
+
+vLLM's OpenAI-compatible server does **not** apply model-appropriate
+sampling defaults on its own, and Qwen's own docs warn that its defaults are
+prone to repetitive/looping output for Qwen2.5 models — you're expected to
+always pass `top_p` and `repetition_penalty` explicitly. Crustly now does
+this automatically, based on the model family:
+
+| Model family | `top_p` | `top_k` | `repetition_penalty` |
+|---|---|---|---|
+| Qwen2.5 / Qwen2.5-Coder | 0.8 | — | 1.05 |
+| Qwen3 (non-thinking) | 0.8 | 20 | — (not recommended for Qwen3) |
+| Qwen3 (thinking) | 0.95 | 20 | — (not recommended for Qwen3) |
+
+`top_k` and `repetition_penalty` are vLLM/LM Studio extensions to the
+OpenAI schema, so they're only auto-injected for local deployments —
+DashScope only ever gets the standard `top_p`, unless you override it below.
+
+To override any of these (e.g. for DashScope, or to tune repetition
+yourself), set them explicitly in `crustly.toml`:
+
+```toml
+[providers.qwen]
+top_p = 0.8
+top_k = 20               # local deployments only, unless set here
+repetition_penalty = 1.05  # local deployments only, unless set here
+```
+
+An explicit override always wins over the automatic model-family default.
+
 ## Qwen3 Thinking Mode
 
 When enabled, Qwen3 models use `<think>` tags to show their reasoning process:
@@ -281,6 +311,16 @@ parser automatically falls back to detecting that shape (`{"name": ...,
 "arguments": {...}}`, tagged or bare) when no `<tool_call>` tags are found,
 so no configuration change is needed — just make sure you're on a build that
 includes this fallback if tool calls with a Coder model still aren't firing.
+
+### Repetitive or Looping Output
+
+Crustly now sends Qwen-recommended `top_p`/`top_k`/`repetition_penalty`
+automatically (see [Sampling Parameters](#sampling-parameters)), which is
+the documented fix for vLLM's default sampling being prone to repetition on
+Qwen2.5/Coder models. If you still see looping output, try setting
+`repetition_penalty` a bit higher (e.g. `1.1`) in `[providers.qwen]` — but
+avoid pushing it much further, as too high a value degrades naturally
+repetitive text (tables, code with repeated tokens).
 
 ### Thinking Mode Not Working
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -346,6 +346,25 @@ pub struct QwenProviderConfig {
     /// DashScope region: "intl" (Singapore) or "cn" (Beijing)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
+
+    /// Nucleus sampling override (0.0-1.0). Qwen recommends 0.8 for
+    /// Qwen2.5/Coder and Qwen3 (non-thinking), 0.95 for Qwen3 thinking mode;
+    /// crustly applies those automatically when this is unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+
+    /// Top-k sampling override. Qwen recommends 20 for Qwen3; not applicable
+    /// to Qwen2.5. Only sent to local deployments (vLLM/LM Studio), never to
+    /// DashScope, unless explicitly set here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+
+    /// Repetition penalty override. Qwen recommends 1.05 for Qwen2.5/Coder
+    /// to counter vLLM's default sampling being prone to repetition; not
+    /// recommended for Qwen3. Only sent to local deployments unless
+    /// explicitly set here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repetition_penalty: Option<f32>,
 }
 
 /// Native Ollama provider configuration (`/api/chat`, via `ollama-rs`).
@@ -718,6 +737,9 @@ impl Config {
                 enable_thinking: false,
                 thinking_budget: None,
                 region: None,
+                top_p: None,
+                top_k: None,
+                repetition_penalty: None,
             });
             provider.api_key = Some(api_key);
         }
@@ -733,6 +755,9 @@ impl Config {
                 enable_thinking: false,
                 thinking_budget: None,
                 region: None,
+                top_p: None,
+                top_k: None,
+                repetition_penalty: None,
             });
             provider.base_url = Some(base_url);
         }
@@ -748,6 +773,9 @@ impl Config {
                 enable_thinking: false,
                 thinking_budget: None,
                 region: None,
+                top_p: None,
+                top_k: None,
+                repetition_penalty: None,
             });
             provider.enable_thinking = thinking.parse().unwrap_or(false);
         }

--- a/src/llm/provider/factory.rs
+++ b/src/llm/provider/factory.rs
@@ -271,6 +271,12 @@ fn configure_qwen(mut provider: QwenProvider, config: &QwenProviderConfig) -> Qw
         provider = provider.with_default_model(model.clone());
     }
 
+    // Sampling overrides (top_p/top_k/repetition_penalty). Unset fields fall
+    // back to Qwen's model-family-aware recommended defaults.
+    if config.top_p.is_some() || config.top_k.is_some() || config.repetition_penalty.is_some() {
+        provider = provider.with_sampling(config.top_p, config.top_k, config.repetition_penalty);
+    }
+
     provider
 }
 
@@ -515,6 +521,9 @@ mod tests {
                     enable_thinking: false,
                     thinking_budget: None,
                     region: None,
+                    top_p: None,
+                    top_k: None,
+                    repetition_penalty: None,
                 }),
                 ..Default::default()
             },

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -180,12 +180,28 @@ impl QwenProvider {
             .expect("Failed to create HTTP client")
     }
 
+    /// Whether this provider talks to a local deployment (vLLM, LM Studio)
+    /// rather than DashScope cloud. Centralizes the sentinel used by
+    /// [`QwenProvider::local`] so callers don't repeat the string comparison.
+    fn is_local(&self) -> bool {
+        self.api_key == "not-needed"
+    }
+
+    /// Generate a synthetic tool-call id in the `call_<24 hex chars>` shape
+    /// used across all tool-call parsers in this file.
+    fn generate_call_id() -> String {
+        format!(
+            "call_{}",
+            &uuid::Uuid::new_v4().to_string().replace('-', "")[..24]
+        )
+    }
+
     /// Build request headers
     fn headers(&self) -> reqwest::header::HeaderMap {
         let mut headers = reqwest::header::HeaderMap::new();
 
         // Only add authorization if not using local
-        if self.api_key != "not-needed" {
+        if !self.is_local() {
             headers.insert(
                 reqwest::header::AUTHORIZATION,
                 format!("Bearer {}", self.api_key)
@@ -243,10 +259,7 @@ impl QwenProvider {
                         parsed.get("name").and_then(|v| v.as_str()),
                         parsed.get("arguments"),
                     ) {
-                        let id = format!(
-                            "call_{}",
-                            &uuid::Uuid::new_v4().to_string().replace("-", "")[..24]
-                        );
+                        let id = Self::generate_call_id();
                         tool_calls.push((id, name.to_string(), arguments.clone()));
                     }
                 }
@@ -308,9 +321,15 @@ impl QwenProvider {
                 if let Some(end) = end {
                     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text[i..end]) {
                         result.push((i, end, value));
+                        i = end;
+                        continue;
                     }
-                    i = end;
-                    continue;
+                    // The whole balanced span failed to parse (e.g. an
+                    // unquoted key in an enclosing object) — don't skip
+                    // past it. A validly-formed JSON object can still be
+                    // nested inside, so just advance one byte; the next
+                    // `{` encountered (including one inside this span)
+                    // will be scanned on its own.
                 }
             }
             i += 1;
@@ -318,18 +337,42 @@ impl QwenProvider {
         result
     }
 
+    /// Expand a matched JSON span to also swallow an immediately adjacent
+    /// fence marker (```json or ```) directly before/after it — separated
+    /// only by whitespace — so a ```json fenced tool call's fence markers
+    /// are removed along with the JSON, without touching an unrelated fence
+    /// elsewhere in the message.
+    fn expand_span_over_adjacent_fences(text: &str, start: usize, end: usize) -> (usize, usize) {
+        let before = text[..start].trim_end();
+        let new_start = before
+            .strip_suffix("```json")
+            .or_else(|| before.strip_suffix("```"))
+            .map_or(start, str::len);
+
+        let after = text[end..].trim_start();
+        let new_end = after
+            .strip_prefix("```")
+            .map_or(end, |rest| text.len() - rest.len());
+
+        (new_start, new_end)
+    }
+
     /// Fallback tool-call extraction for Qwen2.5-Coder models, which
     /// frequently skip the Hermes `<tool_call>` wrapper and emit bare JSON
     /// or a ```json fenced block shaped like
-    /// `{"name": ..., "arguments": {...}}` instead. Only objects matching
-    /// that exact shape are treated as tool calls, so ordinary JSON the
-    /// model prints while explaining code is left alone.
+    /// `{"name": ..., "arguments": {...}}` instead. A match is only
+    /// accepted when `name` is one of `known_tools` (the tools offered in
+    /// the request) — without that check, ordinary JSON the model prints
+    /// while explaining something (e.g. an example payload) can look
+    /// identical to a real tool call.
     ///
     /// Returns the parsed calls and the input text with matched JSON spans
-    /// (and any surrounding ```json fence markers) removed for display.
+    /// (and their immediately adjacent ```json fence markers, if any)
+    /// removed for display.
     fn parse_fallback_tool_calls(
         &self,
         text: &str,
+        known_tools: &[String],
     ) -> (Vec<(String, String, serde_json::Value)>, String) {
         let mut calls = Vec::new();
         let mut spans = Vec::new();
@@ -338,18 +381,18 @@ impl QwenProvider {
             let name = value.get("name").and_then(|v| v.as_str());
             let arguments = value.get("arguments");
             if let (Some(name), Some(arguments)) = (name, arguments) {
+                if !known_tools.iter().any(|t| t == name) {
+                    continue;
+                }
                 let args_value = match arguments {
                     serde_json::Value::String(s) => {
                         serde_json::from_str(s).unwrap_or_else(|_| serde_json::json!({}))
                     }
                     other => other.clone(),
                 };
-                let id = format!(
-                    "call_{}",
-                    &uuid::Uuid::new_v4().to_string().replace('-', "")[..24]
-                );
+                let id = Self::generate_call_id();
                 calls.push((id, name.to_string(), args_value));
-                spans.push((start, end));
+                spans.push(Self::expand_span_over_adjacent_fences(text, start, end));
             }
         }
 
@@ -357,15 +400,12 @@ impl QwenProvider {
             return (calls, text.to_string());
         }
 
-        // Remove matched JSON spans, highest offset first so earlier spans
-        // (computed against the original text) stay valid.
+        // Remove matched (fence-expanded) spans, highest offset first so
+        // earlier spans (computed against the original text) stay valid.
         let mut clean_text = text.to_string();
         for (start, end) in spans.into_iter().rev() {
             clean_text.replace_range(start..end, "");
         }
-
-        // Strip any leftover fence markers left behind by the removal.
-        let clean_text = clean_text.replace("```json", "").replace("```", "");
 
         (calls, clean_text)
     }
@@ -468,10 +508,7 @@ impl QwenProvider {
                     if !fn_name.is_empty() && !args_text.is_empty() {
                         match serde_json::from_str::<serde_json::Value>(args_text) {
                             Ok(args) => {
-                                let id = format!(
-                                    "call_{}",
-                                    &uuid::Uuid::new_v4().to_string().replace('-', "")[..24]
-                                );
+                                let id = Self::generate_call_id();
                                 tool_calls.push((id, fn_name, args));
                             }
                             Err(e) => {
@@ -763,7 +800,7 @@ impl QwenProvider {
         // to any backend (including DashScope); top_k/repetition_penalty
         // are vLLM/LM Studio extensions, so auto-injected defaults are only
         // sent to local deployments unless explicitly configured.
-        let is_local = self.api_key == "not-needed";
+        let is_local = self.is_local();
         let (default_top_p, default_top_k, default_repetition_penalty) =
             Self::default_sampling(&request.model, self.thinking_config.enabled);
         let top_p = request.top_p.or(self.sampling.top_p).or(default_top_p);
@@ -802,17 +839,63 @@ impl QwenProvider {
         model: &str,
         thinking_enabled: bool,
     ) -> (Option<f32>, Option<u32>, Option<f32>) {
-        if model.to_lowercase().contains("qwen3") {
+        let lower = model.to_lowercase();
+        if lower.contains("qwen3") {
             let top_p = if thinking_enabled { 0.95 } else { 0.8 };
             (Some(top_p), Some(20), None)
-        } else {
+        } else if lower.contains("qwen2") || lower.contains("coder") {
             (Some(0.8), None, Some(1.05))
+        } else {
+            // Model name doesn't identify a known family (e.g. a custom
+            // --served-model-name on a local deployment). We can't tell
+            // whether Qwen3's or Qwen2.5's tuning applies, so only send the
+            // top_p baseline both agree on — never guess repetition_penalty,
+            // which Qwen explicitly advises against for Qwen3.
+            (Some(0.8), None, None)
         }
     }
 
-    /// Convert Qwen response to our generic format
+    /// Try the fallback JSON tool-call detector on `remaining`; on a match,
+    /// push text/tool-use blocks and set `has_tool_calls`. Falls back to
+    /// pushing `remaining` verbatim as text when nothing matches. Shared by
+    /// the Hermes and OpenAI branches of [`QwenProvider::from_qwen_response`],
+    /// since Qwen2.5-Coder's untrained tool-call format can surface as bare
+    /// or fenced JSON regardless of which parser mode is configured.
+    fn push_fallback_or_text(
+        &self,
+        remaining: String,
+        known_tools: &[String],
+        has_tool_calls: &mut bool,
+        content_blocks: &mut Vec<ContentBlock>,
+    ) {
+        let (fallback_calls, clean_text) = self.parse_fallback_tool_calls(&remaining, known_tools);
+        if !fallback_calls.is_empty() {
+            *has_tool_calls = true;
+            let clean_text = clean_text.trim();
+            if !clean_text.is_empty() {
+                content_blocks.push(ContentBlock::Text {
+                    text: clean_text.to_string(),
+                });
+            }
+            for (id, name, input) in fallback_calls {
+                tracing::debug!(
+                    "Parsed fallback JSON tool call (non-Hermes format): {} with id {}",
+                    name,
+                    id
+                );
+                content_blocks.push(ContentBlock::ToolUse { id, name, input });
+            }
+        } else if !remaining.is_empty() {
+            content_blocks.push(ContentBlock::Text { text: remaining });
+        }
+    }
+
+    /// Convert Qwen response to our generic format. `known_tools` are the
+    /// tool names offered in the originating request — used to gate the
+    /// fallback JSON tool-call detector against false positives (see
+    /// [`QwenProvider::parse_fallback_tool_calls`]).
     #[allow(clippy::wrong_self_convention)]
-    fn from_qwen_response(&self, response: QwenResponse) -> LLMResponse {
+    fn from_qwen_response(&self, response: QwenResponse, known_tools: &[String]) -> LLMResponse {
         let choice = response
             .choices
             .into_iter()
@@ -885,27 +968,12 @@ impl QwenProvider {
                             // fenced JSON instead; fall back to detecting
                             // that shape before treating the reply as plain
                             // text.
-                            let (fallback_calls, clean_text) =
-                                self.parse_fallback_tool_calls(&remaining);
-                            if !fallback_calls.is_empty() {
-                                has_tool_calls = true;
-                                let clean_text = clean_text.trim();
-                                if !clean_text.is_empty() {
-                                    content_blocks.push(ContentBlock::Text {
-                                        text: clean_text.to_string(),
-                                    });
-                                }
-                                for (id, name, input) in fallback_calls {
-                                    tracing::debug!(
-                                        "Parsed fallback JSON tool call (non-Hermes format): {} with id {}",
-                                        name,
-                                        id
-                                    );
-                                    content_blocks.push(ContentBlock::ToolUse { id, name, input });
-                                }
-                            } else if !remaining.is_empty() {
-                                content_blocks.push(ContentBlock::Text { text: remaining });
-                            }
+                            self.push_fallback_or_text(
+                                remaining,
+                                known_tools,
+                                &mut has_tool_calls,
+                                &mut content_blocks,
+                            );
                         }
                     }
                     ToolCallParser::NativeQwen => {
@@ -955,10 +1023,20 @@ impl QwenProvider {
                         }
                     }
                     ToolCallParser::OpenAI => {
-                        // OpenAI format doesn't embed tool calls in text
-                        if !remaining.is_empty() {
-                            content_blocks.push(ContentBlock::Text { text: remaining });
-                        }
+                        // The API's structured `tool_calls` field (handled
+                        // below, independent of `self.tool_parser`) is the
+                        // primary path here. But Qwen2.5-Coder's untrained
+                        // tool-call format means it can still emit bare or
+                        // fenced JSON in `content` even when the client
+                        // requested OpenAI-style tool_calls, so fall back to
+                        // detecting that shape too instead of only ever
+                        // treating this content as plain text.
+                        self.push_fallback_or_text(
+                            remaining,
+                            known_tools,
+                            &mut has_tool_calls,
+                            &mut content_blocks,
+                        );
                     }
                 }
             }
@@ -1085,6 +1163,12 @@ impl Provider for QwenProvider {
     async fn complete(&self, request: LLMRequest) -> Result<LLMResponse> {
         use super::retry::{retry_with_backoff, RetryConfig};
 
+        let known_tools: Vec<String> = request
+            .tools
+            .as_ref()
+            .map(|tools| tools.iter().map(|t| t.name.clone()).collect())
+            .unwrap_or_default();
+
         let qwen_request = self.to_qwen_request(request);
         let retry_config = RetryConfig::default();
 
@@ -1120,7 +1204,7 @@ impl Provider for QwenProvider {
                 }
 
                 let qwen_response: QwenResponse = response.json().await?;
-                Ok(self.from_qwen_response(qwen_response))
+                Ok(self.from_qwen_response(qwen_response, &known_tools))
             },
             &retry_config,
         )
@@ -1129,6 +1213,12 @@ impl Provider for QwenProvider {
 
     async fn stream(&self, request: LLMRequest) -> Result<ProviderStream> {
         use super::retry::{retry_with_backoff, RetryConfig};
+
+        let known_tools: Vec<String> = request
+            .tools
+            .as_ref()
+            .map(|tools| tools.iter().map(|t| t.name.clone()).collect())
+            .unwrap_or_default();
 
         let mut qwen_request = self.to_qwen_request(request);
         qwen_request.stream = Some(true);
@@ -1284,7 +1374,7 @@ impl Provider for QwenProvider {
                 completion_tokens: 0,
             }),
         };
-        let llm_response = self.from_qwen_response(synthetic);
+        let llm_response = self.from_qwen_response(synthetic, &known_tools);
 
         Ok(Box::pin(futures::stream::iter(
             llm_response_to_stream_events(llm_response)
@@ -1339,7 +1429,7 @@ impl Provider for QwenProvider {
 
     fn validate_model(&self, model: &str) -> bool {
         // Accept any model for local deployments
-        if self.api_key == "not-needed" {
+        if self.is_local() {
             return true;
         }
         self.supported_models().contains(&model.to_string()) || model.starts_with("qwen")
@@ -1372,7 +1462,7 @@ impl Provider for QwenProvider {
     fn calculate_cost(&self, model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
         // DashScope pricing (as of 2025) in USD per million tokens
         // Local models have no cost
-        if self.api_key == "not-needed" {
+        if self.is_local() {
             return 0.0;
         }
 
@@ -1633,6 +1723,7 @@ mod tests {
     fn stream_events_from_buffered_content(
         provider: &QwenProvider,
         content: &str,
+        known_tools: &[String],
     ) -> Vec<StreamEvent> {
         let synthetic = QwenResponse {
             id: "qwen-stream-test".to_string(),
@@ -1652,7 +1743,7 @@ mod tests {
                 completion_tokens: 10,
             },
         };
-        let llm_response = provider.from_qwen_response(synthetic);
+        let llm_response = provider.from_qwen_response(synthetic, known_tools);
         llm_response_to_stream_events(llm_response)
     }
 
@@ -1664,7 +1755,7 @@ mod tests {
         let content = "Let me read that.\n\
              <tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"src/main.rs\"}}\n</tool_call>";
 
-        let events = stream_events_from_buffered_content(&provider, content);
+        let events = stream_events_from_buffered_content(&provider, content, &[]);
 
         let tool = events.iter().find_map(|e| match e {
             StreamEvent::ContentBlockStart {
@@ -1689,7 +1780,7 @@ mod tests {
     #[test]
     fn streaming_plain_text_roundtrips_without_tool_calls() {
         let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
-        let events = stream_events_from_buffered_content(&provider, "Hello there!");
+        let events = stream_events_from_buffered_content(&provider, "Hello there!", &[]);
 
         let text: String = events
             .iter()
@@ -2162,12 +2253,29 @@ Here's my analysis of the code."#;
 
         let text = r#"I'll read that file for you.
 {"name": "read_file", "arguments": {"path": "/home/user/test.txt"}}"#;
+        let known_tools = vec!["read_file".to_string()];
 
-        let (calls, clean_text) = provider.parse_fallback_tool_calls(text);
+        let (calls, clean_text) = provider.parse_fallback_tool_calls(text, &known_tools);
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].1, "read_file");
         assert_eq!(calls[0].2["path"], "/home/user/test.txt");
         assert!(!clean_text.contains("read_file"));
+    }
+
+    /// Regression: JSON shaped exactly like a tool call but whose "name"
+    /// isn't among the tools offered in the request must NOT be treated as
+    /// a tool call — e.g. an illustrative example the model prints while
+    /// explaining something.
+    #[test]
+    fn test_fallback_rejects_unregistered_tool_name() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let text = r#"A payload for this event looks like {"name": "page_view", "arguments": {"url": "/home"}}."#;
+        let known_tools = vec!["read_file".to_string(), "list_files".to_string()];
+
+        let (calls, clean_text) = provider.parse_fallback_tool_calls(text, &known_tools);
+        assert!(calls.is_empty());
+        assert_eq!(clean_text, text);
     }
 
     /// Qwen2.5-Coder sometimes wraps the JSON tool call in a ```json fence
@@ -2177,12 +2285,31 @@ Here's my analysis of the code."#;
         let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
 
         let text = "Let me check that.\n```json\n{\"name\": \"list_files\", \"arguments\": {\"dir\": \"src\"}}\n```";
+        let known_tools = vec!["list_files".to_string()];
 
-        let (calls, clean_text) = provider.parse_fallback_tool_calls(text);
+        let (calls, clean_text) = provider.parse_fallback_tool_calls(text, &known_tools);
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].1, "list_files");
         assert_eq!(calls[0].2["dir"], "src");
         assert!(!clean_text.contains("```"));
+    }
+
+    /// A fenced tool call must only have ITS OWN fence markers removed —
+    /// an unrelated fenced code block elsewhere in the same reply must be
+    /// left intact.
+    #[test]
+    fn test_fallback_does_not_corrupt_unrelated_fenced_code_block() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+        let known_tools = vec!["list_files".to_string()];
+
+        let text = "Here's an example:\n```python\nprint(1)\n```\nAlso: {\"name\": \"list_files\", \"arguments\": {\"dir\": \"src\"}}";
+
+        let (calls, clean_text) = provider.parse_fallback_tool_calls(text, &known_tools);
+        assert_eq!(calls.len(), 1);
+        assert!(
+            clean_text.contains("```python\nprint(1)\n```"),
+            "unrelated fenced block must survive intact, got: {clean_text:?}"
+        );
     }
 
     /// Ordinary JSON the model prints while explaining code (no "name" +
@@ -2193,8 +2320,25 @@ Here's my analysis of the code."#;
 
         let text = "Here's an example config:\n```json\n{\"host\": \"localhost\", \"port\": 8000}\n```";
 
-        let (calls, _) = provider.parse_fallback_tool_calls(text);
+        let (calls, _) = provider.parse_fallback_tool_calls(text, &[]);
         assert!(calls.is_empty());
+    }
+
+    /// Regression: `find_json_objects` must not skip past a validly-formed
+    /// JSON object nested inside an outer brace pair that itself fails to
+    /// parse (e.g. an unquoted key), rather than silently dropping it.
+    #[test]
+    fn test_find_json_objects_recovers_nested_object_after_failed_outer_parse() {
+        let text = r#"Note {oops: {"name": "read_file", "arguments": {"path": "x"}}} end"#;
+
+        let objects = QwenProvider::find_json_objects(text);
+        let found = objects
+            .iter()
+            .any(|(_, _, value)| value.get("name").and_then(|v| v.as_str()) == Some("read_file"));
+        assert!(
+            found,
+            "the validly-formed nested tool-call object must still be found, got: {objects:?}"
+        );
     }
 
     /// End-to-end: a response with no `<tool_call>` tags but a bare JSON
@@ -2226,7 +2370,8 @@ Here's my analysis of the code."#;
             },
         };
 
-        let llm_response = provider.from_qwen_response(response);
+        let known_tools = vec!["read_file".to_string()];
+        let llm_response = provider.from_qwen_response(response, &known_tools);
         let tool = llm_response.content.iter().find_map(|b| match b {
             ContentBlock::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
             _ => None,
@@ -2235,6 +2380,62 @@ Here's my analysis of the code."#;
         assert_eq!(name, "read_file");
         assert_eq!(input, serde_json::json!({"path": "src/main.rs"}));
         assert_eq!(llm_response.stop_reason, Some(StopReason::ToolUse));
+    }
+
+    /// Regression: Qwen2.5-Coder's untrained tool-call format can surface as
+    /// bare JSON even when `tool_parser = "openai"` is configured (a
+    /// documented local-deployment option) — the OpenAI branch must also
+    /// fall back to detecting it, not just the Hermes branch.
+    #[test]
+    fn test_from_qwen_response_openai_parser_still_detects_fallback_json() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string())
+            .with_tool_parser(ToolCallParser::OpenAI);
+
+        let response = QwenResponse {
+            id: "qwen-openai-fallback-test".to_string(),
+            model: "qwen2.5-coder-7b-instruct".to_string(),
+            choices: vec![QwenChoice {
+                index: 0,
+                message: QwenMessage {
+                    role: "assistant".to_string(),
+                    content: Some(
+                        r#"{"name": "read_file", "arguments": {"path": "src/main.rs"}}"#
+                            .to_string(),
+                    ),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: QwenUsage {
+                prompt_tokens: 5,
+                completion_tokens: 10,
+            },
+        };
+
+        let known_tools = vec!["read_file".to_string()];
+        let llm_response = provider.from_qwen_response(response, &known_tools);
+        let tool = llm_response.content.iter().find_map(|b| match b {
+            ContentBlock::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
+            _ => None,
+        });
+        let (name, _) = tool.expect("fallback JSON tool call must be detected under the OpenAI parser too");
+        assert_eq!(name, "read_file");
+    }
+
+    /// A model name that doesn't identify a known Qwen family (e.g. a
+    /// custom --served-model-name on a local deployment) must not guess
+    /// repetition_penalty, since that's specifically discouraged for Qwen3
+    /// and we can't tell which family actually applies.
+    #[test]
+    fn test_sampling_defaults_unrecognized_model_name_is_conservative() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+        let request = LLMRequest::new("acme-ft-v2", vec![Message::user("hello")]);
+
+        let qwen_request = provider.to_qwen_request(request);
+        assert_eq!(qwen_request.top_p, Some(0.8));
+        assert_eq!(qwen_request.top_k, None);
+        assert_eq!(qwen_request.repetition_penalty, None);
     }
 
     #[test]

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -228,6 +228,116 @@ impl QwenProvider {
         tool_calls
     }
 
+    /// Extract balanced top-level JSON objects from `text`, returning their
+    /// byte span (start, end-exclusive) and parsed value.
+    ///
+    /// Used as a fallback for Qwen2.5-Coder, which — unlike Qwen3 — was not
+    /// trained on Hermes `<tool_call>` tokens (see vLLM issues #10952,
+    /// #29192, #32926) and frequently emits bare JSON or a ```json fenced
+    /// block instead of the wrapped tag format.
+    fn find_json_objects(text: &str) -> Vec<(usize, usize, serde_json::Value)> {
+        let bytes = text.as_bytes();
+        let mut result = Vec::new();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'{' {
+                let mut depth = 0i32;
+                let mut in_string = false;
+                let mut escape = false;
+                let mut j = i;
+                let mut end = None;
+                while j < bytes.len() {
+                    let c = bytes[j];
+                    if in_string {
+                        if escape {
+                            escape = false;
+                        } else if c == b'\\' {
+                            escape = true;
+                        } else if c == b'"' {
+                            in_string = false;
+                        }
+                    } else {
+                        match c {
+                            b'"' => in_string = true,
+                            b'{' => depth += 1,
+                            b'}' => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    end = Some(j + 1);
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    j += 1;
+                }
+
+                if let Some(end) = end {
+                    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text[i..end]) {
+                        result.push((i, end, value));
+                    }
+                    i = end;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        result
+    }
+
+    /// Fallback tool-call extraction for Qwen2.5-Coder models, which
+    /// frequently skip the Hermes `<tool_call>` wrapper and emit bare JSON
+    /// or a ```json fenced block shaped like
+    /// `{"name": ..., "arguments": {...}}` instead. Only objects matching
+    /// that exact shape are treated as tool calls, so ordinary JSON the
+    /// model prints while explaining code is left alone.
+    ///
+    /// Returns the parsed calls and the input text with matched JSON spans
+    /// (and any surrounding ```json fence markers) removed for display.
+    fn parse_fallback_tool_calls(
+        &self,
+        text: &str,
+    ) -> (Vec<(String, String, serde_json::Value)>, String) {
+        let mut calls = Vec::new();
+        let mut spans = Vec::new();
+
+        for (start, end, value) in Self::find_json_objects(text) {
+            let name = value.get("name").and_then(|v| v.as_str());
+            let arguments = value.get("arguments");
+            if let (Some(name), Some(arguments)) = (name, arguments) {
+                let args_value = match arguments {
+                    serde_json::Value::String(s) => {
+                        serde_json::from_str(s).unwrap_or_else(|_| serde_json::json!({}))
+                    }
+                    other => other.clone(),
+                };
+                let id = format!(
+                    "call_{}",
+                    &uuid::Uuid::new_v4().to_string().replace('-', "")[..24]
+                );
+                calls.push((id, name.to_string(), args_value));
+                spans.push((start, end));
+            }
+        }
+
+        if calls.is_empty() {
+            return (calls, text.to_string());
+        }
+
+        // Remove matched JSON spans, highest offset first so earlier spans
+        // (computed against the original text) stay valid.
+        let mut clean_text = text.to_string();
+        for (start, end) in spans.into_iter().rev() {
+            clean_text.replace_range(start..end, "");
+        }
+
+        // Strip any leftover fence markers left behind by the removal.
+        let clean_text = clean_text.replace("```json", "").replace("```", "");
+
+        (calls, clean_text)
+    }
+
     /// Extract thinking content from Qwen3 response
     fn extract_thinking(&self, text: &str) -> (Option<String>, String) {
         if !self.thinking_config.enabled {
@@ -692,8 +802,33 @@ impl QwenProvider {
                                 tracing::debug!("Parsed Hermes tool call: {} with id {}", name, id);
                                 content_blocks.push(ContentBlock::ToolUse { id, name, input });
                             }
-                        } else if !remaining.is_empty() {
-                            content_blocks.push(ContentBlock::Text { text: remaining });
+                        } else {
+                            // Qwen2.5-Coder was not trained on Hermes
+                            // `<tool_call>` tokens and often emits bare or
+                            // fenced JSON instead; fall back to detecting
+                            // that shape before treating the reply as plain
+                            // text.
+                            let (fallback_calls, clean_text) =
+                                self.parse_fallback_tool_calls(&remaining);
+                            if !fallback_calls.is_empty() {
+                                has_tool_calls = true;
+                                let clean_text = clean_text.trim();
+                                if !clean_text.is_empty() {
+                                    content_blocks.push(ContentBlock::Text {
+                                        text: clean_text.to_string(),
+                                    });
+                                }
+                                for (id, name, input) in fallback_calls {
+                                    tracing::debug!(
+                                        "Parsed fallback JSON tool call (non-Hermes format): {} with id {}",
+                                        name,
+                                        id
+                                    );
+                                    content_blocks.push(ContentBlock::ToolUse { id, name, input });
+                                }
+                            } else if !remaining.is_empty() {
+                                content_blocks.push(ContentBlock::Text { text: remaining });
+                            }
                         }
                     }
                     ToolCallParser::NativeQwen => {
@@ -1847,6 +1982,89 @@ Here's my analysis of the code."#;
         let text = "Complete text";
         let cleaned = provider.clean_incomplete_markers(text);
         assert_eq!(cleaned, "Complete text");
+    }
+
+    /// Qwen2.5-Coder frequently skips the Hermes `<tool_call>` wrapper and
+    /// emits a bare JSON object shaped like a function call instead.
+    #[test]
+    fn test_fallback_parses_bare_json_tool_call() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let text = r#"I'll read that file for you.
+{"name": "read_file", "arguments": {"path": "/home/user/test.txt"}}"#;
+
+        let (calls, clean_text) = provider.parse_fallback_tool_calls(text);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "read_file");
+        assert_eq!(calls[0].2["path"], "/home/user/test.txt");
+        assert!(!clean_text.contains("read_file"));
+    }
+
+    /// Qwen2.5-Coder sometimes wraps the JSON tool call in a ```json fence
+    /// instead of `<tool_call>` tags.
+    #[test]
+    fn test_fallback_parses_fenced_json_tool_call() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let text = "Let me check that.\n```json\n{\"name\": \"list_files\", \"arguments\": {\"dir\": \"src\"}}\n```";
+
+        let (calls, clean_text) = provider.parse_fallback_tool_calls(text);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, "list_files");
+        assert_eq!(calls[0].2["dir"], "src");
+        assert!(!clean_text.contains("```"));
+    }
+
+    /// Ordinary JSON the model prints while explaining code (no "name" +
+    /// "arguments" shape) must not be misdetected as a tool call.
+    #[test]
+    fn test_fallback_ignores_unrelated_json() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let text = "Here's an example config:\n```json\n{\"host\": \"localhost\", \"port\": 8000}\n```";
+
+        let (calls, _) = provider.parse_fallback_tool_calls(text);
+        assert!(calls.is_empty());
+    }
+
+    /// End-to-end: a response with no `<tool_call>` tags but a bare JSON
+    /// function call must still surface as a `ToolUse` block via
+    /// `from_qwen_response`.
+    #[test]
+    fn test_from_qwen_response_uses_fallback_when_no_hermes_tags() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let response = QwenResponse {
+            id: "qwen-fallback-test".to_string(),
+            model: "qwen2.5-coder-7b-instruct".to_string(),
+            choices: vec![QwenChoice {
+                index: 0,
+                message: QwenMessage {
+                    role: "assistant".to_string(),
+                    content: Some(
+                        r#"{"name": "read_file", "arguments": {"path": "src/main.rs"}}"#
+                            .to_string(),
+                    ),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: QwenUsage {
+                prompt_tokens: 5,
+                completion_tokens: 10,
+            },
+        };
+
+        let llm_response = provider.from_qwen_response(response);
+        let tool = llm_response.content.iter().find_map(|b| match b {
+            ContentBlock::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
+            _ => None,
+        });
+        let (name, input) = tool.expect("fallback JSON tool call must become a ToolUse block");
+        assert_eq!(name, "read_file");
+        assert_eq!(input, serde_json::json!({"path": "src/main.rs"}));
+        assert_eq!(llm_response.stop_reason, Some(StopReason::ToolUse));
     }
 
     #[test]

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -807,12 +807,11 @@ impl QwenProvider {
         let top_k = self
             .sampling
             .top_k
-            .or(if is_local { default_top_k } else { None });
-        let repetition_penalty = self.sampling.repetition_penalty.or(if is_local {
-            default_repetition_penalty
-        } else {
-            None
-        });
+            .or(Self::local_only(is_local, default_top_k));
+        let repetition_penalty = self
+            .sampling
+            .repetition_penalty
+            .or(Self::local_only(is_local, default_repetition_penalty));
 
         QwenRequest {
             model: request.model,
@@ -824,6 +823,18 @@ impl QwenProvider {
             max_tokens: request.max_tokens,
             stream: Some(request.stream),
             tools,
+        }
+    }
+
+    /// Only forward `value` when this is a local deployment. `top_k` and
+    /// `repetition_penalty` are vLLM/LM Studio extensions to the OpenAI
+    /// schema, not part of it, so auto-injected defaults should never reach
+    /// DashScope.
+    fn local_only<T>(is_local: bool, value: Option<T>) -> Option<T> {
+        if is_local {
+            value
+        } else {
+            None
         }
     }
 
@@ -949,6 +960,14 @@ impl QwenProvider {
                                     break;
                                 }
                             }
+
+                            // Qwen2.5-Coder can mix one correctly Hermes-tagged
+                            // call with a second call emitted as bare/fenced
+                            // JSON in the same reply; scan what's left after
+                            // stripping Hermes tags for that too, instead of
+                            // only ever detecting the first.
+                            let (extra_calls, clean_text) =
+                                self.parse_fallback_tool_calls(&clean_text, known_tools);
                             let clean_text = clean_text.trim();
 
                             if !clean_text.is_empty() {
@@ -960,6 +979,14 @@ impl QwenProvider {
                             // Add tool use blocks
                             for (id, name, input) in hermes_calls {
                                 tracing::debug!("Parsed Hermes tool call: {} with id {}", name, id);
+                                content_blocks.push(ContentBlock::ToolUse { id, name, input });
+                            }
+                            for (id, name, input) in extra_calls {
+                                tracing::debug!(
+                                    "Parsed additional fallback JSON tool call alongside Hermes calls: {} with id {}",
+                                    name,
+                                    id
+                                );
                                 content_blocks.push(ContentBlock::ToolUse { id, name, input });
                             }
                         } else {
@@ -2054,10 +2081,7 @@ Here's my analysis of the code."#;
     #[test]
     fn test_sampling_defaults_qwen25_coder_local() {
         let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
-        let request = LLMRequest::new(
-            "qwen2.5-coder-7b-instruct",
-            vec![Message::user("hello")],
-        );
+        let request = LLMRequest::new("qwen2.5-coder-7b-instruct", vec![Message::user("hello")]);
 
         let qwen_request = provider.to_qwen_request(request);
         assert_eq!(qwen_request.top_p, Some(0.8));
@@ -2121,8 +2145,11 @@ Here's my analysis of the code."#;
     /// overrides are honored even for DashScope if the user set them.
     #[test]
     fn test_sampling_config_override_wins_over_defaults() {
-        let provider = QwenProvider::dashscope_intl("test-key".to_string())
-            .with_sampling(Some(0.5), Some(40), Some(1.2));
+        let provider = QwenProvider::dashscope_intl("test-key".to_string()).with_sampling(
+            Some(0.5),
+            Some(40),
+            Some(1.2),
+        );
         let request = LLMRequest::new("qwen-plus", vec![Message::user("hello")]);
 
         let qwen_request = provider.to_qwen_request(request);
@@ -2318,7 +2345,8 @@ Here's my analysis of the code."#;
     fn test_fallback_ignores_unrelated_json() {
         let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
 
-        let text = "Here's an example config:\n```json\n{\"host\": \"localhost\", \"port\": 8000}\n```";
+        let text =
+            "Here's an example config:\n```json\n{\"host\": \"localhost\", \"port\": 8000}\n```";
 
         let (calls, _) = provider.parse_fallback_tool_calls(text, &[]);
         assert!(calls.is_empty());
@@ -2419,8 +2447,53 @@ Here's my analysis of the code."#;
             ContentBlock::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
             _ => None,
         });
-        let (name, _) = tool.expect("fallback JSON tool call must be detected under the OpenAI parser too");
+        let (name, _) =
+            tool.expect("fallback JSON tool call must be detected under the OpenAI parser too");
         assert_eq!(name, "read_file");
+    }
+
+    /// Regression: a reply mixing one correctly Hermes-tagged tool call with
+    /// a second call emitted as bare JSON (no tags) must surface BOTH calls,
+    /// not just the tagged one — Qwen2.5-Coder is inconsistent about using
+    /// the tag format even within a single response.
+    #[test]
+    fn test_from_qwen_response_detects_bare_json_call_mixed_with_hermes_call() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let content = "First I'll read the file.\n\
+             <tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"src/main.rs\"}}\n</tool_call>\n\
+             Then I'll list the directory: {\"name\": \"list_files\", \"arguments\": {\"dir\": \"src\"}}";
+
+        let response = QwenResponse {
+            id: "qwen-mixed-format-test".to_string(),
+            model: "qwen2.5-coder-7b-instruct".to_string(),
+            choices: vec![QwenChoice {
+                index: 0,
+                message: QwenMessage {
+                    role: "assistant".to_string(),
+                    content: Some(content.to_string()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: QwenUsage {
+                prompt_tokens: 5,
+                completion_tokens: 10,
+            },
+        };
+
+        let known_tools = vec!["read_file".to_string(), "list_files".to_string()];
+        let llm_response = provider.from_qwen_response(response, &known_tools);
+        let names: Vec<String> = llm_response
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["read_file", "list_files"]);
     }
 
     /// A model name that doesn't identify a known Qwen family (e.g. a

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -64,6 +64,15 @@ pub struct ThinkingConfig {
     pub budget_tokens: Option<u32>,
 }
 
+/// User-supplied sampling overrides. `None` fields fall back to
+/// [`QwenProvider::default_sampling`]'s model-family-aware defaults.
+#[derive(Debug, Clone, Default)]
+struct SamplingOverrides {
+    top_p: Option<f32>,
+    top_k: Option<u32>,
+    repetition_penalty: Option<f32>,
+}
+
 /// Qwen provider for Alibaba's Qwen models
 #[derive(Clone)]
 pub struct QwenProvider {
@@ -73,6 +82,7 @@ pub struct QwenProvider {
     custom_default_model: Option<String>,
     tool_parser: ToolCallParser,
     thinking_config: ThinkingConfig,
+    sampling: SamplingOverrides,
 }
 
 impl QwenProvider {
@@ -97,6 +107,7 @@ impl QwenProvider {
             custom_default_model: None,
             tool_parser: ToolCallParser::Hermes, // Default to Hermes for local
             thinking_config: ThinkingConfig::default(),
+            sampling: SamplingOverrides::default(),
         }
     }
 
@@ -111,6 +122,7 @@ impl QwenProvider {
             custom_default_model: None,
             tool_parser: ToolCallParser::OpenAI, // Default to OpenAI for cloud
             thinking_config: ThinkingConfig::default(),
+            sampling: SamplingOverrides::default(),
         }
     }
 
@@ -123,6 +135,26 @@ impl QwenProvider {
     /// Set tool call parsing mode
     pub fn with_tool_parser(mut self, parser: ToolCallParser) -> Self {
         self.tool_parser = parser;
+        self
+    }
+
+    /// Override sampling parameters sent with every request. Any field left
+    /// `None` falls back to [`QwenProvider::default_sampling`]'s
+    /// model-family-aware defaults (Qwen2.5/Coder vs Qwen3), which are
+    /// applied automatically because vLLM's OpenAI-compatible server does
+    /// not apply sensible defaults itself and is prone to repetition
+    /// without them.
+    pub fn with_sampling(
+        mut self,
+        top_p: Option<f32>,
+        top_k: Option<u32>,
+        repetition_penalty: Option<f32>,
+    ) -> Self {
+        self.sampling = SamplingOverrides {
+            top_p,
+            top_k,
+            repetition_penalty,
+        };
         self
     }
 
@@ -723,13 +755,58 @@ impl QwenProvider {
             None // Hermes-style uses system prompt instead
         };
 
+        // vLLM's OpenAI-compatible server does not apply model-appropriate
+        // sampling defaults and is prone to repetition without them (see
+        // https://qwen.readthedocs.io/en/latest/deployment/vllm.html), so
+        // fall back to Qwen's recommended values when neither the caller
+        // nor provider config specified an override. top_p is safe to send
+        // to any backend (including DashScope); top_k/repetition_penalty
+        // are vLLM/LM Studio extensions, so auto-injected defaults are only
+        // sent to local deployments unless explicitly configured.
+        let is_local = self.api_key == "not-needed";
+        let (default_top_p, default_top_k, default_repetition_penalty) =
+            Self::default_sampling(&request.model, self.thinking_config.enabled);
+        let top_p = request.top_p.or(self.sampling.top_p).or(default_top_p);
+        let top_k = self
+            .sampling
+            .top_k
+            .or(if is_local { default_top_k } else { None });
+        let repetition_penalty = self.sampling.repetition_penalty.or(if is_local {
+            default_repetition_penalty
+        } else {
+            None
+        });
+
         QwenRequest {
             model: request.model,
             messages,
             temperature: request.temperature,
+            top_p,
+            top_k,
+            repetition_penalty,
             max_tokens: request.max_tokens,
             stream: Some(request.stream),
             tools,
+        }
+    }
+
+    /// Model-family-aware default sampling parameters recommended by Qwen
+    /// for vLLM deployments. Returns `(top_p, top_k, repetition_penalty)`.
+    ///
+    /// Qwen3 recommends `top_k=20` and a higher `top_p` for thinking mode,
+    /// and explicitly does *not* recommend a repetition penalty (it can
+    /// degrade naturally repetitive text like tables). Qwen2.5 / Qwen2.5-Coder
+    /// recommend `top_p=0.8` and `repetition_penalty=1.05` to counter vLLM's
+    /// default sampling, which is prone to repetition/looping output.
+    fn default_sampling(
+        model: &str,
+        thinking_enabled: bool,
+    ) -> (Option<f32>, Option<u32>, Option<f32>) {
+        if model.to_lowercase().contains("qwen3") {
+            let top_p = if thinking_enabled { 0.95 } else { 0.8 };
+            (Some(top_p), Some(20), None)
+        } else {
+            (Some(0.8), None, Some(1.05))
         }
     }
 
@@ -1406,6 +1483,16 @@ struct QwenRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f32>,
+    /// vLLM/LM Studio extension (not part of the OpenAI schema); only sent
+    /// to local deployments unless explicitly configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<u32>,
+    /// vLLM/LM Studio extension (not part of the OpenAI schema); only sent
+    /// to local deployments unless explicitly configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repetition_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
@@ -1868,6 +1955,89 @@ Here's my analysis of the code."#;
         let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string())
             .with_default_model("qwen2.5-coder-14b-instruct".to_string());
         assert_eq!(provider.default_model(), "qwen2.5-coder-14b-instruct");
+    }
+
+    /// Qwen2.5-Coder deployed locally must get the documented Qwen2.5
+    /// defaults (top_p=0.8, repetition_penalty=1.05, no top_k) when the
+    /// caller and config leave sampling unset.
+    #[test]
+    fn test_sampling_defaults_qwen25_coder_local() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+        let request = LLMRequest::new(
+            "qwen2.5-coder-7b-instruct",
+            vec![Message::user("hello")],
+        );
+
+        let qwen_request = provider.to_qwen_request(request);
+        assert_eq!(qwen_request.top_p, Some(0.8));
+        assert_eq!(qwen_request.top_k, None);
+        assert_eq!(qwen_request.repetition_penalty, Some(1.05));
+    }
+
+    /// Qwen3 non-thinking gets top_p=0.8/top_k=20 and no repetition penalty
+    /// (Qwen explicitly does not recommend one for Qwen3).
+    #[test]
+    fn test_sampling_defaults_qwen3_non_thinking() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+        let request = LLMRequest::new("qwen3-8b", vec![Message::user("hello")]);
+
+        let qwen_request = provider.to_qwen_request(request);
+        assert_eq!(qwen_request.top_p, Some(0.8));
+        assert_eq!(qwen_request.top_k, Some(20));
+        assert_eq!(qwen_request.repetition_penalty, None);
+    }
+
+    /// Qwen3 thinking mode uses the higher top_p=0.95 Qwen recommends.
+    #[test]
+    fn test_sampling_defaults_qwen3_thinking() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string())
+            .with_thinking(true);
+        let request = LLMRequest::new("qwen3-32b", vec![Message::user("hello")]);
+
+        let qwen_request = provider.to_qwen_request(request);
+        assert_eq!(qwen_request.top_p, Some(0.95));
+        assert_eq!(qwen_request.top_k, Some(20));
+    }
+
+    /// DashScope (cloud) must still get the safe, standard top_p default,
+    /// but never the vLLM-only top_k/repetition_penalty extensions unless
+    /// the user explicitly configured them.
+    #[test]
+    fn test_sampling_defaults_dashscope_omits_vendor_extensions() {
+        let provider = QwenProvider::dashscope_intl("test-key".to_string());
+        let request = LLMRequest::new("qwen-plus", vec![Message::user("hello")]);
+
+        let qwen_request = provider.to_qwen_request(request);
+        assert_eq!(qwen_request.top_p, Some(0.8));
+        assert_eq!(qwen_request.top_k, None);
+        assert_eq!(qwen_request.repetition_penalty, None);
+    }
+
+    /// Explicit per-request top_p (LLMRequest::with_top_p) always wins over
+    /// both provider config and model-family defaults.
+    #[test]
+    fn test_sampling_explicit_request_top_p_wins() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+        let request = LLMRequest::new("qwen2.5-coder-7b-instruct", vec![Message::user("hello")])
+            .with_top_p(0.42);
+
+        let qwen_request = provider.to_qwen_request(request);
+        assert_eq!(qwen_request.top_p, Some(0.42));
+    }
+
+    /// Explicit provider-level config overrides (e.g. from crustly.toml)
+    /// win over the model-family defaults, and top_k/repetition_penalty
+    /// overrides are honored even for DashScope if the user set them.
+    #[test]
+    fn test_sampling_config_override_wins_over_defaults() {
+        let provider = QwenProvider::dashscope_intl("test-key".to_string())
+            .with_sampling(Some(0.5), Some(40), Some(1.2));
+        let request = LLMRequest::new("qwen-plus", vec![Message::user("hello")]);
+
+        let qwen_request = provider.to_qwen_request(request);
+        assert_eq!(qwen_request.top_p, Some(0.5));
+        assert_eq!(qwen_request.top_k, Some(40));
+        assert_eq!(qwen_request.repetition_penalty, Some(1.2));
     }
 
     #[test]


### PR DESCRIPTION
Qwen2.5-Coder was not trained on Hermes <tool_call> tokens (unlike
Qwen3), so it often replies with bare JSON or a fenced ```json block
shaped like a function call instead of the wrapped tag format. The
Hermes parser only looked for <tool_call> tags, so those calls were
rendered as plain text and never executed.

Add a fallback that scans for balanced JSON objects matching the
{"name": ..., "arguments": {...}} shape when no Hermes tags are
present, used only after tag-based parsing finds nothing so normal
Hermes-formatted models (Qwen3) are unaffected.