### PR TITLE
Add Gemma 4 26B A4B MoE model support for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ Google's latest generation. Excellent instruction following and reasoning; stron
 | Gemma-3-27B-IT | 20 GB VRAM / 40 GB RAM | 128K | Highest quality in the family |
 | **Gemma 4 26B A4B (MoE)** ⭐ | 12 GB VRAM / 32 GB RAM | 256K | 128 experts, 8 active (~3.8B active params/token); native tool calling, vision, and thinking mode |
 
-> Gemma 4 26B A4B is a Mixture-of-Experts model: 25.8B total parameters but only ~3.8B active per token, giving dense-26B-class quality at a fraction of the compute/VRAM cost. See [`docs/models/gemma-4-26b-a4b/`](docs/models/gemma-4-26b-a4b/) for the full architecture, tool-calling, and Crustly integration reference.
+> Gemma 4 26B A4B is a Mixture-of-Experts model: 25.2B total parameters but only ~3.8B active per token (8 active / 128 total experts + 1 shared), giving dense-26B-class quality at a fraction of the compute/VRAM cost. Apache 2.0 licensed. Also available in `12b`, `31b` (dense), `e2b`/`e4b` (edge-optimized), and `31b-cloud` (Ollama-hosted) variants — see [`ollama.com/library/gemma4:26b`](https://ollama.com/library/gemma4:26b). Full architecture, tool-calling, MoE routing, JSON output, and Crustly integration reference: [`docs/models/gemma-4-26b-a4b/`](docs/models/gemma-4-26b-a4b/).
 
 **LM Studio search term:** `gemma-3-12b-it` (Gemma-3) / check HuggingFace for Gemma 4 26B A4B GGUF quants
 **Ollama:** `ollama pull gemma3:12b` (Gemma-3) / `ollama pull gemma4:26b` (Gemma 4 26B A4B MoE)
@@ -915,7 +915,7 @@ Google's latest generation. Excellent instruction following and reasoning; stron
 **Minimum system requirements:**
 - RAM: **8 GB** (4B model); 20 GB (12B); 40 GB (27B); 32 GB (26B A4B MoE)
 - GPU (optional): Any NVIDIA/AMD with 4 GB+ VRAM for 4B model; RTX 3060 12 GB+ recommended for 26B A4B MoE
-- Storage: ~3 GB (4B Q4), ~7 GB (12B Q4), ~17 GB (27B Q4), ~15 GB (26B A4B MoE Q4)
+- Storage: ~3 GB (4B Q4), ~7 GB (12B Q4), ~17 GB (27B Q4), ~18 GB (26B A4B MoE Q4_K_M, Ollama's default quant)
 
 **Config for LM Studio:**
 ```toml
@@ -930,7 +930,10 @@ default_model = "gemma-3-12b-it"
 [providers.ollama]
 enabled = true
 default_model = "gemma4:26b"
-num_ctx = 65536  # good latency/quality balance; model supports up to 262144
+num_ctx = 65536      # good latency/quality balance; model supports up to 262144
+temperature = 1.0    # Google/Ollama's standardized recommendation
+top_p = 0.95
+top_k = 64
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -898,23 +898,24 @@ default_model = "qwen2.5-coder-7b-instruct"
 
 #### Gemma 4 (Google)
 
-Google's latest generation, released 2025. Excellent instruction following and reasoning; strong on code review and explanation tasks.
+Google's latest generation. Excellent instruction following and reasoning; strong on code review and explanation tasks.
 
 | Version | VRAM / RAM | Context | Notes |
 |---------|-----------|---------|-------|
 | **Gemma-3-4B-IT** ⭐ | 4 GB VRAM / 8 GB RAM | 128K | Runs on almost any machine |
 | Gemma-3-12B-IT | 9 GB VRAM / 20 GB RAM | 128K | Best Gemma balance for coding |
 | Gemma-3-27B-IT | 20 GB VRAM / 40 GB RAM | 128K | Highest quality in the family |
+| **Gemma 4 26B A4B (MoE)** ⭐ | 12 GB VRAM / 32 GB RAM | 256K | 128 experts, 8 active (~3.8B active params/token); native tool calling, vision, and thinking mode |
 
-> Note: At the time of writing, "Gemma 4" GGUF weights are available via community conversions on HuggingFace. LM Studio's discover tab may list them as `gemma-3-*` — these are the same models.
+> Gemma 4 26B A4B is a Mixture-of-Experts model: 25.8B total parameters but only ~3.8B active per token, giving dense-26B-class quality at a fraction of the compute/VRAM cost. See [`docs/models/gemma-4-26b-a4b/`](docs/models/gemma-4-26b-a4b/) for the full architecture, tool-calling, and Crustly integration reference.
 
-**LM Studio search term:** `gemma-3-12b-it`
-**Ollama:** `ollama pull gemma3:12b`
+**LM Studio search term:** `gemma-3-12b-it` (Gemma-3) / check HuggingFace for Gemma 4 26B A4B GGUF quants
+**Ollama:** `ollama pull gemma3:12b` (Gemma-3) / `ollama pull gemma4:26b` (Gemma 4 26B A4B MoE)
 
 **Minimum system requirements:**
-- RAM: **8 GB** (4B model); 20 GB (12B); 40 GB (27B)
-- GPU (optional): Any NVIDIA/AMD with 4 GB+ VRAM for 4B model
-- Storage: ~3 GB (4B Q4), ~7 GB (12B Q4), ~17 GB (27B Q4)
+- RAM: **8 GB** (4B model); 20 GB (12B); 40 GB (27B); 32 GB (26B A4B MoE)
+- GPU (optional): Any NVIDIA/AMD with 4 GB+ VRAM for 4B model; RTX 3060 12 GB+ recommended for 26B A4B MoE
+- Storage: ~3 GB (4B Q4), ~7 GB (12B Q4), ~17 GB (27B Q4), ~15 GB (26B A4B MoE Q4)
 
 **Config for LM Studio:**
 ```toml
@@ -922,6 +923,14 @@ Google's latest generation, released 2025. Excellent instruction following and r
 api_key = "lm-studio"
 base_url = "http://localhost:1234/v1"
 default_model = "gemma-3-12b-it"
+```
+
+**Config for Ollama (Gemma 4 26B A4B MoE):**
+```toml
+[providers.ollama]
+enabled = true
+default_model = "gemma4:26b"
+num_ctx = 65536  # good latency/quality balance; model supports up to 262144
 ```
 
 ---
@@ -1670,6 +1679,7 @@ Crustly: [executes bash tool] ✅ 145 tests passed
 | Qwen2.5-Coder 14B | `ollama pull qwen2.5-coder:14b` | 24 GB | ★★★★★ | ✅ Excellent | Higher quality code generation |
 | Qwen2.5-Coder 32B | `ollama pull qwen2.5-coder:32b` | 48 GB | ★★★★★ | ✅ Excellent | Near-GPT-4 code quality |
 | Llama 3.3 70B | `ollama pull llama3.3:70b` | 64 GB | ★★★★★ | ✅ Full | Complex multi-file tasks |
+| **Gemma 4 26B A4B (MoE)** ⭐ | `ollama pull gemma4:26b` | 32 GB | ★★★★★ | ✅ Excellent | 256K context, repo-wide analysis, agentic workflows |
 
 > ⚠️ **Tool calling is required** for Crustly's plan mode and file operations. All models in the table above support it. **Avoid DeepSeek Coder V2** — a tokenizer bug causes empty tool-call responses in both Ollama and LM Studio.
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -112,20 +112,25 @@ default_model = "qwen2.5-coder-7b-instruct"
 # top_p = 0.90
 # top_k = 20
 #
-# Option C - Gemma 4 26B A4B (MoE, 128 experts/8 active, 256K context, native
-# tool calling + vision + thinking):
+# Option C - Gemma 4 26B A4B (MoE, 8 active / 128 total experts + 1 shared,
+# 25.2B total / 3.8B active params, 256K context, native tool calling, vision,
+# and thinking):
 # ollama pull gemma4:26b
-# Sampling values below are Gemma 4's documented recommendation for software
-# development tasks; see docs/models/gemma-4-26b-a4b/ for the full reference.
+# Sampling values below are Google/Ollama's standardized recommendation
+# (ollama.com/library/gemma4:26b) "across all use cases", including agentic
+# and tool-calling workflows - see docs/models/gemma-4-26b-a4b/ for the full
+# reference. Lower temperature (e.g. 0.1-0.2) is a Crustly-side option if you
+# want stricter determinism for tool calls/JSON output, at the cost of
+# deviating from the vendor's tuned defaults.
 # [providers.ollama]
 # enabled = true
 # host = "http://localhost:11434"
 # default_model = "gemma4:26b"
 # keep_alive = "5m"
 # num_ctx = 65536       # Model supports up to 262144; 65536 balances context vs. memory/latency
-# temperature = 0.10    # 0.1-0.2 recommended; lower for tool calling/JSON output
-# top_p = 0.90
-# top_k = 20
+# temperature = 1.0
+# top_p = 0.95
+# top_k = 64
 #
 # Env var equivalents: OLLAMA_HOST (or OLLAMA_BASE_URL), OLLAMA_MODEL
 #

--- a/config.toml.example
+++ b/config.toml.example
@@ -132,6 +132,13 @@ default_model = "qwen2.5-coder-7b-instruct"
 # top_p = 0.95
 # top_k = 64
 #
+# Other Gemma 4 tags (swap default_model above, same sampling values apply):
+#   gemma4:e2b / gemma4:e4b - edge/effective-parameter models, 128K context,
+#                             lower RAM (~8-16 GB), also support audio input
+#   gemma4:12b              - 128K context, dense, mid-size
+#   gemma4:31b               - 256K context, dense, highest quality, heaviest
+#   gemma4:31b-cloud         - Ollama-hosted, no local GPU/RAM required
+#
 # Env var equivalents: OLLAMA_HOST (or OLLAMA_BASE_URL), OLLAMA_MODEL
 #
 # Model management from the command line (list/pull/delete/show/embed):

--- a/config.toml.example
+++ b/config.toml.example
@@ -112,6 +112,21 @@ default_model = "qwen2.5-coder-7b-instruct"
 # top_p = 0.90
 # top_k = 20
 #
+# Option C - Gemma 4 26B A4B (MoE, 128 experts/8 active, 256K context, native
+# tool calling + vision + thinking):
+# ollama pull gemma4:26b
+# Sampling values below are Gemma 4's documented recommendation for software
+# development tasks; see docs/models/gemma-4-26b-a4b/ for the full reference.
+# [providers.ollama]
+# enabled = true
+# host = "http://localhost:11434"
+# default_model = "gemma4:26b"
+# keep_alive = "5m"
+# num_ctx = 65536       # Model supports up to 262144; 65536 balances context vs. memory/latency
+# temperature = 0.10    # 0.1-0.2 recommended; lower for tool calling/JSON output
+# top_p = 0.90
+# top_k = 20
+#
 # Env var equivalents: OLLAMA_HOST (or OLLAMA_BASE_URL), OLLAMA_MODEL
 #
 # Model management from the command line (list/pull/delete/show/embed):

--- a/docs/models/gemma-4-26b-a4b/01-introduction.md
+++ b/docs/models/gemma-4-26b-a4b/01-introduction.md
@@ -148,7 +148,7 @@ Generated Tokens
 | Élément | Valeur |
 |-|-|
 | Architecture | Transformer Decoder |
-| Paramètres totaux | ~26 milliards |
+| Paramètres totaux | 25.2 milliards |
 | Paramètres actifs | ~3.8 milliards/token |
 | Experts | 128 |
 | Experts actifs | 8 |

--- a/docs/models/gemma-4-26b-a4b/01-introduction.md
+++ b/docs/models/gemma-4-26b-a4b/01-introduction.md
@@ -1,0 +1,532 @@
+# Gemma 4 26B A4B MoE
+# Introduction technique
+
+> Présentation générale, évolution du modèle et concepts fondamentaux.
+
+---
+
+# 1. Présentation
+
+Gemma 4 26B A4B est un modèle de langage open source développé par Google DeepMind.
+
+Il appartient à la famille **Gemma 4**, une génération conçue pour fournir des performances proches des modèles propriétaires tout en restant exploitable localement.
+
+Le modèle est particulièrement adapté aux applications :
+
+- assistants de programmation ;
+- agents autonomes ;
+- analyse documentaire ;
+- raisonnement complexe ;
+- génération de contenu ;
+- applications multimodales.
+
+Dans le contexte de Crustly, Gemma 4 26B est utilisé comme moteur cognitif capable de :
+
+- comprendre un dépôt logiciel complet ;
+- planifier des modifications ;
+- analyser plusieurs fichiers ;
+- générer des patchs ;
+- utiliser des outils externes ;
+- maintenir un contexte long.
+
+---
+
+# 2. Positionnement dans la famille Gemma
+
+Evolution simplifiée :
+
+```
+Gemma 1
+ |
+ +-- Gemma 2
+      |
+      +-- Gemma 3
+           |
+           +-- Gemma 4
+                |
+                +-- Gemma 4 4B
+                |
+                +-- Gemma 4 12B
+                |
+                +-- Gemma 4 26B A4B MoE
+                |
+                +-- Gemma 4 31B
+```
+
+Chaque génération apporte :
+
+| Version | Amélioration principale |
+|-|-|
+| Gemma 1 | Base LLM compacte |
+| Gemma 2 | Raisonnement amélioré |
+| Gemma 3 | Long contexte + vision |
+| Gemma 4 | Agents + MoE + efficacité |
+
+---
+
+# 3. Philosophie de Gemma 4
+
+Les modèles précédents augmentaient principalement la taille :
+
+```
+Plus de paramètres
+        |
+        v
+Plus de capacité
+        |
+        v
+Plus de mémoire nécessaire
+```
+
+Gemma 4 utilise une approche différente :
+
+```
+Plusieurs experts spécialisés
+        |
+        v
+Activation sélective
+        |
+        v
+Moins de calcul
+        |
+        v
+Meilleure efficacité
+```
+
+Le principe :
+
+Le modèle possède beaucoup de paramètres disponibles, mais seuls certains experts travaillent sur chaque token.
+
+---
+
+# 4. Architecture générale
+
+Gemma 4 26B utilise une architecture :
+
+```
+Decoder Only Transformer
+
+Input Tokens
+
+      |
+      v
+
+Embedding Layer
+
+      |
+      v
+
+Transformer Blocks
+
+      |
+      |
+      +----------------+
+      |                |
+      v                v
+
+Attention        Mixture Of Experts
+
+      |                |
+
+      +----------------+
+
+      |
+      v
+
+Output Projection
+
+      |
+      v
+
+Generated Tokens
+```
+
+---
+
+# 5. Spécifications principales
+
+| Élément | Valeur |
+|-|-|
+| Architecture | Transformer Decoder |
+| Paramètres totaux | ~26 milliards |
+| Paramètres actifs | ~3.8 milliards/token |
+| Experts | 128 |
+| Experts actifs | 8 |
+| Expert partagé | Oui |
+| Contexte maximum | 256 000 tokens |
+| Type | Instruction tuned |
+| Multimodal | Oui |
+| Tool Calling | Oui |
+
+---
+
+# 6. Pourquoi 26B n'est pas équivalent à un modèle dense 26B
+
+Un modèle classique :
+
+```
+Chaque token :
+
+26B paramètres utilisés
+
+↓
+
+26B calculés
+```
+
+Gemma MoE :
+
+```
+Chaque token :
+
+26B paramètres disponibles
+
+↓
+
+Sélection de 8 experts
+
+↓
+
+~3.8B paramètres actifs
+```
+
+Conséquences :
+
+- moins de calcul ;
+- meilleure vitesse ;
+- consommation mémoire réduite ;
+- possibilité d'avoir des experts spécialisés.
+
+---
+
+# 7. Gemma 4 comme modèle agentique
+
+Un modèle conversationnel classique :
+
+```
+Question
+ |
+ v
+Réponse
+```
+
+Un modèle agentique :
+
+```
+Objectif utilisateur
+
+        |
+        v
+
+Analyse
+
+        |
+        v
+
+Planification
+
+        |
+        v
+
+Appel outils
+
+        |
+        v
+
+Modification environnement
+
+        |
+        v
+
+Validation
+
+        |
+        v
+
+Réponse finale
+```
+
+Gemma 4 est optimisé pour ce second fonctionnement.
+
+---
+
+# 8. Utilisation avec Crustly
+
+Architecture recommandée :
+
+```
+                 Crustly
+
+                    |
+                    |
+
+             Agent Controller
+
+                    |
+                    |
+
+        +-----------+-----------+
+
+        |                       |
+
+    Gemma 4                 Tools
+
+    LLM                      |
+
+                             |
+
+                Filesystem / Git / Terminal
+```
+
+Le LLM ne modifie pas directement le système.
+
+Crustly orchestre :
+
+1. Analyse
+2. Décision
+3. Action
+4. Validation
+
+---
+
+# 9. Capacités principales
+
+## Compréhension de code
+
+Gemma 4 peut analyser :
+
+- fonctions ;
+- classes ;
+- modules ;
+- architectures ;
+- dépendances ;
+- erreurs.
+
+---
+
+## Génération
+
+Exemples :
+
+- nouvelles fonctions ;
+- API REST ;
+- composants UI ;
+- tests unitaires ;
+- documentation.
+
+---
+
+## Refactoring
+
+Capable de :
+
+- déplacer du code ;
+- simplifier une architecture ;
+- améliorer la lisibilité ;
+- migrer une version.
+
+---
+
+## Debugging
+
+Processus :
+
+```
+Erreur
+
+↓
+
+Analyse logs
+
+↓
+
+Recherche cause
+
+↓
+
+Modification
+
+↓
+
+Validation
+```
+
+---
+
+# 10. Fenêtre de contexte 256k
+
+Le contexte représente la mémoire temporaire du modèle.
+
+Un contexte de 256k permet :
+
+- plusieurs milliers de lignes de code ;
+- documentation complète ;
+- historique Git ;
+- logs ;
+- tests.
+
+Exemple :
+
+```
+Projet Python
+
+src/
+ ├── api/
+ ├── database/
+ ├── models/
+ ├── tests/
+
++
+
+README
+
++
+
+Documentation
+
++
+
+Issue GitHub
+```
+
+peuvent être analysés ensemble.
+
+---
+
+# 11. Limites du contexte
+
+Un grand contexte ne signifie pas automatiquement meilleure réponse.
+
+Risques :
+
+- informations inutiles ;
+- perte d'attention ;
+- augmentation de latence.
+
+Bonne pratique :
+
+```
+Mauvais :
+
+Charger tout le disque
+
+↓
+
+Demander un changement
+
+
+Bon :
+
+Identifier fichiers concernés
+
+↓
+
+Envoyer contexte utile
+
+↓
+
+Modifier
+```
+
+---
+
+# 12. Gemma 4 et raisonnement
+
+Gemma 4 introduit une séparation entre :
+
+- réflexion interne ;
+- réponse utilisateur.
+
+Concept :
+
+```
+Input
+
+ |
+
+Thinking Process
+
+ |
+
+Final Answer
+```
+
+Le raisonnement permet :
+
+- meilleure planification ;
+- moins d'erreurs ;
+- meilleure résolution de problèmes complexes.
+
+---
+
+# 13. Pourquoi Gemma 4 est intéressant en local
+
+Comparaison :
+
+| Modèle | Local | Agent | Code |
+|-|-|-|-|
+| Petit LLM | Excellent | Moyen | Moyen |
+| Dense 70B | Difficile | Excellent | Excellent |
+| Gemma 4 26B MoE | Très bon | Excellent | Excellent |
+
+Gemma 4 représente un compromis :
+
+```
+Performance proche grand modèle
+
++
+
+Coût matériel raisonnable
+```
+
+---
+
+# 14. Cas d'utilisation recommandés
+
+## Excellent
+
+- Développement logiciel
+- Agents autonomes
+- Revue de code
+- Refactoring
+- Analyse de projet
+- Documentation technique
+
+---
+
+## Moins adapté
+
+- Très gros calculs mathématiques spécialisés
+- Génération artistique pure
+- Remplacement complet d'un développeur senior
+
+---
+
+# 15. Conclusion
+
+Gemma 4 26B A4B est un modèle conçu pour la nouvelle génération d'assistants IA :
+
+- plus autonomes ;
+- plus efficaces ;
+- capables d'utiliser des outils ;
+- adaptés aux environnements locaux.
+
+Associé à Ollama et Crustly, il devient un moteur capable de fonctionner comme un véritable assistant d'ingénierie logicielle local.
+
+---
+
+# Chapitre suivant
+
+```
+02-architecture.md
+```
+
+Le prochain chapitre détaille :
+
+- les blocs Transformer ;
+- le routage MoE ;
+- les experts ;
+- l'attention ;
+- la mémoire KV Cache ;
+- l'impact sur la VRAM ;
+- les conséquences pour Ollama.

--- a/docs/models/gemma-4-26b-a4b/02-architecture.md
+++ b/docs/models/gemma-4-26b-a4b/02-architecture.md
@@ -1,0 +1,645 @@
+# Gemma 4 26B A4B MoE
+# Architecture interne
+
+> Analyse technique de l'architecture Transformer, du routage MoE, de l'attention et des implications pour l'inférence locale.
+
+---
+
+# 1. Vue générale de l'architecture
+
+Gemma 4 26B A4B utilise une architecture :
+
+```
+Decoder-only Transformer
++
+Mixture of Experts (MoE)
++
+Long Context Attention
++
+Multimodal Encoder (selon variante)
+```
+
+Le pipeline global :
+
+```
+               Input Text
+
+                    |
+                    v
+
+              Tokenizer
+
+                    |
+                    v
+
+             Token Embeddings
+
+                    |
+                    v
+
+        +-----------------------+
+        | Transformer Layers    |
+        |                       |
+        |  Attention            |
+        |       |               |
+        |       v               |
+        |  MoE Feed Forward     |
+        |       |               |
+        +-----------------------+
+
+                    |
+                    v
+
+             Output Layer
+
+                    |
+                    v
+
+              Next Token
+```
+
+---
+
+# 2. Transformer Decoder Only
+
+Gemma 4 appartient à la famille des modèles auto-régressifs.
+
+Le modèle prédit le prochain token :
+
+```
+Input:
+
+"function calculate"
+
+Probabilités:
+
+{
+ "(": 0.72,
+ "=": 0.12,
+ "(": 0.08,
+ ...
+}
+
+Choix:
+
+"("
+```
+
+Puis il recommence :
+
+```
+function calculate(
+```
+
+devient l'entrée suivante.
+
+---
+
+# 3. Les blocs Transformer
+
+Chaque couche contient généralement :
+
+```
+Input
+
+ |
+
+Layer Normalization
+
+ |
+
+Multi Head Attention
+
+ |
+
+Residual Connection
+
+ |
+
+Layer Normalization
+
+ |
+
+Feed Forward Network
+
+ |
+
+Residual Connection
+
+ |
+
+Output
+```
+
+---
+
+# 4. Attention Mechanism
+
+L'attention permet au modèle de savoir quels tokens sont importants.
+
+Exemple :
+
+```python
+class User:
+    def login(self):
+        return self.password
+```
+
+Quand le modèle analyse :
+
+```
+self.password
+```
+
+l'attention peut relier :
+
+```
+password
+
+↓
+
+User attribute
+
+↓
+
+class User
+```
+
+---
+
+# 5. Multi Head Attention
+
+Au lieu d'une seule attention :
+
+```
+Attention
+```
+
+Gemma utilise plusieurs têtes :
+
+```
+             Attention
+
+       +------+------+------+
+
+       | Head | Head | Head |
+
+       +------+------+------+
+
+              |
+
+          Combined
+
+              |
+
+          Output
+```
+
+Chaque tête apprend des relations différentes :
+
+| Head | Exemple |
+|-|-|
+| 1 | Syntaxe |
+| 2 | Dépendances |
+| 3 | Structure |
+| 4 | Relations longues |
+
+---
+
+# 6. Long Context Attention
+
+Gemma 4 supporte :
+
+```
+256 000 tokens
+```
+
+Cela nécessite des optimisations.
+
+Un contexte classique :
+
+```
+Token1 Token2 Token3 Token4
+```
+
+avec attention complète :
+
+```
+Chaque token regarde tous les autres
+```
+
+Complexité :
+
+```
+O(n²)
+```
+
+Pour 256k tokens cela devient impossible.
+
+---
+
+# 7. Sliding Window Attention
+
+Gemma utilise une combinaison :
+
+```
+Local Attention
+
++
+
+Global Attention
+```
+
+Schéma :
+
+```
+Token actuel
+
+       |
+       |
++------+------+------+
+|      |      |      |
+T-3   T-2    T-1     T
+
+       |
+
+Attention locale
+
+
++
+
+Tokens importants globaux
+```
+
+Avantages :
+
+- moins de calcul ;
+- contexte long ;
+- meilleure efficacité.
+
+---
+
+# 8. Feed Forward Network
+
+Dans un Transformer classique :
+
+```
+Attention
+
+   |
+
+MLP
+
+   |
+
+Output
+```
+
+Le MLP contient énormément de paramètres.
+
+Dans Gemma 4 :
+
+```
+Attention
+
+   |
+
+Router
+
+   |
+
+Experts
+
+   |
+
+Output
+```
+
+Le MLP devient un système MoE.
+
+---
+
+# 9. Architecture Mixture of Experts
+
+Gemma 4 26B possède :
+
+```
+128 experts
+```
+
+Mais tous ne travaillent pas ensemble.
+
+Pour chaque token :
+
+```
+Token
+
+ |
+
+Router
+
+ |
+
+Choix experts
+
+ |
+
+8 experts actifs
+
+ |
+
+Fusion
+
+ |
+
+Output
+```
+
+---
+
+# 10. Le Router
+
+Le router est un petit réseau qui décide :
+
+"Quels experts sont les meilleurs pour ce token ?"
+
+Exemple :
+
+Token :
+
+```
+async function
+```
+
+Le router peut choisir :
+
+```
+Expert 12
+Expert 33
+Expert 48
+Expert 91
+...
+```
+
+Pour un token :
+
+```
+docker-compose.yml
+```
+
+il peut choisir d'autres experts.
+
+---
+
+# 11. Experts spécialisés
+
+Un expert peut apprendre davantage :
+
+- langage naturel ;
+- code ;
+- mathématiques ;
+- raisonnement ;
+- langues ;
+- documentation.
+
+Le modèle développe automatiquement ces spécialisations pendant l'entraînement.
+
+---
+
+# 12. Paramètres actifs
+
+Gemma 4 26B :
+
+Paramètres totaux :
+
+```
+≈ 26 milliards
+```
+
+Mais actifs :
+
+```
+≈ 3.8 milliards/token
+```
+
+Comparaison :
+
+## Modèle dense
+
+```
+Token
+
+ |
+
+26B paramètres
+
+ |
+
+Calcul
+```
+
+## Gemma MoE
+
+```
+Token
+
+ |
+
+Router
+
+ |
+
+3.8B paramètres
+
+ |
+
+Calcul
+```
+
+---
+
+# 13. Impact sur Ollama
+
+Le nombre total de paramètres influence :
+
+- taille du modèle ;
+- stockage ;
+- RAM nécessaire.
+
+Les paramètres actifs influencent :
+
+- vitesse ;
+- tokens/seconde ;
+- coût calcul.
+
+Donc :
+
+Gemma 4 26B peut être plus rapide qu'un dense 26B.
+
+---
+
+# 14. KV Cache
+
+Pendant la génération, Ollama conserve une mémoire appelée :
+
+```
+Key Value Cache
+```
+
+Elle évite de recalculer les tokens précédents.
+
+Sans KV Cache :
+
+```
+Token 1000
+
+recalcule tokens 1-999
+```
+
+Avec :
+
+```
+Token 1000
+
+utilise cache existant
+```
+
+---
+
+# 15. Impact du contexte sur la mémoire
+
+Le KV Cache augmente avec :
+
+- taille contexte ;
+- nombre couches ;
+- taille batch.
+
+Exemple :
+
+```
+num_ctx 8192
+
+↓
+
+faible mémoire
+
+
+num_ctx 131072
+
+↓
+
+beaucoup plus mémoire
+```
+
+---
+
+# 16. Architecture et RTX 3060
+
+Configuration :
+
+```
+RTX 3060 12GB
+
++
+
+34GB RAM
+
++
+
+Ollama
+```
+
+Stratégie :
+
+```
+GPU
+
+↓
+
+Poids principaux
+
+
+RAM
+
+↓
+
+Cache + contexte
+```
+
+---
+
+# 17. Recommandation Crustly
+
+Pour un agent de code :
+
+```
+num_ctx = 65536
+```
+
+est un bon compromis.
+
+Pourquoi :
+
+- assez grand pour un projet ;
+- latence raisonnable ;
+- consommation mémoire maîtrisée.
+
+---
+
+# 18. Résumé architecture
+
+| Élément | Fonction |
+|-|-|
+| Transformer | Compréhension séquentielle |
+| Attention | Relations entre tokens |
+| MoE Router | Sélection experts |
+| Experts | Capacités spécialisées |
+| KV Cache | Mémoire génération |
+| Sliding Attention | Long contexte |
+| Tokenizer | Conversion texte/token |
+
+---
+
+# Conclusion
+
+Gemma 4 26B A4B n'est pas simplement un modèle de 26 milliards de paramètres.
+
+C'est un système hybride :
+
+```
+26B paramètres disponibles
+
+        +
+
+3.8B actifs par token
+
+        +
+
+Architecture MoE
+
+        +
+
+Long Context
+
+        +
+
+Tool Calling
+```
+
+Cette architecture explique pourquoi il peut fournir des performances élevées tout en restant utilisable localement.
+
+---
+
+# Chapitre suivant
+
+```
+03-mixture-of-experts.md
+```
+
+Le prochain chapitre détaillera :
+
+- fonctionnement exact du routage ;
+- experts partagés ;
+- équilibrage des experts ;
+- impact sur les performances ;
+- réglages Ollama pour exploiter correctement le MoE.

--- a/docs/models/gemma-4-26b-a4b/02-architecture.md
+++ b/docs/models/gemma-4-26b-a4b/02-architecture.md
@@ -413,7 +413,7 @@ Gemma 4 26B :
 Paramètres totaux :
 
 ```
-≈ 26 milliards
+≈ 25.2 milliards
 ```
 
 Mais actifs :
@@ -602,7 +602,7 @@ Pourquoi :
 
 # Conclusion
 
-Gemma 4 26B A4B n'est pas simplement un modèle de 26 milliards de paramètres.
+Gemma 4 26B A4B n'est pas simplement un modèle de 25.2 milliards de paramètres.
 
 C'est un système hybride :
 

--- a/docs/models/gemma-4-26b-a4b/03-mixture-of-experts.md
+++ b/docs/models/gemma-4-26b-a4b/03-mixture-of-experts.md
@@ -1,0 +1,651 @@
+# Gemma 4 26B A4B MoE
+# Mixture of Experts (MoE)
+
+> Documentation technique du système Mixture of Experts utilisé par Gemma 4 26B A4B. Ce document explique le routage des experts, l'architecture sparse, l'impact sur l'inférence locale et les implications pour Ollama et Crustly.
+
+---
+
+# 1. Introduction au Mixture of Experts
+
+Le Mixture of Experts (MoE) est une architecture permettant à un modèle d'avoir un très grand nombre de paramètres tout en n'activant qu'une partie de ces paramètres pour chaque token généré.
+
+Un modèle Transformer classique est dense :
+
+```
+Token
+ |
+ v
+Tous les paramètres du modèle
+ |
+ v
+Sortie
+```
+
+Un modèle MoE :
+
+```
+Token
+ |
+ v
+Router
+ |
+ +------------+
+ |            |
+ v            v
+
+Expert A    Expert B
+
+ |            |
+
+ +------------+
+
+       |
+       v
+
+    Sortie
+```
+
+Seuls certains experts participent au calcul.
+
+---
+
+# 2. Pourquoi utiliser un MoE ?
+
+Les modèles denses ont un problème :
+
+Plus de paramètres =
+
+- meilleure connaissance ;
+- meilleur raisonnement ;
+- meilleure compréhension ;
+
+mais aussi :
+
+- plus de VRAM ;
+- plus de calcul ;
+- plus de latence.
+
+Le MoE cherche un compromis :
+
+```
+Grande capacité mémoire
+
++
+
+Petit coût d'inférence
+```
+
+---
+
+# 3. Gemma 4 26B A4B Architecture MoE
+
+Gemma 4 26B utilise :
+
+| Élément | Valeur |
+|-|-|
+| Paramètres totaux | ~26B |
+| Paramètres actifs | ~3.8B/token |
+| Nombre experts | 128 |
+| Experts actifs | 8 |
+| Expert partagé | Oui |
+
+Le modèle possède donc une grande réserve de connaissances mais n'utilise qu'une partie à chaque étape.
+
+---
+
+# 4. Architecture d'un bloc MoE
+
+Un bloc Transformer classique :
+
+```
+Input
+
+ |
+
+Attention
+
+ |
+
+Feed Forward Network
+
+ |
+
+Output
+```
+
+Gemma 4 :
+
+```
+Input
+
+ |
+
+Attention
+
+ |
+
+Router
+
+ |
+
++----------------+
+|                |
+v                v
+
+Expert 1      Expert 2
+
+Expert 3      Expert 4
+
+...
+
+Expert 128
+
++----------------+
+
+ |
+
+Expert Fusion
+
+ |
+
+Output
+```
+
+---
+
+# 5. Le Router
+
+Le router est un petit réseau neuronal spécialisé.
+
+Son rôle :
+
+> « Déterminer quels experts sont les plus pertinents pour chaque token. »
+
+Exemple :
+
+Entrée :
+
+```
+async function authenticate()
+```
+
+Le router peut sélectionner :
+
+```
+Expert 12
+Expert 43
+Expert 67
+Expert 89
+...
+```
+
+Alors qu'un autre token :
+
+```
+docker-compose.yml
+```
+
+peut activer :
+
+```
+Expert 4
+Expert 18
+Expert 55
+Expert 101
+...
+```
+
+---
+
+# 6. Sélection Top-K Experts
+
+Gemma 4 utilise une stratégie :
+
+```
+Top-K Routing
+```
+
+Processus :
+
+```
+Token
+
+ |
+
+Router calcule scores
+
+ |
+
+Classement experts
+
+ |
+
+Sélection meilleurs experts
+
+ |
+
+Calcul parallèle
+
+ |
+
+Fusion
+```
+
+Exemple :
+
+Scores :
+
+```json
+{
+  "expert_1": 0.02,
+  "expert_25": 0.91,
+  "expert_48": 0.84,
+  "expert_90": 0.77
+}
+```
+
+Les experts avec les meilleurs scores sont activés.
+
+---
+
+# 7. Experts spécialisés
+
+Les experts ne sont pas assignés manuellement.
+
+Pendant l'entraînement, ils développent naturellement des spécialisations.
+
+Exemples possibles :
+
+| Expert | Domaine appris |
+|-|-|
+| Expert A | Python |
+| Expert B | JavaScript |
+| Expert C | Raisonnement |
+| Expert D | Documentation |
+| Expert E | Mathématiques |
+| Expert F | Langues |
+
+Le modèle apprend automatiquement cette répartition.
+
+---
+
+# 8. Expert partagé (Shared Expert)
+
+Gemma 4 utilise également un expert partagé.
+
+Architecture :
+
+```
+             Token
+
+               |
+
+             Router
+
+        +------+------+
+
+        |             |
+
+    Selected       Shared
+
+    Experts        Expert
+
+        |             |
+
+        +------+------+
+
+               |
+
+             Output
+```
+
+Avantages :
+
+- meilleure stabilité ;
+- connaissances générales toujours disponibles ;
+- moins de pertes lors du routage.
+
+---
+
+# 9. MoE et génération de code
+
+Pour un assistant comme Crustly :
+
+Question :
+
+```
+Refactor this authentication system
+```
+
+Le modèle peut activer :
+
+```
+Expert sécurité
+
++
+
+Expert architecture
+
++
+
+Expert Python
+
++
+
+Expert tests
+
++
+
+Expert documentation
+```
+
+Ce mécanisme est particulièrement adapté aux tâches complexes.
+
+---
+
+# 10. MoE et raisonnement
+
+Lors d'une tâche difficile :
+
+```
+Analyse bug complexe
+```
+
+Le routeur peut favoriser des experts associés à :
+
+- logique ;
+- planification ;
+- analyse ;
+- résolution de problèmes.
+
+---
+
+# 11. Différence Dense vs MoE
+
+## Modèle Dense
+
+Exemple :
+
+```
+Llama 70B
+```
+
+Chaque token :
+
+```
+70B paramètres actifs
+```
+
+Avantages :
+
+- comportement homogène ;
+- simplicité.
+
+Inconvénients :
+
+- très lourd.
+
+---
+
+## Modèle MoE
+
+Exemple :
+
+```
+Gemma 4 26B A4B
+```
+
+Chaque token :
+
+```
+~3.8B paramètres actifs
+```
+
+Avantages :
+
+- rapide ;
+- efficace ;
+- grande capacité.
+
+---
+
+# 12. Impact sur la VRAM
+
+La mémoire nécessaire dépend de :
+
+- poids du modèle ;
+- quantification ;
+- contexte ;
+- KV Cache.
+
+Exemple :
+
+```
+Modèle complet
+
+26B paramètres
+
+        |
+
+Quantification Q4
+
+        |
+
+GPU + RAM
+```
+
+Le calcul actif est inférieur mais les poids restent nécessaires.
+
+---
+
+# 13. Quantification MoE
+
+La quantification réduit la taille des poids.
+
+Formats courants :
+
+| Format | Qualité | Mémoire |
+|-|-|-|
+| FP16 | Maximum | Très élevée |
+| Q8 | Très haute | Haute |
+| Q6 | Excellente | Moyenne |
+| Q5 | Très bonne | Réduite |
+| Q4 | Bon compromis | Faible |
+
+Pour RTX 3060 :
+
+```
+Q4_K_M
+```
+
+est généralement le meilleur compromis.
+
+---
+
+# 14. Impact sur Ollama
+
+Ollama utilise :
+
+- GGUF ;
+- llama.cpp backend ;
+- offload GPU.
+
+Configuration :
+
+```bash
+ollama run gemma4:26b
+```
+
+Ollama gère automatiquement :
+
+- chargement experts ;
+- allocation mémoire ;
+- GPU layers.
+
+---
+
+# 15. Optimisation Crustly
+
+Pour un agent logiciel :
+
+Recommandation :
+
+```
+Model: gemma4:26b
+Context: 65536
+Temperature: 0.1-0.2
+Top_k: 20
+Top_p: 0.9
+```
+
+---
+
+# 16. Problèmes possibles du MoE
+
+## Routage instable
+
+Symptômes :
+
+- réponses incohérentes ;
+- changement brutal de style.
+
+Solution :
+
+Réduire :
+
+```
+temperature
+```
+
+---
+
+## Experts sous-utilisés
+
+Pendant l'entraînement, certains experts peuvent recevoir trop peu de tokens.
+
+Solution :
+
+Techniques :
+
+- load balancing loss ;
+- expert capacity control.
+
+---
+
+# 17. MoE et agents autonomes
+
+Le MoE est particulièrement adapté aux agents.
+
+Un agent doit alterner :
+
+```
+Comprendre
+
+↓
+
+Planifier
+
+↓
+
+Coder
+
+↓
+
+Tester
+
+↓
+
+Documenter
+```
+
+Chaque étape peut solliciter des capacités différentes.
+
+---
+
+# 18. Architecture recommandée Crustly
+
+```
+              User
+
+               |
+
+             Crustly
+
+               |
+
+        Agent Controller
+
+               |
+
+          Gemma 4 MoE
+
+               |
+
+     +---------+---------+
+
+     |                   |
+
+  Tools              Reasoning
+
+     |
+
+Filesystem / Git / Terminal
+```
+
+---
+
+# 19. Résumé technique
+
+| Concept | Description |
+|-|-|
+| MoE | Plusieurs réseaux spécialisés |
+| Router | Sélection experts |
+| Top-K | Nombre experts actifs |
+| Shared Expert | Connaissance générale |
+| Sparse Activation | Calcul réduit |
+| Active Parameters | Paramètres utilisés |
+| Total Parameters | Capacité totale |
+
+---
+
+# Conclusion
+
+Gemma 4 26B A4B n'est pas un simple modèle de 26 milliards de paramètres.
+
+Son architecture MoE lui permet d'obtenir :
+
+- une grande capacité ;
+- une meilleure efficacité ;
+- une excellente adaptation aux agents ;
+- une consommation adaptée au calcul local.
+
+Pour Crustly, le MoE est particulièrement intéressant car il permet de combiner :
+
+```
+Grande intelligence
+
++
+
+Coût local raisonnable
+
++
+
+Capacité agentique
+```
+
+---
+
+# Chapitre suivant
+
+```
+04-tokenizer.md
+```
+
+Ce chapitre détaillera :
+
+- le tokenizer Gemma 4 ;
+- vocabulaire ;
+- tokens spéciaux ;
+- encodage ChatML ;
+- impact sur le contexte ;
+- optimisation des prompts.

--- a/docs/models/gemma-4-26b-a4b/03-mixture-of-experts.md
+++ b/docs/models/gemma-4-26b-a4b/03-mixture-of-experts.md
@@ -83,7 +83,7 @@ Gemma 4 26B utilise :
 
 | Élément | Valeur |
 |-|-|
-| Paramètres totaux | ~26B |
+| Paramètres totaux | 25.2B |
 | Paramètres actifs | ~3.8B/token |
 | Nombre experts | 128 |
 | Experts actifs | 8 |
@@ -610,7 +610,7 @@ Filesystem / Git / Terminal
 
 # Conclusion
 
-Gemma 4 26B A4B n'est pas un simple modèle de 26 milliards de paramètres.
+Gemma 4 26B A4B n'est pas un simple modèle de 25.2 milliards de paramètres.
 
 Son architecture MoE lui permet d'obtenir :
 

--- a/docs/models/gemma-4-26b-a4b/07-thinking-mode.md
+++ b/docs/models/gemma-4-26b-a4b/07-thinking-mode.md
@@ -1,0 +1,119 @@
+# Gemma 4 26B A4B MoE
+# Thinking Mode
+
+> Documentation technique du mode de raisonnement (thinking) de Gemma 4, basée sur la documentation officielle Ollama ([ollama.com/library/gemma4:26b](https://ollama.com/library/gemma4:26b)).
+
+---
+
+# 1. Introduction
+
+Gemma 4 sépare la réflexion interne du modèle de sa réponse finale, comme introduit conceptuellement dans [`01-introduction.md`](01-introduction.md#12-gemma-4-et-raisonnement).
+
+Ce chapitre documente le mécanisme concret : les tokens de contrôle, le format de sortie, et son comportement en conversation multi-tours.
+
+---
+
+# 2. Activer/désactiver le thinking
+
+Le thinking est contrôlé par un token spécial placé au début du system prompt :
+
+```
+<|think|>
+```
+
+- **Activer** : inclure `<|think|>` au début du system prompt.
+- **Désactiver** : retirer ce token du system prompt.
+
+---
+
+# 3. Format de sortie
+
+## Thinking activé
+
+Quand le thinking est activé, le modèle produit d'abord son raisonnement interne, puis la réponse finale, selon cette structure :
+
+```
+<|channel>thought\n[Internal reasoning]<channel|>
+```
+
+suivi de la réponse finale.
+
+## Thinking désactivé
+
+Pour tous les modèles de la famille **sauf E2B et E4B**, si le thinking est désactivé, le modèle génère toujours les balises, mais avec un bloc de réflexion vide :
+
+```
+<|channel>thought\n<channel|>[Final answer]
+```
+
+> Les variantes E2B/E4B n'émettent pas ces balises quand le thinking est désactivé.
+
+---
+
+# 4. Gestion en conversation multi-tours
+
+Règle importante documentée par Google/Ollama :
+
+> Dans une conversation multi-tours, la sortie historique du modèle ne doit contenir que la réponse finale. Les réflexions ("thoughts") des tours précédents ne doivent jamais être réinjectées avant le tour utilisateur suivant.
+
+Schéma :
+
+```
+Tour 1
+
+  User -> Assistant (thought + answer)
+
+Historique conservé pour Tour 2:
+
+  User -> Assistant (answer only, thought stripped)
+
+Tour 2
+
+  User -> Assistant (new thought + answer)
+```
+
+---
+
+# 5. Ce qu'Ollama gère automatiquement
+
+La documentation officielle précise :
+
+> "Ollama already handles the complexities of the chat template for you."
+
+En pratique, Ollama applique lui-même le chat template natif du modèle (y compris l'insertion/retrait du token `<|think|>` et le parsing des balises `<|channel|>`) à partir du paramètre `think` de l'API native `/api/chat` — l'appelant n'a pas besoin de manipuler ces tokens manuellement.
+
+---
+
+# 6. Correspondance avec l'implémentation Crustly
+
+Le provider Ollama natif de Crustly (`src/llm/provider/ollama.rs`) traite déjà le thinking de façon générique, sans connaissance spécifique de Gemma 4 :
+
+```rust
+let think = request.thinking.as_ref().map(|t| match t.budget_tokens {
+    0..=2_000 => ThinkType::Low,
+    2_001..=8_000 => ThinkType::Medium,
+    _ => ThinkType::High,
+});
+```
+
+Ce `ThinkType` est transmis tel quel à `ollama-rs`, qui l'envoie comme paramètre `think` de l'API native. C'est exactement le mécanisme que la documentation officielle décrit comme géré côté Ollama — **aucune modification de code n'était nécessaire** pour supporter le thinking mode de Gemma 4 : le modèle bénéficie du même chemin générique déjà utilisé pour DeepSeek-R1 et QwQ-32B.
+
+Côté TUI, l'utilisateur peut afficher/masquer le panneau de réflexion avec la touche `t` (voir le comportement documenté dans `CLAUDE.md` sous "Streaming Architecture").
+
+---
+
+# 7. Bonnes pratiques
+
+- Ne jamais réinjecter les blocs `thought` précédents dans l'historique envoyé au modèle.
+- Pour un agent (Crustly), préférer un budget de thinking proportionné à la complexité de la tâche (`budget_tokens` bas pour des actions simples, élevé pour un debugging complexe ou une planification multi-étapes).
+- Le thinking désactivé n'élimine pas la latence des balises vides sur les variantes non-edge (E2B/E4B) — c'est un comportement du modèle, pas un bug d'intégration.
+
+---
+
+# Chapitre suivant
+
+```
+08-tool-calling.md
+```
+
+Déjà rédigé — voir [`08-tool-calling.md`](08-tool-calling.md) pour le Function Calling.

--- a/docs/models/gemma-4-26b-a4b/08-tool-calling.md
+++ b/docs/models/gemma-4-26b-a4b/08-tool-calling.md
@@ -483,6 +483,8 @@ Pour Tool Calling :
 }
 ```
 
+> Note : Google/Ollama documentent une configuration standardisée différente (`temperature=1.0, top_p=0.95, top_k=64`) comme recommandation générale "pour tous les cas d'usage", y compris agentique (voir [`README.md`](README.md#recommended-parameters)). Les valeurs basses ci-dessus sont une recommandation Crustly, pas une valeur officielle du fournisseur, à utiliser si l'on privilégie la déterminisme du tool calling au détriment du comportement par défaut du modèle.
+
 Pourquoi :
 
 - moins d'hallucinations ;

--- a/docs/models/gemma-4-26b-a4b/08-tool-calling.md
+++ b/docs/models/gemma-4-26b-a4b/08-tool-calling.md
@@ -1,0 +1,574 @@
+# Gemma 4 26B A4B MoE
+# Tool Calling
+
+> Documentation technique du système d'appel d'outils (Function Calling) pour intégration avec Ollama, agents IA et Crustly.
+
+---
+
+# 1. Introduction
+
+Le Tool Calling permet au modèle Gemma 4 de demander l'exécution d'actions externes.
+
+Un LLM classique :
+
+```
+Utilisateur
+    |
+    v
+Modèle
+    |
+    v
+Réponse texte
+```
+
+Un agent avec Tool Calling :
+
+```
+Utilisateur
+    |
+    v
+Agent Crustly
+    |
+    v
+Gemma 4
+    |
+    v
+Décision d'utiliser un outil
+    |
+    v
+Exécution outil
+    |
+    v
+Résultat retourné au modèle
+    |
+    v
+Réponse finale
+```
+
+---
+
+# 2. Pourquoi utiliser Tool Calling avec Crustly
+
+Pour un assistant de développement, le modèle ne doit pas seulement générer du texte.
+
+Il doit pouvoir :
+
+- lire un fichier ;
+- rechercher dans un projet ;
+- exécuter des tests ;
+- lancer Git ;
+- analyser des logs ;
+- modifier du code ;
+- appeler une API.
+
+Le modèle décide quoi faire, mais Crustly contrôle comment l'action est exécutée.
+
+---
+
+# 3. Architecture générale
+
+```
+                 Crustly
+
+                    |
+                    |
+
+              Agent Controller
+
+                    |
+                    |
+
+              Gemma 4 LLM
+
+                    |
+        +-----------+-----------+
+        |                       |
+        v                       v
+
+    Texte final             Tool Call
+
+
+                                |
+                                v
+
+                         Tool Executor
+
+                                |
+                                v
+
+                         Résultat outil
+
+                                |
+                                v
+
+                         Retour LLM
+```
+
+---
+
+# 4. Format conceptuel d'un outil
+
+Un outil possède :
+
+- un nom ;
+- une description ;
+- des paramètres ;
+- un résultat.
+
+Exemple :
+
+```json
+{
+  "name": "read_file",
+  "description": "Read content of a source file",
+  "parameters": {
+    "path": {
+      "type": "string",
+      "description": "File path"
+    }
+  }
+}
+```
+
+---
+
+# 5. Déclaration des outils
+
+Exemple OpenAI compatible :
+
+```json
+{
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "read_file",
+        "description": "Read a file from the repository",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+# 6. Exemple complet avec Ollama API
+
+Requête
+
+```
+POST http://localhost:11434/api/chat
+Content-Type: application/json
+```
+
+```json
+{
+  "model": "gemma4:26b",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a senior software engineer."
+    },
+    {
+      "role": "user",
+      "content": "Analyze src/main.py and find possible bugs."
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "read_file",
+        "description": "Read source file",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+# 7. Réponse Tool Call
+
+Le modèle peut répondre :
+
+```json
+{
+  "message": {
+    "role": "assistant",
+    "tool_calls": [
+      {
+        "function": {
+          "name": "read_file",
+          "arguments": {
+            "path": "src/main.py"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+Le modèle ne lit pas réellement le fichier.
+
+Il demande :
+
+```
+Crustly,
+exécute read_file("src/main.py")
+```
+
+---
+
+# 8. Exécution du Tool
+
+Crustly exécute la fonction :
+
+```python
+def read_file(path):
+
+    with open(path, "r") as file:
+        return file.read()
+```
+
+Résultat :
+
+```python
+class Application:
+
+    def start():
+        ...
+```
+
+---
+
+# 9. Retour du résultat au modèle
+
+Le résultat est envoyé avec un message :
+
+```json
+{
+  "role": "tool",
+  "content": "class Application:\n..."
+}
+```
+
+Le modèle continue :
+
+```
+Analyse du fichier
+
+↓
+
+Détection problème
+
+↓
+
+Proposition correction
+```
+
+---
+
+# 10. Outils recommandés pour Crustly
+
+## Filesystem
+
+| Outil | Fonction |
+|-|-|
+| read_file | Lire fichier |
+| write_file | Modifier fichier |
+| list_directory | Explorer projet |
+| search_code | Recherche texte |
+
+---
+
+## Git
+
+| Outil | Fonction |
+|-|-|
+| git_status | Etat dépôt |
+| git_diff | Voir modifications |
+| git_commit | Créer commit |
+
+---
+
+## Terminal
+
+| Outil | Fonction |
+|-|-|
+| execute_command | Exécuter commande |
+| run_tests | Lancer tests |
+| install_package | Installer dépendance |
+
+---
+
+# 11. Exemple workflow développeur
+
+Utilisateur :
+
+```
+Corrige le bug dans l'API utilisateur
+```
+
+Agent :
+
+1. Recherche fichiers API
+
+Tool :
+
+```json
+{
+  "name": "search_code",
+  "arguments": {
+    "query": "UserController"
+  }
+}
+```
+
+---
+
+Agent :
+
+2. Lecture fichier trouvé
+
+Tool :
+
+```json
+{
+  "name": "read_file",
+  "arguments": {
+    "path": "src/controllers/user.py"
+  }
+}
+```
+
+---
+
+Agent :
+
+3. Modification
+
+Tool :
+
+```json
+{
+  "name": "write_file",
+  "arguments": {
+    "path": "src/controllers/user.py",
+    "content": "..."
+  }
+}
+```
+
+---
+
+Agent :
+
+4. Validation
+
+Tool :
+
+```json
+{
+  "name": "run_tests"
+}
+```
+
+---
+
+# 12. Gestion des erreurs
+
+Un outil doit toujours retourner une erreur structurée.
+
+Exemple :
+
+```json
+{
+  "success": false,
+  "error": {
+    "type": "FILE_NOT_FOUND",
+    "message": "src/test.py does not exist"
+  }
+}
+```
+
+Le modèle peut alors corriger sa stratégie.
+
+---
+
+# 13. Bonnes pratiques
+
+## Toujours fournir une description claire
+
+Mauvais :
+
+```
+execute()
+```
+
+Bon :
+
+```
+execute_shell_command:
+Execute a safe shell command inside the project directory.
+```
+
+---
+
+## Limiter les permissions
+
+Ne jamais exposer :
+
+- suppression système ;
+- accès root ;
+- secrets ;
+- clés API.
+
+---
+
+## Ajouter des validations
+
+Avant :
+
+```
+write_file()
+```
+
+Faire :
+
+```
+validate_patch()
+
+↓
+
+apply_change()
+
+↓
+
+run_tests()
+```
+
+---
+
+# 14. Paramètres recommandés Gemma 4
+
+Pour Tool Calling :
+
+```json
+{
+  "temperature": 0.1,
+  "top_p": 0.9,
+  "top_k": 20,
+  "repeat_penalty": 1.05
+}
+```
+
+Pourquoi :
+
+- moins d'hallucinations ;
+- appels plus cohérents ;
+- meilleure stabilité.
+
+---
+
+# 15. Prompt système recommandé
+
+```
+You are an autonomous software engineer.
+
+Rules:
+
+- Always inspect files before modifying.
+- Use tools when information is missing.
+- Never invent file contents.
+- Validate modifications with tests.
+- Explain only after completing actions.
+```
+
+---
+
+# 16. Sécurité Agent
+
+Architecture recommandée :
+
+```
+Gemma 4
+
+   |
+   v
+
+Crustly Permission Layer
+
+   |
+   +-- Allowed tools
+   |
+   +-- Sandbox
+   |
+   +-- Logs
+   |
+   +-- Approval system
+```
+
+Le modèle ne doit jamais avoir un accès direct au système.
+
+---
+
+# 17. Résumé
+
+Le Tool Calling transforme Gemma 4 26B en véritable moteur agentique.
+
+Avec Crustly :
+
+```
+Gemma 4
++
+Ollama
++
+Tool Calling
++
+Sandbox
++
+Git
++
+Filesystem
+
+=
+
+Assistant développeur local autonome
+```
+
+---
+
+# Chapitre suivant
+
+```
+09-json-output.md
+```
+
+Ce chapitre détaillera :
+
+- sorties structurées ;
+- JSON Schema ;
+- validation automatique ;
+- génération de patchs ;
+- intégration avec les agents Crustly.

--- a/docs/models/gemma-4-26b-a4b/09-json-output.md
+++ b/docs/models/gemma-4-26b-a4b/09-json-output.md
@@ -394,6 +394,8 @@ Pour JSON :
 }
 ```
 
+> Note : Google/Ollama documentent une configuration standardisée différente (`temperature=1.0, top_p=0.95, top_k=64`) comme recommandation générale "pour tous les cas d'usage" (voir [`README.md`](README.md#recommended-parameters)). Les valeurs basses ci-dessus sont une recommandation Crustly, pas une valeur officielle du fournisseur, à utiliser si l'on privilégie la conformité stricte du JSON au détriment du comportement par défaut du modèle.
+
 Pourquoi :
 
 - moins de variations ;

--- a/docs/models/gemma-4-26b-a4b/09-json-output.md
+++ b/docs/models/gemma-4-26b-a4b/09-json-output.md
@@ -1,0 +1,580 @@
+# Gemma 4 26B A4B MoE
+# Structured JSON Output
+
+> Documentation technique des sorties JSON structurées avec Gemma 4, Ollama et Crustly. Ce chapitre explique comment forcer le modèle à produire des réponses machine-readable, valider les sorties et construire des agents fiables.
+
+---
+
+# 1. Introduction
+
+Un LLM produit naturellement du texte :
+
+```
+The bug is caused by a missing null check.
+You should update the function.
+```
+
+Ce format est adapté aux humains mais difficile à exploiter par un agent.
+
+Un agent comme Crustly nécessite des sorties structurées :
+
+```json
+{
+  "action": "modify_file",
+  "file": "src/auth.py",
+  "changes": [
+    "Add null validation"
+  ]
+}
+```
+
+Le JSON permet :
+
+- validation automatique ;
+- exécution d'actions ;
+- orchestration d'agents ;
+- communication entre composants.
+
+---
+
+# 2. Architecture JSON avec Crustly
+
+Architecture recommandée :
+
+```
+                 User
+
+                  |
+
+               Crustly
+
+                  |
+
+            Gemma 4 26B
+
+                  |
+
+          Structured JSON
+
+                  |
+
+        JSON Validator
+
+                  |
+
+     +------------+------------+
+
+     |                         |
+
+ Execute Action          Request Fix
+```
+
+Le modèle propose une action.
+
+Crustly décide si elle est valide.
+
+---
+
+# 3. Modes de sortie JSON
+
+Gemma 4 peut être utilisé avec plusieurs niveaux de contrainte.
+
+## Mode libre
+
+Le modèle répond normalement :
+
+```json
+{
+  "content": "Here is the explanation..."
+}
+```
+
+---
+
+## Mode JSON demandé
+
+Le prompt impose :
+
+```
+Return only valid JSON.
+```
+
+Exemple :
+
+```json
+{
+  "bug": "NullPointerException",
+  "solution": "Add validation"
+}
+```
+
+---
+
+## Mode JSON Schema
+
+Le format est imposé :
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string"
+    }
+  }
+}
+```
+
+C'est le mode recommandé pour les agents.
+
+---
+
+# 4. Requête Ollama JSON simple
+
+Endpoint :
+
+```
+POST http://localhost:11434/api/chat
+```
+
+Exemple :
+
+```json
+{
+  "model": "gemma4:26b",
+  "messages": [
+    {
+      "role": "system",
+      "content": "Return only JSON."
+    },
+    {
+      "role": "user",
+      "content": "Analyze this error."
+    }
+  ],
+  "format": "json"
+}
+```
+
+---
+
+# 5. Réponse Ollama
+
+Exemple :
+
+```json
+{
+  "model": "gemma4:26b",
+  "message": {
+    "role": "assistant",
+    "content": {
+      "error": "Missing import",
+      "severity": "medium",
+      "solution": "Add required module"
+    }
+  },
+  "done": true
+}
+```
+
+---
+
+# 6. JSON Schema
+
+Pour un agent de programmation :
+
+```json
+{
+  "type": "object",
+  "required": [
+    "action",
+    "target",
+    "reason"
+  ],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": [
+        "read",
+        "modify",
+        "create",
+        "delete"
+      ]
+    },
+    "target": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    }
+  }
+}
+```
+
+---
+
+# 7. Exemple Agent Crustly
+
+Demande :
+
+```
+Fix authentication bug.
+```
+
+Réponse Gemma :
+
+```json
+{
+  "action": "modify",
+  "target": "src/auth/login.py",
+  "reason": "Missing password validation",
+  "changes": [
+    {
+      "line": 42,
+      "operation": "insert",
+      "code": "validate_password(password)"
+    }
+  ]
+}
+```
+
+---
+
+# 8. Génération de patch JSON
+
+Format recommandé :
+
+```json
+{
+  "patch": {
+    "file": "src/api/user.py",
+    "operations": [
+      {
+        "type": "replace",
+        "start_line": 20,
+        "end_line": 25,
+        "content": "new code"
+      }
+    ]
+  }
+}
+```
+
+Avantages :
+
+- traçable ;
+- réversible ;
+- compatible Git.
+
+---
+
+# 9. Analyse de projet JSON
+
+Exemple :
+
+```json
+{
+  "project": {
+    "language": "Python",
+    "framework": "FastAPI",
+    "files_analyzed": 245
+  },
+  "issues": [
+    {
+      "type": "security",
+      "file": "auth.py",
+      "priority": "high"
+    }
+  ]
+}
+```
+
+---
+
+# 10. Sortie JSON pour Tool Calling
+
+Structure :
+
+```json
+{
+  "tool": "read_file",
+  "arguments": {
+    "path": "src/main.py"
+  }
+}
+```
+
+Crustly transforme :
+
+```json
+{
+  "name": "read_file",
+  "arguments": {
+    "path": "src/main.py"
+  }
+}
+```
+
+en appel réel.
+
+---
+
+# 11. Validation côté application
+
+Toujours valider.
+
+Exemple Python :
+
+```python
+import json
+from jsonschema import validate
+
+data = json.loads(response)
+
+validate(
+    instance=data,
+    schema=my_schema
+)
+```
+
+---
+
+# 12. Gestion des erreurs JSON
+
+Problème :
+
+```
+Here is the JSON:
+
+{
+  "action": "modify"
+}
+```
+
+Le texte avant le JSON casse le parser.
+
+Solution :
+
+Prompt :
+
+```
+Output ONLY JSON.
+No markdown.
+No explanation.
+```
+
+---
+
+# 13. Prompt système recommandé
+
+```
+You are a software engineering agent.
+
+Rules:
+
+- Output only valid JSON.
+- Follow the provided schema.
+- Never add explanations outside JSON.
+- Never invent missing information.
+- Ask for clarification using the "request_info" action.
+```
+
+---
+
+# 14. Paramètres Gemma recommandés
+
+Pour JSON :
+
+```json
+{
+  "temperature": 0.1,
+  "top_p": 0.9,
+  "top_k": 20,
+  "repeat_penalty": 1.05
+}
+```
+
+Pourquoi :
+
+- moins de variations ;
+- moins d'erreurs syntaxiques ;
+- meilleure conformité.
+
+---
+
+# 15. Actions agent recommandées
+
+Schema Crustly :
+
+```json
+{
+  "action": [
+    "inspect_project",
+    "read_file",
+    "search_code",
+    "modify_file",
+    "create_file",
+    "run_test",
+    "commit_change"
+  ]
+}
+```
+
+---
+
+# 16. Exemple workflow complet
+
+Etape 1
+
+Utilisateur :
+
+```
+Improve API security.
+```
+
+Etape 2
+
+Gemma :
+
+```json
+{
+  "action": "inspect_project"
+}
+```
+
+Etape 3
+
+Crustly exécute.
+
+Retour :
+
+```json
+{
+  "files": [
+    "auth.py",
+    "api.py"
+  ]
+}
+```
+
+Etape 4
+
+Gemma :
+
+```json
+{
+  "action": "modify_file",
+  "target": "auth.py"
+}
+```
+
+---
+
+# 17. JSON Streaming
+
+Avec streaming :
+
+```
+{
+"action":
+```
+
+puis :
+
+```
+{
+"action":"modify_file"
+```
+
+puis :
+
+```json
+{
+  "action": "modify_file",
+  "target": "main.py"
+}
+```
+
+Le client doit reconstruire le JSON avant validation.
+
+---
+
+# 18. Bonnes pratiques
+
+Toujours :
+
+- utiliser un schema ;
+- valider côté application ;
+- journaliser les actions ;
+- conserver l'historique ;
+- demander confirmation pour actions dangereuses.
+
+---
+
+Ne jamais :
+
+- exécuter directement un JSON généré ;
+- donner accès root ;
+- accepter une suppression sans validation.
+
+---
+
+# 19. JSON vs Tool Calling
+
+| Besoin | Solution |
+|-|-|
+| Réponse structurée | JSON Output |
+| Action externe | Tool Calling |
+| Agent autonome | Les deux |
+| Patch code | JSON Schema |
+| Terminal | Tool Calling |
+
+---
+
+# 20. Résumé
+
+Les sorties JSON transforment Gemma 4 en composant fiable pour un agent logiciel.
+
+Architecture recommandée :
+
+```
+Gemma 4
+
++
+
+JSON Schema
+
++
+
+Validator
+
++
+
+Tool Executor
+
++
+
+Crustly Controller
+
+=
+
+Agent développeur local sécurisé
+```
+
+---
+
+# Chapitre suivant
+
+```
+10-ollama-api.md
+```
+
+Ce chapitre détaillera :
+
+- API REST Ollama complète ;
+- endpoints ;
+- paramètres ;
+- requêtes curl ;
+- Python SDK ;
+- JavaScript ;
+- gestion streaming.

--- a/docs/models/gemma-4-26b-a4b/20-benchmarks.md
+++ b/docs/models/gemma-4-26b-a4b/20-benchmarks.md
@@ -1,0 +1,86 @@
+# Gemma 4 26B A4B MoE
+# Benchmarks
+
+> Résultats d'évaluation officiels, transcrits depuis [ollama.com/library/gemma4:26b](https://ollama.com/library/gemma4:26b). Les scores sont ceux des versions instruction-tuned.
+
+---
+
+# 1. Famille Gemma 4 comparée
+
+| Model | Total Params | Active Params | Context | Modalities |
+|-|-|-|-|-|
+| Gemma 4 E2B | 2.3B effective (5.1B w/ embeddings) | 2.3B | 128K | Text, Image, Audio |
+| Gemma 4 E4B | 4.5B effective (8B w/ embeddings) | 4.5B | 128K | Text, Image, Audio |
+| Gemma 4 12B | — | — | 128K | Text, Image |
+| **Gemma 4 26B A4B (MoE)** | 25.2B | 3.8B | 256K | Text, Image |
+| Gemma 4 31B (Dense) | 30.7B | 30.7B | 256K | Text, Image |
+
+`E2B`/`E4B` = "effective parameters", optimisés pour déploiement sur appareils edge (laptop/mobile). Detailed per-variant architecture specs (layers, sliding window, vocab, encoder sizes) are in [`02-architecture.md`](02-architecture.md).
+
+---
+
+# 2. Benchmarks généraux
+
+| Benchmark | Gemma 4 31B | Gemma 4 26B A4B | Gemma 4 E4B | Gemma 4 E2B | Gemma 3 27B (no think) |
+|-|-|-|-|-|-|
+| MMLU Pro | 85.2% | 82.6% | 69.4% | 60.0% | 67.6% |
+| AIME 2026 no tools | 89.2% | 88.3% | 42.5% | 37.5% | 20.8% |
+| LiveCodeBench v6 | 80.0% | 77.1% | 52.0% | 44.0% | 29.1% |
+| Codeforces ELO | 2150 | 1718 | 940 | 633 | 110 |
+| GPQA Diamond | 84.3% | 82.3% | 58.6% | 43.4% | 42.4% |
+| Tau2 (average over 3) | 76.9% | 68.2% | 42.2% | 24.5% | 16.2% |
+| HLE no tools | 19.5% | 8.7% | - | - | - |
+| HLE with search | 26.5% | 17.2% | - | - | - |
+| BigBench Extra Hard | 74.4% | 64.8% | 33.1% | 21.9% | 19.3% |
+| MMMLU | 88.4% | 86.3% | 76.6% | 67.4% | 70.7% |
+
+---
+
+# 3. Vision
+
+| Benchmark | Gemma 4 31B | Gemma 4 26B A4B | Gemma 4 E4B | Gemma 4 E2B | Gemma 3 27B (no think) |
+|-|-|-|-|-|-|
+| MMMU Pro | 76.9% | 73.8% | 52.6% | 44.2% | 49.7% |
+| OmniDocBench 1.5 (avg edit distance, lower is better) | 0.131 | 0.149 | 0.181 | 0.290 | 0.365 |
+| MATH-Vision | 85.6% | 82.4% | 59.5% | 52.4% | 46.0% |
+| MedXPertQA MM | 61.3% | 58.1% | 28.7% | 23.5% | - |
+
+---
+
+# 4. Audio
+
+Seules les variantes edge (E2B/E4B) supportent l'audio — voir [`README.md`](README.md#model-summary) et [`02-architecture.md`](02-architecture.md), Gemma 4 26B A4B (MoE) ne supporte que texte + image.
+
+| Benchmark | Gemma 4 E4B | Gemma 4 E2B |
+|-|-|-|
+| CoVoST | 35.54 | 33.47 |
+| FLEURS (lower is better) | 0.08 | 0.09 |
+
+---
+
+# 5. Long Context
+
+| Benchmark | Gemma 4 31B | Gemma 4 26B A4B | Gemma 4 E4B | Gemma 4 E2B | Gemma 3 27B (no think) |
+|-|-|-|-|-|-|
+| MRCR v2 8 needle 128k (average) | 66.4% | 44.1% | 25.4% | 19.1% | 13.5% |
+
+---
+
+# 6. Lecture des résultats pour Crustly
+
+Points clés pour le choix du modèle dans un contexte agentique :
+
+- **Codeforces ELO (1718) et LiveCodeBench v6 (77.1%)** : Gemma 4 26B A4B reste largement au-dessus de Gemma 3 27B sur la génération de code compétitif, malgré ~3.8B paramètres actifs contre un modèle dense équivalent.
+- **Tau2 (68.2%)** : Tau2 mesure des capacités agentiques (utilisation d'outils, suivi d'instructions multi-étapes) — pertinent directement pour l'usage Crustly.
+- **MRCR v2 (44.1% à 128k)** : la dégradation en long contexte existe mais reste très supérieure à Gemma 3 27B (13.5%) — cohérent avec les optimisations d'attention décrites dans [`02-architecture.md`](02-architecture.md#6-long-context-attention).
+- **Écart avec le 31B Dense** : sur presque tous les benchmarks, le 31B Dense dépasse le 26B A4B MoE de quelques points, ce qui est attendu (30.7B paramètres actifs contre 3.8B) — le compromis MoE reste favorable en local du fait du coût de calcul réduit (voir [`03-mixture-of-experts.md`](03-mixture-of-experts.md#11-différence-dense-vs-moe)).
+
+---
+
+# Chapitre suivant
+
+```
+21-troubleshooting.md
+```
+
+Ce chapitre détaillera les problèmes courants (routage MoE instable, sorties JSON invalides, performance dégradée) et leurs solutions.

--- a/docs/models/gemma-4-26b-a4b/README.md
+++ b/docs/models/gemma-4-26b-a4b/README.md
@@ -59,7 +59,7 @@ This documentation targets:
 | 21-troubleshooting.md | Troubleshooting |
 | appendix.md | Reference |
 
-> Only `01-introduction.md` and `02-architecture.md` are written so far. The remaining chapters are planned and will be added incrementally; this table tracks the target structure.
+> Only `01-introduction.md`, `02-architecture.md`, and `08-tool-calling.md` are written so far. The remaining chapters are planned and will be added incrementally; this table tracks the target structure.
 
 ---
 

--- a/docs/models/gemma-4-26b-a4b/README.md
+++ b/docs/models/gemma-4-26b-a4b/README.md
@@ -59,9 +59,11 @@ This documentation targets:
 | 21-troubleshooting.md | Troubleshooting |
 | appendix.md | Reference |
 
-> Only `01-introduction.md`, `02-architecture.md`, `03-mixture-of-experts.md`, `08-tool-calling.md`, and `09-json-output.md` are written so far. The remaining chapters are planned and will be added incrementally; this table tracks the target structure.
+> Only `01-introduction.md`, `02-architecture.md`, `03-mixture-of-experts.md`, `07-thinking-mode.md`, `08-tool-calling.md`, `09-json-output.md`, and `20-benchmarks.md` are written so far. The remaining chapters are planned and will be added incrementally; this table tracks the target structure.
 >
-> `09-json-output.md`'s JSON mode and JSON Schema output are already supported end-to-end by Crustly's native Ollama provider (`response_format` maps to Ollama's `format: "json"` / structured schema — see `src/llm/provider/ollama.rs`'s `to_ollama_format`), so no code changes were needed for that chapter.
+> `09-json-output.md`'s JSON mode and JSON Schema output, and `07-thinking-mode.md`'s thinking-mode control tokens, are already supported end-to-end by Crustly's native Ollama provider (`response_format` → `to_ollama_format`; `thinking.budget_tokens` → `ThinkType` — see `src/llm/provider/ollama.rs`), so no code changes were needed for either chapter.
+>
+> Specs and benchmarks in this documentation set have been cross-checked against the official listing at [ollama.com/library/gemma4:26b](https://ollama.com/library/gemma4:26b) as of 2026-07-13.
 
 ---
 
@@ -69,23 +71,30 @@ This documentation targets:
 
 | Property | Value |
 |------------|----------------|
-| Name | Gemma 4 26B |
+| Name | Gemma 4 26B A4B |
 | Family | Gemma 4 |
 | Architecture | Decoder Transformer |
 | Type | Mixture of Experts |
-| Parameters | 25.8B |
-| Active Parameters | ~3.8B/token |
-| Experts | 128 |
+| Total Parameters | 25.2B |
+| Active Parameters | 3.8B/token |
+| Layers | 30 |
+| Experts | 128 total, 1 shared |
 | Active Experts | 8 |
 | Shared Expert | Yes |
-| Context Window | 256k |
-| Vocabulary | 262k |
+| Context Window | 256K |
+| Sliding Window | 1024 tokens |
+| Vocabulary | 262K |
+| Vision Encoder Params | ~550M |
 | Attention | Sliding Window + Global |
-| Quantization | GGUF |
-| Ollama | Supported |
+| Quantization | GGUF (Ollama default: Q4_K_M, ~18 GB) |
+| License | Apache License 2.0 |
+| Ollama | Supported (`gemma4:26b`) |
 | Tool Calling | Supported |
 | Vision | Supported |
+| Audio | Not supported (26B MoE variant; E2B/E4B support audio) |
 | Thinking | Supported |
+
+> Source: [ollama.com/library/gemma4:26b](https://ollama.com/library/gemma4:26b). Sibling variants in the same family: `gemma4:e2b`, `gemma4:e4b` (edge/effective-parameter models), `gemma4:12b` (dense), `gemma4:31b` (dense), `gemma4:31b-cloud` (Ollama-hosted).
 
 ---
 
@@ -253,15 +262,16 @@ Minimal request
 
 # Recommended Parameters
 
+Google/Ollama's standardized sampling configuration, documented as recommended "across all use cases" (including agentic/tool-calling workflows):
+
 | Parameter | Value |
 |------------|----------|
-| temperature | 0.2 |
-| top_p | 0.9 |
-| top_k | 20 |
-| repeat_penalty | 1.05 |
+| temperature | 1.0 |
+| top_p | 0.95 |
+| top_k | 64 |
 | num_ctx | 65536 |
 
-These values provide deterministic answers suitable for software development.
+> For stricter determinism in tool calling or JSON output specifically, Crustly's [`08-tool-calling.md`](08-tool-calling.md) and [`09-json-output.md`](09-json-output.md) chapters suggest a lower temperature (~0.1) as an optional override — this is a Crustly-side recommendation, not a documented Google/Ollama value, and trades some of the model's tuned behavior for more predictable structured output.
 
 ---
 

--- a/docs/models/gemma-4-26b-a4b/README.md
+++ b/docs/models/gemma-4-26b-a4b/README.md
@@ -75,7 +75,7 @@ This documentation targets:
 | Family | Gemma 4 |
 | Architecture | Decoder Transformer |
 | Type | Mixture of Experts |
-| Total Parameters | 25.2B |
+| Total Parameters | 25.2B (spec table) / 25.8B (model blob metadata)* |
 | Active Parameters | 3.8B/token |
 | Layers | 30 |
 | Experts | 128 total, 1 shared |
@@ -95,6 +95,8 @@ This documentation targets:
 | Thinking | Supported |
 
 > Source: [ollama.com/library/gemma4:26b](https://ollama.com/library/gemma4:26b). Sibling variants in the same family: `gemma4:e2b`, `gemma4:e4b` (edge/effective-parameter models), `gemma4:12b` (dense), `gemma4:31b` (dense), `gemma4:31b-cloud` (Ollama-hosted).
+>
+> \* The page lists two different total-parameter figures for the same `gemma4:26b` tag: the architecture "Model information" table says **25.2B**, while the pulled model blob's own metadata panel (next to the `Q4_K_M` quant and digest `5571076f3d70`) says **25.8B**. Both come from the official listing — the ~0.6B delta likely reflects whether embedding/lm_head weights are counted in the blob inspector's tally. Active parameters (3.8B/token) match in both places, which is what actually drives inference cost.
 
 ---
 

--- a/docs/models/gemma-4-26b-a4b/README.md
+++ b/docs/models/gemma-4-26b-a4b/README.md
@@ -59,7 +59,9 @@ This documentation targets:
 | 21-troubleshooting.md | Troubleshooting |
 | appendix.md | Reference |
 
-> Only `01-introduction.md`, `02-architecture.md`, and `08-tool-calling.md` are written so far. The remaining chapters are planned and will be added incrementally; this table tracks the target structure.
+> Only `01-introduction.md`, `02-architecture.md`, `03-mixture-of-experts.md`, `08-tool-calling.md`, and `09-json-output.md` are written so far. The remaining chapters are planned and will be added incrementally; this table tracks the target structure.
+>
+> `09-json-output.md`'s JSON mode and JSON Schema output are already supported end-to-end by Crustly's native Ollama provider (`response_format` maps to Ollama's `format: "json"` / structured schema — see `src/llm/provider/ollama.rs`'s `to_ollama_format`), so no code changes were needed for that chapter.
 
 ---
 

--- a/docs/models/gemma-4-26b-a4b/README.md
+++ b/docs/models/gemma-4-26b-a4b/README.md
@@ -1,0 +1,302 @@
+# Gemma 4 26B A4B MoE
+
+> Complete technical documentation for integrating Gemma 4 26B A4B with Ollama and Crustly.
+
+---
+
+# Overview
+
+This documentation provides a complete developer reference for using **Gemma 4 26B A4B MoE** locally through **Ollama**.
+
+The goal is to provide enough technical information to build an AI coding agent capable of:
+
+- Repository analysis
+- Code generation
+- Refactoring
+- Bug fixing
+- Tool Calling
+- Long context reasoning
+- Multi-step planning
+- Agentic software engineering
+
+This documentation targets:
+
+- Crustly
+- Ollama
+- OpenAI Compatible APIs
+- Continue
+- Roo Code
+- OpenHands
+- Aider
+- Custom AI Agents
+
+---
+
+# Documentation Structure
+
+| File | Description |
+|---------|------------|
+| 01-introduction.md | General presentation |
+| 02-architecture.md | Internal architecture |
+| 03-mixture-of-experts.md | Complete MoE explanation |
+| 04-tokenizer.md | Tokenization |
+| 05-chat-template.md | Conversation format |
+| 06-system-prompts.md | System prompts |
+| 07-thinking-mode.md | Reasoning mode |
+| 08-tool-calling.md | Function Calling |
+| 09-json-output.md | Structured outputs |
+| 10-ollama-api.md | Ollama REST API |
+| 11-openai-compatible-api.md | OpenAI compatibility |
+| 12-streaming.md | Streaming protocol |
+| 13-sampling.md | Sampling parameters |
+| 14-context-management.md | Context engineering |
+| 15-performance.md | Performance tuning |
+| 16-vram-guide.md | GPU sizing |
+| 17-modelfile.md | Ollama Modelfiles |
+| 18-crustly-integration.md | Crustly integration |
+| 19-best-practices.md | Coding workflows |
+| 20-benchmarks.md | Evaluation |
+| 21-troubleshooting.md | Troubleshooting |
+| appendix.md | Reference |
+
+> Only `01-introduction.md` and `02-architecture.md` are written so far. The remaining chapters are planned and will be added incrementally; this table tracks the target structure.
+
+---
+
+# Model Summary
+
+| Property | Value |
+|------------|----------------|
+| Name | Gemma 4 26B |
+| Family | Gemma 4 |
+| Architecture | Decoder Transformer |
+| Type | Mixture of Experts |
+| Parameters | 25.8B |
+| Active Parameters | ~3.8B/token |
+| Experts | 128 |
+| Active Experts | 8 |
+| Shared Expert | Yes |
+| Context Window | 256k |
+| Vocabulary | 262k |
+| Attention | Sliding Window + Global |
+| Quantization | GGUF |
+| Ollama | Supported |
+| Tool Calling | Supported |
+| Vision | Supported |
+| Thinking | Supported |
+
+---
+
+# Supported Tasks
+
+## Programming
+
+- Python
+- JavaScript
+- TypeScript
+- Rust
+- Go
+- C#
+- Java
+- Kotlin
+- PHP
+- SQL
+- Bash
+
+---
+
+## DevOps
+
+- Docker
+- Kubernetes
+- Terraform
+- GitHub Actions
+- CI/CD
+
+---
+
+## Infrastructure
+
+- Linux
+- Nginx
+- Apache
+- HAProxy
+- SSH
+- Networking
+
+---
+
+## Data
+
+- PostgreSQL
+- MySQL
+- SQLite
+- MongoDB
+- Redis
+
+---
+
+## Documentation
+
+- Markdown
+- Mermaid
+- OpenAPI
+- JSON Schema
+- UML
+
+---
+
+# Why Gemma 4?
+
+Gemma 4 introduces several major improvements over previous generations.
+
+Compared to Gemma 3:
+
+- Better reasoning
+- Better instruction following
+- Better coding
+- Better long-context understanding
+- Better multilingual capabilities
+- Native Tool Calling
+- Native Vision
+- Better efficiency through Mixture of Experts
+
+---
+
+# Why MoE?
+
+Instead of activating all parameters for every generated token, Gemma activates only a subset of experts.
+
+Advantages:
+
+- lower latency
+- lower VRAM usage
+- higher quality
+- specialized experts
+
+This makes Gemma particularly suitable for local inference.
+
+---
+
+# Recommended Hardware
+
+## Minimum
+
+- GPU: RTX 3060 12 GB
+- RAM: 32 GB
+- CPU: 8 Threads
+
+## Recommended
+
+- GPU: RTX 4070
+- RAM: 64 GB
+- CPU: Ryzen 9 / Intel i9
+
+## Professional
+
+- GPU: RTX 4090
+- RAM: 128 GB
+
+---
+
+# Ollama Installation
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+Pull Gemma
+
+```bash
+ollama pull gemma4:26b
+```
+
+Run
+
+```bash
+ollama run gemma4:26b
+```
+
+List installed models
+
+```bash
+ollama list
+```
+
+---
+
+# Basic API
+
+Endpoint
+
+```
+POST http://localhost:11434/api/chat
+```
+
+Minimal request
+
+```json
+{
+  "model": "gemma4:26b",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello"
+    }
+  ]
+}
+```
+
+---
+
+# Recommended Parameters
+
+| Parameter | Value |
+|------------|----------|
+| temperature | 0.2 |
+| top_p | 0.9 |
+| top_k | 20 |
+| repeat_penalty | 1.05 |
+| num_ctx | 65536 |
+
+These values provide deterministic answers suitable for software development.
+
+---
+
+# Crustly Recommendations
+
+Gemma 4 works particularly well for:
+
+- Repository indexing
+- Multi-file refactoring
+- Test generation
+- Bug fixing
+- Architecture discussions
+- Pull Request reviews
+- Documentation generation
+
+---
+
+# Version Compatibility
+
+| Component | Version |
+|------------|----------|
+| Ollama | Latest stable |
+| GGUF | Supported |
+| OpenAI API | Compatible |
+| Tool Calling | Yes |
+| Streaming | Yes |
+| Vision | Yes |
+| Thinking | Yes |
+
+---
+
+# Next Chapter
+
+Continue with:
+
+```
+01-introduction.md
+```
+
+This chapter introduces Gemma 4 architecture and explains how Google designed the model before diving into implementation details.

--- a/src/llm/provider/model_hints.rs
+++ b/src/llm/provider/model_hints.rs
@@ -22,6 +22,7 @@ pub fn is_vision_model(model_name: &str) -> bool {
         "phi-3-vision",
         "phi3-vision",
         "idefics",
+        "gemma4",
     ];
     VISION_PATTERNS.iter().any(|p| model_lc.contains(p))
 }
@@ -35,6 +36,7 @@ mod tests {
         assert!(is_vision_model("llava:13b"));
         assert!(is_vision_model("llama3.2-vision:11b-instruct-fp16"));
         assert!(is_vision_model("MiniCPM-V-2.6"));
+        assert!(is_vision_model("gemma4:26b"));
     }
 
     #[test]

--- a/src/llm/provider/ollama.rs
+++ b/src/llm/provider/ollama.rs
@@ -584,6 +584,7 @@ impl Provider for OllamaProvider {
             "llama3.1:8b".to_string(),
             "qwen2.5-coder:7b".to_string(),
             "gemma3:12b".to_string(),
+            "gemma4:26b".to_string(),
             "mistral:latest".to_string(),
             "deepseek-r1:14b".to_string(),
         ]
@@ -830,6 +831,14 @@ mod tests {
     fn test_validate_model_always_true() {
         let provider = OllamaProvider::default_local();
         assert!(provider.validate_model("anything-the-user-pulled:latest"));
+    }
+
+    #[test]
+    fn test_supported_models_includes_gemma4() {
+        let provider = OllamaProvider::default_local();
+        assert!(provider
+            .supported_models()
+            .contains(&"gemma4:26b".to_string()));
     }
 
     #[test]

--- a/src/tui/ollama_download.rs
+++ b/src/tui/ollama_download.rs
@@ -20,6 +20,7 @@ use tokio::task::JoinHandle;
 pub const CURATED_MODELS: &[&str] = &[
     "qwen2.5-coder:7b",
     "gemma3:12b",
+    "gemma4:26b",
     "llama3.1:8b",
     "llama3.2:3b",
     "mistral:latest",


### PR DESCRIPTION
Registers gemma4:26b as a curated Ollama model (provider hint list and
TUI download picker), detects it as vision-capable, and documents its
MoE architecture, hardware requirements, and Crustly/Ollama config in
docs/models/gemma-4-26b-a4b/ and the README's model tables.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017FGg9sMJVHoJc81jHwJhDS