### PR TITLE
Add Ornith 9B as a first-class Ollama model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,7 +963,9 @@ Ornith AI's Qwen-3.5-based model, post-trained specifically for agentic software
 |---------|-----------|---------|-------|
 | **Ornith 9B (Q4_K_M)** ⭐ | 8 GB VRAM / 16 GB RAM | 256K | Recommended quant — best speed/quality balance |
 | Ornith 9B (Q5_K_M) | 10 GB VRAM / 20 GB RAM | 256K | Slightly higher quality |
-| Ornith 9B (Q8) | 14 GB VRAM / 32 GB RAM | 256K | Highest quality, heavier memory use |
+| Ornith 9B (FP16) | 24 GB VRAM / 32 GB RAM | 256K | Full precision, rarely needed locally |
+
+> Q8 is also available (very high quality, heavier than Q5_K_M) but Ornith's documentation doesn't publish an exact memory figure for it — measure with `ollama ps` after pulling if you need one.
 
 **Ollama:** `ollama pull ornith:9b`
 

--- a/README.md
+++ b/README.md
@@ -955,6 +955,36 @@ default_model = "meta-llama-3.1-8b-instruct"
 
 ---
 
+#### Ornith 9B (agentic coding)
+
+Ornith AI's Qwen-3.5-based model, post-trained specifically for agentic software development: repo navigation, planning, refactoring, bug fixing, and tool calling. MIT licensed, with a 256K-token context window — the largest of any model in this section.
+
+| Version | VRAM / RAM | Context | Notes |
+|---------|-----------|---------|-------|
+| **Ornith 9B (Q4_K_M)** ⭐ | 8 GB VRAM / 16 GB RAM | 256K | Recommended quant — best speed/quality balance |
+| Ornith 9B (Q5_K_M) | 10 GB VRAM / 20 GB RAM | 256K | Slightly higher quality |
+| Ornith 9B (Q8) | 14 GB VRAM / 32 GB RAM | 256K | Highest quality, heavier memory use |
+
+**Ollama:** `ollama pull ornith:9b`
+
+**Minimum system requirements:**
+- GPU: 8 GB VRAM (RTX 3060 12 GB or better recommended)
+- RAM: **16 GB** minimum; 32 GB recommended; 64 GB for the largest contexts
+- Storage: ~5.6 GB (Q4_K_M), ~6.5 GB (Q5_K_M), ~18 GB (FP16)
+
+**Recommended sampling** (per Ornith's documentation — use `providers.ollama` for native `/api/chat`, not the OpenAI-compatible shim, so `temperature`/`top_p`/`top_k`/`num_ctx` apply):
+```toml
+[providers.ollama]
+enabled = true
+default_model = "ornith:9b"
+num_ctx = 65536      # up to 262144 supported; 65536 balances context vs. memory/latency
+temperature = 0.10   # 0.05 for refactoring, 0.30 for brainstorming
+top_p = 0.90
+top_k = 20
+```
+
+---
+
 #### Quick Comparison
 
 | Model | RAM | Code | Reasoning | Speed | Best For |
@@ -962,6 +992,7 @@ default_model = "meta-llama-3.1-8b-instruct"
 | Qwen2.5-Coder-7B ⭐ | 16 GB | ★★★★★ | ★★★★☆ | Fast | Code generation, tool use |
 | Gemma-3-12B | 20 GB | ★★★★☆ | ★★★★★ | Medium | Code review, explanation |
 | Llama-3.1-8B ⭐ | 16 GB | ★★★★☆ | ★★★★☆ | Fast | General-purpose coding |
+| Ornith 9B | 16 GB | ★★★★★ | ★★★★☆ | Fast | Agentic coding, 256K context |
 | Qwen2.5-Coder-32B | 48 GB | ★★★★★ | ★★★★★ | Slow | Production-quality code |
 | Llama-3.3-70B | 64 GB | ★★★★★ | ★★★★★ | Very slow | Complex multi-file tasks |
 
@@ -1665,6 +1696,7 @@ Crustly: [executes bash tool] ✅ 145 tests passed
 |-------|-------------|-----|------|-------------|---------|
 | **Qwen2.5-Coder 7B** ⭐ | `ollama pull qwen2.5-coder:7b` | 16 GB | ★★★★★ | ✅ Excellent | Code gen, tool use, default pick |
 | **Llama 3.1 8B** ⭐ | `ollama pull llama3.1:8b` | 16 GB | ★★★★☆ | ✅ Full | General-purpose coding |
+| **Ornith 9B** ⭐ | `ollama pull ornith:9b` | 16 GB | ★★★★★ | ✅ Excellent | Agentic coding, 256K context |
 | Llama 3.2 3B | `ollama pull llama3.2:3b` | 8 GB | ★★★☆☆ | ✅ Yes | Low-RAM / CPU-only machines |
 | Gemma 3 12B | `ollama pull gemma3:12b` | 20 GB | ★★★★☆ | ✅ Yes | Code review & explanation |
 | Qwen2.5-Coder 14B | `ollama pull qwen2.5-coder:14b` | 24 GB | ★★★★★ | ✅ Excellent | Higher quality code generation |

--- a/config.toml.example
+++ b/config.toml.example
@@ -86,6 +86,11 @@ default_model = "qwen2.5-coder-7b-instruct"
 # keep_alive/num_ctx control plus runtime performance metrics (tokens/sec,
 # model load time) shown in the TUI. Requires building crustly with
 # `--features ollama` (or `all-llm`).
+# Only ONE [providers.ollama] table is valid per config file - the two
+# examples below show alternative values for the *same* table (which model
+# to run), not two sections to enable together. Uncomment one, not both.
+#
+# Option A - Qwen2.5-Coder 7B (default example):
 # [providers.ollama]
 # enabled = true
 # host = "http://localhost:11434"
@@ -93,18 +98,7 @@ default_model = "qwen2.5-coder-7b-instruct"
 # keep_alive = "5m"    # "-1" (never unload), "0" (unload immediately), or "5m"/"30s"/"2h"
 # num_ctx = 8192       # Context window size to request from the model
 #
-# Env var equivalents: OLLAMA_HOST (or OLLAMA_BASE_URL), OLLAMA_MODEL
-#
-# Model management from the command line (list/pull/delete/show/embed):
-#   crustly ollama list
-#   crustly ollama pull qwen2.5-coder:7b
-#   crustly ollama rm qwen2.5-coder:7b
-#   crustly ollama show qwen2.5-coder:7b
-#   crustly ollama embed nomic-embed-text "some text to embed"
-
-# ----------------------------------------
-# Example: Ornith 9B (agentic coding model, MIT license, 256K context)
-# ----------------------------------------
+# Option B - Ornith 9B (agentic coding model, MIT license, 256K context):
 # ollama pull ornith:9b
 # Sampling values below are Ornith's documented recommendation for software
 # development tasks (lower for refactoring, e.g. temperature = 0.05).
@@ -117,6 +111,15 @@ default_model = "qwen2.5-coder-7b-instruct"
 # temperature = 0.10
 # top_p = 0.90
 # top_k = 20
+#
+# Env var equivalents: OLLAMA_HOST (or OLLAMA_BASE_URL), OLLAMA_MODEL
+#
+# Model management from the command line (list/pull/delete/show/embed):
+#   crustly ollama list
+#   crustly ollama pull qwen2.5-coder:7b
+#   crustly ollama rm qwen2.5-coder:7b
+#   crustly ollama show qwen2.5-coder:7b
+#   crustly ollama embed nomic-embed-text "some text to embed"
 
 # Environment variables for Qwen:
 # - QWEN_BASE_URL: Local endpoint URL

--- a/config.toml.example
+++ b/config.toml.example
@@ -102,6 +102,22 @@ default_model = "qwen2.5-coder-7b-instruct"
 #   crustly ollama show qwen2.5-coder:7b
 #   crustly ollama embed nomic-embed-text "some text to embed"
 
+# ----------------------------------------
+# Example: Ornith 9B (agentic coding model, MIT license, 256K context)
+# ----------------------------------------
+# ollama pull ornith:9b
+# Sampling values below are Ornith's documented recommendation for software
+# development tasks (lower for refactoring, e.g. temperature = 0.05).
+# [providers.ollama]
+# enabled = true
+# host = "http://localhost:11434"
+# default_model = "ornith:9b"
+# keep_alive = "5m"
+# num_ctx = 65536       # Model supports up to 262144; 65536 balances context vs. memory/latency
+# temperature = 0.10
+# top_p = 0.90
+# top_k = 20
+
 # Environment variables for Qwen:
 # - QWEN_BASE_URL: Local endpoint URL
 # - DASHSCOPE_API_KEY: Cloud API key

--- a/src/llm/provider/ollama.rs
+++ b/src/llm/provider/ollama.rs
@@ -834,6 +834,13 @@ mod tests {
     }
 
     #[test]
+    fn test_supported_models_includes_ornith() {
+        let provider = OllamaProvider::default_local();
+        let models = provider.supported_models();
+        assert!(models.contains(&"ornith:9b".to_string()));
+    }
+
+    #[test]
     fn test_context_window_default_and_custom() {
         let provider = OllamaProvider::default_local();
         assert_eq!(provider.context_window("llama3.2"), Some(8_192));

--- a/src/llm/provider/ollama.rs
+++ b/src/llm/provider/ollama.rs
@@ -586,6 +586,7 @@ impl Provider for OllamaProvider {
             "gemma3:12b".to_string(),
             "mistral:latest".to_string(),
             "deepseek-r1:14b".to_string(),
+            "ornith:9b".to_string(),
         ]
     }
 

--- a/src/tui/ollama_download.rs
+++ b/src/tui/ollama_download.rs
@@ -24,6 +24,7 @@ pub const CURATED_MODELS: &[&str] = &[
     "llama3.2:3b",
     "mistral:latest",
     "deepseek-r1:14b",
+    "ornith:9b",
 ];
 
 /// One progress update from an in-flight pull, decoupled from the `ollama`

--- a/src/tui/ollama_download.rs
+++ b/src/tui/ollama_download.rs
@@ -195,6 +195,12 @@ mod tests {
     }
 
     #[test]
+    fn filter_suggestions_includes_ornith() {
+        let suggestions = filter_suggestions("ornith", &[]);
+        assert_eq!(suggestions, vec!["ornith:9b".to_string()]);
+    }
+
+    #[test]
     fn pull_progress_fraction() {
         let p = ModelPullProgress {
             status: "pulling abc".to_string(),


### PR DESCRIPTION
Ornith 9B (ornith:9b) was already the fallback default in test-only
env-var lookups and doc comments, but had no reachable configuration:
add it to the TUI's curated pull suggestions, the native Ollama
provider's supported-models hint list, a ready-to-use
[providers.ollama] example in config.toml.example with its documented
sampling defaults (temperature 0.10, top_p 0.90, top_k 20, num_ctx
65536), and matching entries in README's recommended-models tables.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NRyk6USvwUcVadbR8b5tLU