### PR TITLE
Break up the longest functions in render.rs, cli/mod.rs, and markdown.rs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1543,4 +1543,65 @@ mod tests {
             other => panic!("expected Ollama Pull command, got {other:?}"),
         }
     }
+
+    #[test]
+    fn build_tool_registry_registers_every_built_in_tool() {
+        let registry = build_tool_registry();
+
+        // One entry per Phase 1-4 tool registered in build_tool_registry.
+        assert_eq!(registry.count(), 21);
+        for name in [
+            "read_file",
+            "write_file",
+            "edit_file",
+            "bash",
+            "ls",
+            "glob",
+            "grep",
+            "web_search",
+            "execute_code",
+            "notebook_edit",
+            "parse_document",
+            "task_manager",
+            "session_context",
+            "http_request",
+            "plan",
+            "web_fetch",
+            "todo_write",
+            "ask_user",
+            "skill",
+            "agent",
+            "powershell",
+        ] {
+            assert!(registry.has_tool(name), "missing tool: {name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_configured_mcp_servers_returns_empty_status_with_no_servers() {
+        let config = crate::config::Config::default();
+        let mut registry = build_tool_registry();
+
+        let status = connect_configured_mcp_servers(&mut registry, &config).await;
+
+        assert!(status.is_empty());
+    }
+
+    #[tokio::test]
+    async fn connect_configured_mcp_servers_records_failure_for_unreachable_server() {
+        let mut config = crate::config::Config::default();
+        config.mcp.servers.push(crate::config::McpServerConfig {
+            name: "broken".to_string(),
+            command: "definitely-not-a-real-binary".to_string(),
+            args: vec![],
+        });
+        let mut registry = build_tool_registry();
+
+        let status = connect_configured_mcp_servers(&mut registry, &config).await;
+
+        assert_eq!(status.len(), 1);
+        assert_eq!(status[0].name, "broken");
+        assert!(!status[0].connected);
+        assert!(status[0].error.is_some());
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -590,44 +590,20 @@ async fn cmd_db(config: &crate::config::Config, operation: DbCommands) -> Result
     }
 }
 
-/// Start interactive chat session
-async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -> Result<()> {
-    use crate::{
-        db::Database,
-        llm::{
-            agent::AgentService,
-            tools::{
-                agent::AgentTool, ask_user::AskUserTool, bash::BashTool, code_exec::CodeExecTool,
-                context::ContextTool, doc_parser::DocParserTool, edit::EditTool, glob::GlobTool,
-                grep::GrepTool, http::HttpClientTool, ls::LsTool, notebook::NotebookEditTool,
-                plan_tool::PlanTool, powershell::PowerShellTool, read::ReadTool,
-                registry::ToolRegistry, skill::SkillTool, task::TaskTool,
-                todo_write::TodoWriteTool, web_fetch::WebFetchTool, web_search::WebSearchTool,
-                write::WriteTool,
-            },
-        },
-        services::ServiceContext,
-        tui,
+/// Build the tool registry with the full set of built-in tools available to
+/// the interactive chat agent (MCP servers are registered separately, since
+/// that requires network I/O and per-server config - see
+/// `connect_configured_mcp_servers`).
+fn build_tool_registry() -> crate::llm::tools::registry::ToolRegistry {
+    use crate::llm::tools::{
+        agent::AgentTool, ask_user::AskUserTool, bash::BashTool, code_exec::CodeExecTool,
+        context::ContextTool, doc_parser::DocParserTool, edit::EditTool, glob::GlobTool,
+        grep::GrepTool, http::HttpClientTool, ls::LsTool, notebook::NotebookEditTool,
+        plan_tool::PlanTool, powershell::PowerShellTool, read::ReadTool, registry::ToolRegistry,
+        skill::SkillTool, task::TaskTool, todo_write::TodoWriteTool, web_fetch::WebFetchTool,
+        web_search::WebSearchTool, write::WriteTool,
     };
 
-    println!("🦀 Starting Crustly AI Assistant...\n");
-
-    // Initialize database
-    tracing::info!("Connecting to database: {}", config.database.path.display());
-    let db = Database::connect(&config.database.path)
-        .await
-        .context("Failed to connect to database")?;
-
-    // Run migrations
-    db.run_migrations()
-        .await
-        .context("Failed to run database migrations")?;
-
-    // Select provider based on configuration using factory
-    let provider = crate::llm::provider::create_provider(config)?;
-
-    // Create tool registry
-    tracing::debug!("Setting up tool registry");
     let mut tool_registry = ToolRegistry::new();
     // Phase 1: Essential file operations
     tool_registry.register(Arc::new(ReadTool));
@@ -655,12 +631,19 @@ async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -
     tool_registry.register(Arc::new(AgentTool));
     tool_registry.register(Arc::new(PowerShellTool));
 
-    // Connect to configured MCP servers (`[[mcp.servers]]`) and register
-    // their tools. Fixes a real gap: config.mcp.servers was previously
-    // parsed but never consumed anywhere, so configured servers had zero
-    // runtime effect. Failures are caught per-server (recorded in the
-    // status snapshot for the TUI's `/mcp` view) rather than aborting
-    // startup - one broken MCP server shouldn't block the whole TUI.
+    tool_registry
+}
+
+/// Connect to every configured MCP server (`[[mcp.servers]]`) and register
+/// their tools. Fixes a real gap: config.mcp.servers was previously parsed
+/// but never consumed anywhere, so configured servers had zero runtime
+/// effect. Failures are caught per-server (recorded in the status snapshot
+/// for the TUI's `/mcp` view) rather than aborting startup - one broken MCP
+/// server shouldn't block the whole TUI.
+async fn connect_configured_mcp_servers(
+    tool_registry: &mut crate::llm::tools::registry::ToolRegistry,
+    config: &crate::config::Config,
+) -> Vec<crate::mcp::McpServerStatus> {
     let mut mcp_status = Vec::new();
     for server in &config.mcp.servers {
         let args: Vec<&str> = server.args.iter().map(String::as_str).collect();
@@ -694,49 +677,24 @@ async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -
             }
         }
     }
+    mcp_status
+}
 
-    // Create service context
-    let service_context = ServiceContext::new(db.pool().clone());
-
-    // Get working directory
-    let working_directory = std::env::current_dir().unwrap_or_default();
-
-    // Create agent service with system prompt and working directory
-    let agent_service = Arc::new(
-        AgentService::new(provider.clone(), service_context.clone())
-            .with_system_prompt(SYSTEM_PROMPT.to_string())
-            .with_max_tool_iterations(20)
-            .with_working_directory(working_directory.clone()),
-    );
-
-    // Create TUI app first (so we can get the event sender)
-    tracing::debug!("Creating TUI app");
-    let mut app = tui::App::new(agent_service, service_context.clone());
-    app.set_ollama_host(ollama_host(config));
-    app.set_mcp_status(mcp_status);
-
-    // Get event sender from app
-    let event_sender = app.event_sender();
-
-    // Shared Auto Mode level (Interactive/AutoPlan/FullAuto), seeded from
-    // config and toggled at runtime by the TUI's Shift+Tab handler
-    // (App::cycle_auto_mode). Cloned into the approval callback below so
-    // toggling it in the TUI takes effect on the very next tool call.
-    let auto_mode = Arc::new(std::sync::Mutex::new(config.plan_mode.mode.clone()));
-    app.set_auto_mode_state(auto_mode.clone());
-
-    // Create approval callback that sends requests to TUI - unless Auto
-    // Mode is active, in which case low-risk tools are approved without
-    // prompting (see PlanExecMode doc comments for exactly what each level
-    // means). High-risk tools (bash/write_file/edit_file/code_exec) still
-    // prompt under AutoPlan; only FullAuto skips the prompt for those too.
-    // This does NOT touch AgentService::auto_approve_tools or the
-    // SecurityConfig policy chain in ToolRegistry::execute - both remain
-    // fully enforced regardless of Auto Mode, so deny-listed tools/paths/
-    // bash patterns stay blocked no matter what, and every auto-approved
-    // call still produces the same "User approved tool" log line as a
-    // manually-approved one (logged downstream in AgentService, not here).
-    let approval_callback: crate::llm::agent::ApprovalCallback = Arc::new(move |tool_info| {
+/// Build the tool-approval callback the agent invokes before executing a
+/// tool. Auto Mode (see `PlanExecMode` doc comments) lets low-risk tools
+/// through without prompting; everything else round-trips through the TUI
+/// event channel and blocks on the user's response. This does NOT touch
+/// `AgentService::auto_approve_tools` or the `SecurityConfig` policy chain in
+/// `ToolRegistry::execute` - both remain fully enforced regardless of Auto
+/// Mode, so deny-listed tools/paths/bash patterns stay blocked no matter
+/// what, and every auto-approved call still produces the same "User approved
+/// tool" log line as a manually-approved one (logged downstream in
+/// `AgentService`, not here).
+fn build_approval_callback(
+    event_sender: tokio::sync::mpsc::UnboundedSender<crate::tui::events::TuiEvent>,
+    auto_mode: Arc<std::sync::Mutex<crate::config::PlanExecMode>>,
+) -> crate::llm::agent::ApprovalCallback {
+    Arc::new(move |tool_info| {
         let sender = event_sender.clone();
         let auto_mode = auto_mode.clone();
         Box::pin(async move {
@@ -786,7 +744,67 @@ async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -
 
             Ok(response.approved)
         })
-    });
+    })
+}
+
+/// Start interactive chat session
+async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -> Result<()> {
+    use crate::{db::Database, llm::agent::AgentService, services::ServiceContext, tui};
+
+    println!("🦀 Starting Crustly AI Assistant...\n");
+
+    // Initialize database
+    tracing::info!("Connecting to database: {}", config.database.path.display());
+    let db = Database::connect(&config.database.path)
+        .await
+        .context("Failed to connect to database")?;
+
+    // Run migrations
+    db.run_migrations()
+        .await
+        .context("Failed to run database migrations")?;
+
+    // Select provider based on configuration using factory
+    let provider = crate::llm::provider::create_provider(config)?;
+
+    // Create tool registry
+    tracing::debug!("Setting up tool registry");
+    let mut tool_registry = build_tool_registry();
+    let mcp_status = connect_configured_mcp_servers(&mut tool_registry, config).await;
+
+    // Create service context
+    let service_context = ServiceContext::new(db.pool().clone());
+
+    // Get working directory
+    let working_directory = std::env::current_dir().unwrap_or_default();
+
+    // Create agent service with system prompt and working directory
+    let agent_service = Arc::new(
+        AgentService::new(provider.clone(), service_context.clone())
+            .with_system_prompt(SYSTEM_PROMPT.to_string())
+            .with_max_tool_iterations(20)
+            .with_working_directory(working_directory.clone()),
+    );
+
+    // Create TUI app first (so we can get the event sender)
+    tracing::debug!("Creating TUI app");
+    let mut app = tui::App::new(agent_service, service_context.clone());
+    app.set_ollama_host(ollama_host(config));
+    app.set_mcp_status(mcp_status);
+
+    // Get event sender from app
+    let event_sender = app.event_sender();
+
+    // Shared Auto Mode level (Interactive/AutoPlan/FullAuto), seeded from
+    // config and toggled at runtime by the TUI's Shift+Tab handler
+    // (App::cycle_auto_mode). Cloned into the approval callback below so
+    // toggling it in the TUI takes effect on the very next tool call.
+    let auto_mode = Arc::new(std::sync::Mutex::new(config.plan_mode.mode.clone()));
+    app.set_auto_mode_state(auto_mode.clone());
+
+    // Create approval callback that sends requests to TUI - unless Auto Mode
+    // bypasses it (see `build_approval_callback` doc comment).
+    let approval_callback = build_approval_callback(event_sender, auto_mode);
 
     // Install the [security] policy chain (deny_tools/deny_paths/allow_bash).
     // Without this the whole section is inert: nothing is denied, and nothing

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -22,194 +22,213 @@ pub fn parse_plain_text(text: &str) -> Vec<Line<'static>> {
         .collect()
 }
 
-/// Parse markdown and convert to styled lines for Ratatui
-pub fn parse_markdown(markdown: &str) -> Vec<Line<'static>> {
-    let parser = Parser::new(markdown);
-    let mut lines = Vec::new();
-    let mut current_line = Vec::new();
-    let mut in_code_block = false;
-    let mut code_language = String::new();
-    let mut code_content = String::new();
-    let mut list_level: u32 = 0;
-    let mut heading_level = 1;
+/// One-pass converter from `pulldown_cmark` events to styled Ratatui lines.
+/// The fields are the accumulator state a single pass of the parser needs to
+/// carry between events (the in-progress line, whether we're inside a code
+/// block, the current heading/list nesting, etc.) - kept together as a
+/// struct rather than threaded through free functions as separate `&mut`
+/// parameters.
+struct MarkdownRenderer {
+    lines: Vec<Line<'static>>,
+    current_line: Vec<Span<'static>>,
+    in_code_block: bool,
+    code_language: String,
+    code_content: String,
+    list_level: u32,
+    heading_level: u32,
+}
 
-    for event in parser {
-        match event {
-            Event::Start(tag) => match tag {
-                Tag::Heading(level, ..) => {
-                    heading_level = level as u32;
-                }
-                Tag::CodeBlock(kind) => {
-                    in_code_block = true;
-                    code_language = match kind {
-                        CodeBlockKind::Fenced(lang) => lang.to_string(),
-                        CodeBlockKind::Indented => String::new(),
-                    };
+impl MarkdownRenderer {
+    fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            current_line: Vec::new(),
+            in_code_block: false,
+            code_language: String::new(),
+            code_content: String::new(),
+            list_level: 0,
+            heading_level: 1,
+        }
+    }
 
-                    // Add code block header if language is specified
-                    if !code_language.is_empty() {
-                        if !current_line.is_empty() {
-                            lines.push(Line::from(std::mem::take(&mut current_line)));
-                        }
-                        lines.push(Line::from(vec![
-                            Span::styled("╭─ ", Style::default().fg(Color::DarkGray)),
-                            Span::styled(
-                                code_language.clone(),
-                                Style::default()
-                                    .fg(Color::Cyan)
-                                    .add_modifier(Modifier::BOLD),
-                            ),
-                            Span::styled(" ─", Style::default().fg(Color::DarkGray)),
-                        ]));
-                    }
-                }
-                Tag::List(_) => {
-                    list_level += 1;
-                }
-                Tag::Strong => {
-                    // Bold text - will be handled in text event
-                }
-                Tag::Emphasis => {
-                    // Italic text - will be handled in text event
-                }
-                Tag::BlockQuote if !current_line.is_empty() => {
-                    lines.push(Line::from(std::mem::take(&mut current_line)));
-                }
-                _ => {}
-            },
+    fn flush_current_line(&mut self) {
+        if !self.current_line.is_empty() {
+            self.lines
+                .push(Line::from(std::mem::take(&mut self.current_line)));
+        }
+    }
 
-            Event::End(tag) => match tag {
-                Tag::Heading(..) if !current_line.is_empty() => {
-                    // Add heading prefix and style
-                    let prefix = match heading_level {
-                        1 => "# ",
-                        2 => "## ",
-                        3 => "### ",
-                        _ => "",
-                    };
+    fn start_code_block(&mut self, kind: CodeBlockKind) {
+        self.in_code_block = true;
+        self.code_language = match kind {
+            CodeBlockKind::Fenced(lang) => lang.to_string(),
+            CodeBlockKind::Indented => String::new(),
+        };
 
-                    let mut styled_line = vec![Span::styled(
-                        prefix.to_string(),
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD),
-                    )];
-
-                    for span in &mut current_line {
-                        // Apply heading style to all spans in the line
-                        *span = span.clone().style(
-                            Style::default()
-                                .fg(Color::Cyan)
-                                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
-                        );
-                    }
-
-                    styled_line.extend(std::mem::take(&mut current_line));
-                    lines.push(Line::from(styled_line));
-                    lines.push(Line::from("")); // Add spacing after heading
-                }
-                Tag::CodeBlock(_) => {
-                    if !current_line.is_empty() {
-                        lines.push(Line::from(std::mem::take(&mut current_line)));
-                    }
-
-                    // Use syntax highlighting if we have code content
-                    if !code_content.is_empty() {
-                        let highlighted_lines = if !code_language.is_empty() {
-                            highlight_code(&code_content, &code_language)
-                        } else {
-                            highlight_code(&code_content, "text")
-                        };
-                        lines.extend(highlighted_lines);
-                    }
-
-                    // Add footer if language was specified
-                    if !code_language.is_empty() {
-                        lines.push(Line::from(Span::styled(
-                            "╰────".to_string(),
-                            Style::default().fg(Color::DarkGray),
-                        )));
-                    }
-
-                    lines.push(Line::from("")); // Add spacing after code block
-                    in_code_block = false;
-                    code_language.clear();
-                    code_content.clear();
-                }
-                Tag::List(_) => {
-                    list_level = list_level.saturating_sub(1);
-                    if list_level == 0 {
-                        lines.push(Line::from("")); // Add spacing after list
-                    }
-                }
-                Tag::Paragraph => {
-                    if !current_line.is_empty() {
-                        lines.push(Line::from(std::mem::take(&mut current_line)));
-                    }
-                    lines.push(Line::from("")); // Add spacing after paragraph
-                }
-                Tag::Item if !current_line.is_empty() => {
-                    lines.push(Line::from(std::mem::take(&mut current_line)));
-                }
-                Tag::BlockQuote => {
-                    lines.push(Line::from("")); // Add spacing after blockquote
-                }
-                _ => {}
-            },
-
-            Event::Text(text) => {
-                let text_str = text.to_string();
-
-                if in_code_block {
-                    // Accumulate code content for syntax highlighting
-                    code_content.push_str(&text_str);
-                } else {
-                    // Regular text - add to current line
-                    current_line.push(Span::styled(text_str, Style::default()));
-                }
-            }
-
-            Event::Code(code) => {
-                // Inline code
-                current_line.push(Span::styled(
-                    format!("`{}`", code),
+        if !self.code_language.is_empty() {
+            self.flush_current_line();
+            self.lines.push(Line::from(vec![
+                Span::styled("╭─ ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    self.code_language.clone(),
                     Style::default()
-                        .fg(Color::Yellow)
-                        .bg(Color::Black)
+                        .fg(Color::Cyan)
                         .add_modifier(Modifier::BOLD),
-                ));
-            }
+                ),
+                Span::styled(" ─", Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+    }
 
-            Event::HardBreak | Event::SoftBreak if !current_line.is_empty() => {
-                lines.push(Line::from(std::mem::take(&mut current_line)));
-            }
-
-            Event::Rule => {
-                if !current_line.is_empty() {
-                    lines.push(Line::from(std::mem::take(&mut current_line)));
-                }
-                lines.push(Line::from(Span::styled(
-                    "────────────────────────────────────────".to_string(),
-                    Style::default().fg(Color::DarkGray),
-                )));
-                lines.push(Line::from(""));
-            }
-
+    fn handle_start_tag(&mut self, tag: Tag) {
+        match tag {
+            Tag::Heading(level, ..) => self.heading_level = level as u32,
+            Tag::CodeBlock(kind) => self.start_code_block(kind),
+            Tag::List(_) => self.list_level += 1,
+            Tag::BlockQuote => self.flush_current_line(),
             _ => {}
         }
     }
 
-    // Add any remaining content
-    if !current_line.is_empty() {
-        lines.push(Line::from(current_line));
+    fn end_heading(&mut self) {
+        if self.current_line.is_empty() {
+            return;
+        }
+
+        let prefix = match self.heading_level {
+            1 => "# ",
+            2 => "## ",
+            3 => "### ",
+            _ => "",
+        };
+        let mut styled_line = vec![Span::styled(
+            prefix.to_string(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )];
+        for span in &mut self.current_line {
+            *span = span.clone().style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+            );
+        }
+        styled_line.extend(std::mem::take(&mut self.current_line));
+        self.lines.push(Line::from(styled_line));
+        self.lines.push(Line::from("")); // Add spacing after heading
     }
 
-    // Remove trailing empty lines
-    while lines.last().is_some_and(|line| line.spans.is_empty()) {
-        lines.pop();
+    fn end_code_block(&mut self) {
+        self.flush_current_line();
+
+        if !self.code_content.is_empty() {
+            let highlighted_lines = if !self.code_language.is_empty() {
+                highlight_code(&self.code_content, &self.code_language)
+            } else {
+                highlight_code(&self.code_content, "text")
+            };
+            self.lines.extend(highlighted_lines);
+        }
+
+        if !self.code_language.is_empty() {
+            self.lines.push(Line::from(Span::styled(
+                "╰────".to_string(),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+
+        self.lines.push(Line::from("")); // Add spacing after code block
+        self.in_code_block = false;
+        self.code_language.clear();
+        self.code_content.clear();
     }
 
-    lines
+    fn end_list(&mut self) {
+        self.list_level = self.list_level.saturating_sub(1);
+        if self.list_level == 0 {
+            self.lines.push(Line::from("")); // Add spacing after list
+        }
+    }
+
+    fn end_paragraph(&mut self) {
+        self.flush_current_line();
+        self.lines.push(Line::from("")); // Add spacing after paragraph
+    }
+
+    fn handle_end_tag(&mut self, tag: Tag) {
+        match tag {
+            Tag::Heading(..) => self.end_heading(),
+            Tag::CodeBlock(_) => self.end_code_block(),
+            Tag::List(_) => self.end_list(),
+            Tag::Paragraph => self.end_paragraph(),
+            Tag::Item => self.flush_current_line(),
+            Tag::BlockQuote => self.lines.push(Line::from("")), // Add spacing after blockquote
+            _ => {}
+        }
+    }
+
+    fn handle_text(&mut self, text: pulldown_cmark::CowStr<'_>) {
+        let text_str = text.to_string();
+        if self.in_code_block {
+            // Accumulate code content for syntax highlighting
+            self.code_content.push_str(&text_str);
+        } else {
+            // Regular text - add to current line
+            self.current_line
+                .push(Span::styled(text_str, Style::default()));
+        }
+    }
+
+    fn handle_inline_code(&mut self, code: pulldown_cmark::CowStr<'_>) {
+        self.current_line.push(Span::styled(
+            format!("`{}`", code),
+            Style::default()
+                .fg(Color::Yellow)
+                .bg(Color::Black)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    fn handle_rule(&mut self) {
+        self.flush_current_line();
+        self.lines.push(Line::from(Span::styled(
+            "────────────────────────────────────────".to_string(),
+            Style::default().fg(Color::DarkGray),
+        )));
+        self.lines.push(Line::from(""));
+    }
+
+    /// Drains any content still in progress and trims the trailing blank
+    /// lines the spacing rules above leave behind.
+    fn finish(mut self) -> Vec<Line<'static>> {
+        if !self.current_line.is_empty() {
+            self.lines.push(Line::from(self.current_line));
+        }
+        while self.lines.last().is_some_and(|line| line.spans.is_empty()) {
+            self.lines.pop();
+        }
+        self.lines
+    }
+}
+
+/// Parse markdown and convert to styled lines for Ratatui
+pub fn parse_markdown(markdown: &str) -> Vec<Line<'static>> {
+    let mut renderer = MarkdownRenderer::new();
+
+    for event in Parser::new(markdown) {
+        match event {
+            Event::Start(tag) => renderer.handle_start_tag(tag),
+            Event::End(tag) => renderer.handle_end_tag(tag),
+            Event::Text(text) => renderer.handle_text(text),
+            Event::Code(code) => renderer.handle_inline_code(code),
+            Event::HardBreak | Event::SoftBreak => renderer.flush_current_line(),
+            Event::Rule => renderer.handle_rule(),
+            _ => {}
+        }
+    }
+
+    renderer.finish()
 }
 
 /// Extract the raw content of the last fenced or indented code block in

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2234,4 +2234,227 @@ mod tests {
         assert!(screen.contains("1065ms"));
         assert!(screen.contains("43 tok/s"));
     }
+
+    #[tokio::test]
+    async fn help_screen_lists_commands_from_every_section() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Help;
+
+        let screen = render_to_string(&app, 100, 100);
+        // GLOBAL COMMANDS
+        assert!(screen.contains("Ctrl+C"));
+        assert!(screen.contains("Quit application"));
+        // CHAT MODE (non-kitty terminal falls back to Alt+Enter)
+        assert!(screen.contains("Alt+Enter"));
+        assert!(screen.contains("New line in message"));
+        // SESSION LIST
+        assert!(screen.contains("Navigate through sessions"));
+        // PLAN MODE
+        assert!(screen.contains("Approve plan and start execution"));
+        // FEATURES
+        assert!(screen.contains("Syntax Highlighting"));
+        // Footer
+        assert!(screen.contains("to return to chat"));
+    }
+
+    #[tokio::test]
+    async fn help_screen_shows_shift_enter_when_kitty_protocol_active() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Help;
+        app.kitty_keyboard_protocol_active = true;
+
+        let screen = render_to_string(&app, 100, 100);
+        assert!(screen.contains("Shift+Enter"));
+    }
+
+    #[tokio::test]
+    async fn chat_shows_pending_plan_banner_only_while_awaiting_approval() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Chat;
+        let mut plan = crate::plan::PlanDocument::new(
+            uuid::Uuid::new_v4(),
+            "Add login page".to_string(),
+            "".to_string(),
+        );
+        plan.status = crate::plan::PlanStatus::PendingApproval;
+        app.current_plan = Some(plan);
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("Plan Pending Approval"));
+
+        app.current_plan.as_mut().unwrap().status = crate::plan::PlanStatus::Approved;
+        let screen = render_to_string(&app, 100, 20);
+        assert!(!screen.contains("Plan Pending Approval"));
+    }
+
+    #[tokio::test]
+    async fn chat_message_thinking_block_toggles_between_collapsed_and_expanded() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Chat;
+        app.messages.push(DisplayMessage {
+            id: uuid::Uuid::new_v4(),
+            role: "assistant".to_string(),
+            content: "answer".to_string(),
+            thinking_text: Some("step one\nstep two".to_string()),
+            thinking_expanded: false,
+            timestamp: chrono::Utc::now(),
+            token_count: None,
+            cost: None,
+            provider_name: None,
+            perf_metrics: None,
+            tokens_per_second: None,
+        });
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("press t to expand"));
+        assert!(!screen.contains("step one"));
+
+        app.messages[0].thinking_expanded = true;
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("press t to collapse"));
+        assert!(screen.contains("step one"));
+        assert!(screen.contains("step two"));
+    }
+
+    #[tokio::test]
+    async fn chat_message_perf_footer_reports_cold_and_warm_starts() {
+        use crate::llm::provider::PerfMetrics;
+
+        let mut app = test_app().await;
+        app.mode = AppMode::Chat;
+        app.messages.push(DisplayMessage {
+            id: uuid::Uuid::new_v4(),
+            role: "assistant".to_string(),
+            content: "hi".to_string(),
+            thinking_text: None,
+            thinking_expanded: false,
+            timestamp: chrono::Utc::now(),
+            token_count: None,
+            cost: None,
+            provider_name: None,
+            perf_metrics: Some(PerfMetrics {
+                load_duration_ms: Some(250),
+                prompt_eval_duration_ms: None,
+                eval_duration_ms: Some(500),
+                total_duration_ms: None,
+                model_was_loaded: Some(false),
+            }),
+            tokens_per_second: Some(12.0),
+        });
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("500ms generation"));
+        assert!(screen.contains("12 tok/s"));
+        assert!(screen.contains("cold start (model loaded in 250ms)"));
+    }
+
+    #[tokio::test]
+    async fn chat_shows_streaming_response_and_processing_indicator() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Chat;
+
+        app.is_processing = true;
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("is thinking..."));
+
+        app.streaming_response = Some("partial reply".to_string());
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("[streaming]"));
+        assert!(screen.contains("partial reply"));
+        // The spinner only shows up before the first token arrives.
+        assert!(!screen.contains("is thinking..."));
+    }
+
+    #[tokio::test]
+    async fn plan_mode_shows_full_document_with_tasks_and_criteria() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Plan;
+
+        let mut plan = crate::plan::PlanDocument::new(
+            uuid::Uuid::new_v4(),
+            "Add login page".to_string(),
+            "Build a login form".to_string(),
+        );
+        plan.technical_stack = vec!["React".to_string()];
+        plan.test_strategy = "Unit test the form validation".to_string();
+
+        let mut task = crate::plan::PlanTask::new(
+            0,
+            "Create Login component".to_string(),
+            "".to_string(),
+            crate::plan::TaskType::Create,
+        );
+        task.acceptance_criteria = vec!["Renders email and password fields".to_string()];
+        plan.tasks.push(task);
+
+        app.current_plan = Some(plan);
+
+        let screen = render_to_string(&app, 100, 40);
+        assert!(screen.contains("Add login page"));
+        assert!(screen.contains("Build a login form"));
+        assert!(screen.contains("React"));
+        assert!(screen.contains("Unit test the form validation"));
+        assert!(screen.contains("Create Login component"));
+        assert!(screen.contains("Renders email and password fields"));
+        assert!(screen.contains("Approve"));
+    }
+
+    #[tokio::test]
+    async fn plan_mode_shows_empty_state_without_a_plan() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Plan;
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("No active plan"));
+    }
+
+    fn test_approval_request(
+        tool_input: serde_json::Value,
+        capabilities: Vec<String>,
+    ) -> crate::tui::events::ToolApprovalRequest {
+        let (response_tx, _response_rx) = tokio::sync::mpsc::unbounded_channel();
+        crate::tui::events::ToolApprovalRequest {
+            request_id: uuid::Uuid::new_v4(),
+            tool_name: "write_file".to_string(),
+            tool_description: "Writes contents to a file".to_string(),
+            tool_input,
+            capabilities,
+            response_tx,
+            requested_at: std::time::Instant::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn approval_dialog_shows_tool_name_capabilities_and_summarized_params() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ToolApproval;
+        app.pending_approval = Some(test_approval_request(
+            serde_json::json!({"path": "src/main.rs", "content": "fn main() {}"}),
+            vec!["filesystem-write".to_string()],
+        ));
+
+        let screen = render_to_string(&app, 100, 30);
+        assert!(screen.contains("write_file"));
+        assert!(screen.contains("Writes contents to a file"));
+        assert!(screen.contains("filesystem-write"));
+        assert!(screen.contains("Parameters"));
+        assert!(screen.contains("path"));
+        // Compact view never shows the raw JSON block.
+        assert!(!screen.contains("Tool Input (JSON)"));
+    }
+
+    #[tokio::test]
+    async fn approval_dialog_details_view_shows_pretty_printed_json() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ToolApproval;
+        app.show_approval_details = true;
+        app.pending_approval = Some(test_approval_request(
+            serde_json::json!({"path": "src/main.rs"}),
+            vec![],
+        ));
+
+        let screen = render_to_string(&app, 100, 30);
+        assert!(screen.contains("Tool Input (JSON)"));
+        assert!(screen.contains("\"path\""));
+    }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -460,7 +460,7 @@ fn render_chat(f: &mut Frame, app: &App, area: Rect) {
                 .border_style(Style::default().fg(Color::Cyan)),
         )
         .wrap(Wrap { trim: false })
-        .scroll((actual_scroll_offset as u16, 0));
+        .scroll((actual_scroll_offset, 0));
 
     f.render_widget(chat, area);
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -196,195 +196,210 @@ fn render_header(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(header, area);
 }
 
-/// Render the chat messages
-fn render_chat(f: &mut Frame, app: &App, area: Rect) {
-    let mut lines: Vec<Line> = Vec::new();
-
-    // Show banner if there's a pending plan
-    if let Some(ref plan) = app.current_plan {
-        if matches!(plan.status, crate::plan::PlanStatus::PendingApproval) {
-            lines.push(Line::from(""));
-            lines.push(Line::from(vec![
-                Span::styled("  ⚠️  ", Style::default().fg(Color::Yellow)),
-                Span::styled(
-                    "Plan Pending Approval",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ]));
-            lines.push(Line::from(vec![
-                Span::styled("  ", Style::default()),
-                Span::styled("Press ", Style::default().fg(Color::DarkGray)),
-                Span::styled(
-                    "Ctrl+P",
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    " to review the plan, or switch to Plan Mode to approve/reject.",
-                    Style::default().fg(Color::DarkGray),
-                ),
-            ]));
-            lines.push(Line::from(Span::styled(
-                "  ─".repeat(30),
-                Style::default().fg(Color::Yellow),
-            )));
-            lines.push(Line::from(""));
-        }
+/// Banner shown above the chat log while a plan is awaiting approval.
+fn render_pending_plan_banner(app: &App) -> Vec<Line<'static>> {
+    let Some(ref plan) = app.current_plan else {
+        return Vec::new();
+    };
+    if !matches!(plan.status, crate::plan::PlanStatus::PendingApproval) {
+        return Vec::new();
     }
 
-    // Get the model name from the current session
-    let model_name = app
-        .current_session
-        .as_ref()
-        .and_then(|s| s.model.as_deref())
-        .unwrap_or("AI");
-
-    for msg in &app.messages {
-        // Add timestamp and role with better formatting
-        let timestamp = msg.timestamp.format("%H:%M:%S");
-
-        // Build role text and style
-        let (role_text, role_style, prefix) = if msg.role == "user" {
-            (
-                "You".to_string(),
+    vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  ⚠️  ", Style::default().fg(Color::Yellow)),
+            Span::styled(
+                "Plan Pending Approval",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  ", Style::default()),
+            Span::styled("Press ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "Ctrl+P",
                 Style::default()
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
-                "  ",
-            )
-        } else {
-            (
-                format!("🤖 {}", model_name),
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-                "",
-            )
-        };
-
-        lines.push(Line::from(vec![
-            Span::styled(prefix, Style::default()),
-            Span::styled(role_text, role_style),
+            ),
             Span::styled(
-                format!(" ({})", timestamp),
+                " to review the plan, or switch to Plan Mode to approve/reject.",
                 Style::default().fg(Color::DarkGray),
             ),
-        ]));
+        ]),
+        Line::from(Span::styled(
+            "  ─".repeat(30),
+            Style::default().fg(Color::Yellow),
+        )),
+        Line::from(""),
+    ]
+}
 
-        // Render thinking block (collapsed by default, expanded with 't' key)
-        if let Some(ref thinking) = msg.thinking_text {
-            if msg.thinking_expanded {
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        "[Thinking ▾] ",
-                        Style::default()
-                            .fg(Color::Magenta)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        "(press t to collapse)",
-                        Style::default().fg(Color::DarkGray),
-                    ),
-                ]));
-                for thinking_line in thinking.lines() {
-                    lines.push(Line::from(vec![
-                        Span::styled("  │ ", Style::default().fg(Color::Magenta)),
-                        Span::styled(thinking_line.to_string(), Style::default().fg(Color::Gray)),
-                    ]));
-                }
-            } else {
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        "[Thinking ▸] ",
-                        Style::default()
-                            .fg(Color::Magenta)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled("(press t to expand)", Style::default().fg(Color::DarkGray)),
-                ]));
-            }
-        }
+/// The runtime performance footer (currently Ollama only) shown under a
+/// message, when the provider actually reported timing metrics.
+fn render_perf_footer(msg: &super::app::DisplayMessage) -> Option<Line<'static>> {
+    let perf = msg.perf_metrics.as_ref()?;
 
-        // Assistant replies are markdown and are rendered as such. The user's own
-        // message is not - it is literal text, and parsing it as CommonMark eats
-        // the backslashes out of any Windows path they typed or pasted.
-        let mut content_lines = if msg.role == "user" {
-            parse_plain_text(&msg.content)
-        } else {
-            parse_markdown(&msg.content)
-        };
-        lines.append(&mut content_lines);
-
-        // Runtime performance metrics footer (currently Ollama only) - shown
-        // only when the provider actually reported them.
-        if let Some(ref perf) = msg.perf_metrics {
-            let mut spans = vec![Span::styled("  ⏱ ", Style::default().fg(Color::DarkGray))];
-            if let Some(eval_ms) = perf.eval_duration_ms {
-                spans.push(Span::styled(
-                    format!("{}ms generation", eval_ms),
-                    Style::default().fg(Color::DarkGray),
-                ));
-            }
-            if let Some(tps) = msg.tokens_per_second {
-                spans.push(Span::styled(
-                    format!(" · {:.0} tok/s", tps),
-                    Style::default().fg(Color::DarkGray),
-                ));
-            }
-            match perf.model_was_loaded {
-                Some(false) => {
-                    let load_ms = perf.load_duration_ms.unwrap_or(0);
-                    spans.push(Span::styled(
-                        format!(" · 🧊 cold start (model loaded in {}ms)", load_ms),
-                        Style::default().fg(Color::DarkGray),
-                    ));
-                }
-                Some(true) => {
-                    spans.push(Span::styled(
-                        " · 🔥 warm",
-                        Style::default().fg(Color::DarkGray),
-                    ));
-                }
-                None => {}
-            }
-            lines.push(Line::from(spans));
-        }
-
-        // Add spacing between messages
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "─".repeat(60),
+    let mut spans = vec![Span::styled("  ⏱ ", Style::default().fg(Color::DarkGray))];
+    if let Some(eval_ms) = perf.eval_duration_ms {
+        spans.push(Span::styled(
+            format!("{}ms generation", eval_ms),
             Style::default().fg(Color::DarkGray),
-        )));
-        lines.push(Line::from(""));
+        ));
     }
+    if let Some(tps) = msg.tokens_per_second {
+        spans.push(Span::styled(
+            format!(" · {:.0} tok/s", tps),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    match perf.model_was_loaded {
+        Some(false) => {
+            let load_ms = perf.load_duration_ms.unwrap_or(0);
+            spans.push(Span::styled(
+                format!(" · 🧊 cold start (model loaded in {}ms)", load_ms),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        Some(true) => {
+            spans.push(Span::styled(
+                " · 🔥 warm",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        None => {}
+    }
+    Some(Line::from(spans))
+}
 
-    // Add streaming response if present
-    if let Some(ref response) = app.streaming_response {
-        lines.push(Line::from(vec![
+/// Render the collapsed/expanded "thinking" block for a message, if present.
+fn render_thinking_block(msg: &super::app::DisplayMessage) -> Vec<Line<'static>> {
+    let Some(ref thinking) = msg.thinking_text else {
+        return Vec::new();
+    };
+
+    if !msg.thinking_expanded {
+        return vec![Line::from(vec![
             Span::styled(
-                format!("🤖 {} ", model_name),
+                "[Thinking ▸] ",
                 Style::default()
-                    .fg(Color::Green)
+                    .fg(Color::Magenta)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled("[streaming]", Style::default().fg(Color::DarkGray)),
-        ]));
-
-        let mut streaming_lines = parse_markdown(response);
-        lines.append(&mut streaming_lines);
+            Span::styled("(press t to expand)", Style::default().fg(Color::DarkGray)),
+        ])];
     }
 
-    // Show processing indicator with animated spinner
-    if app.is_processing && app.streaming_response.is_none() {
-        let spinner_frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-        let frame = spinner_frames[app.animation_frame % spinner_frames.len()];
-
-        lines.push(Line::from(""));
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            "[Thinking ▾] ",
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            "(press t to collapse)",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ])];
+    for thinking_line in thinking.lines() {
         lines.push(Line::from(vec![
+            Span::styled("  │ ", Style::default().fg(Color::Magenta)),
+            Span::styled(thinking_line.to_string(), Style::default().fg(Color::Gray)),
+        ]));
+    }
+    lines
+}
+
+/// Render one full message: role/timestamp header, thinking block, body, perf
+/// footer, and the trailing separator.
+fn render_message_lines(msg: &super::app::DisplayMessage, model_name: &str) -> Vec<Line<'static>> {
+    let timestamp = msg.timestamp.format("%H:%M:%S");
+    let (role_text, role_style, prefix) = if msg.role == "user" {
+        (
+            "You".to_string(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+            "  ",
+        )
+    } else {
+        (
+            format!("🤖 {}", model_name),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+            "",
+        )
+    };
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled(prefix, Style::default()),
+        Span::styled(role_text, role_style),
+        Span::styled(
+            format!(" ({})", timestamp),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ])];
+
+    lines.extend(render_thinking_block(msg));
+
+    // Assistant replies are markdown and are rendered as such. The user's own
+    // message is not - it is literal text, and parsing it as CommonMark eats
+    // the backslashes out of any Windows path they typed or pasted.
+    if msg.role == "user" {
+        lines.extend(parse_plain_text(&msg.content));
+    } else {
+        lines.extend(parse_markdown(&msg.content));
+    };
+
+    lines.extend(render_perf_footer(msg));
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "─".repeat(60),
+        Style::default().fg(Color::DarkGray),
+    )));
+    lines.push(Line::from(""));
+
+    lines
+}
+
+/// The in-progress assistant reply, streamed token-by-token.
+fn render_streaming_response(app: &App, model_name: &str) -> Vec<Line<'static>> {
+    let Some(ref response) = app.streaming_response else {
+        return Vec::new();
+    };
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            format!("🤖 {} ", model_name),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("[streaming]", Style::default().fg(Color::DarkGray)),
+    ])];
+    lines.extend(parse_markdown(response));
+    lines
+}
+
+/// Animated "model is thinking" spinner, shown while waiting for the first
+/// streamed token.
+fn render_processing_indicator(app: &App, model_name: &str) -> Vec<Line<'static>> {
+    if !app.is_processing || app.streaming_response.is_some() {
+        return Vec::new();
+    }
+
+    let spinner_frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    let frame = spinner_frames[app.animation_frame % spinner_frames.len()];
+
+    vec![
+        Line::from(""),
+        Line::from(vec![
             Span::styled(
                 format!("{} ", frame),
                 Style::default()
@@ -395,17 +410,42 @@ fn render_chat(f: &mut Frame, app: &App, area: Rect) {
                 format!("{} is thinking...", model_name),
                 Style::default().fg(Color::Yellow),
             ),
-        ]));
+        ]),
+    ]
+}
+
+/// `app.scroll_offset` is "lines scrolled up from the bottom" (0 = auto-scroll
+/// showing the latest messages); ratatui's `Paragraph::scroll` wants an
+/// absolute offset from the top, so convert between the two here.
+fn compute_scroll_offset(total_lines: usize, visible_height: usize, scroll_offset: usize) -> u16 {
+    let max_scroll = total_lines.saturating_sub(visible_height);
+    max_scroll.saturating_sub(scroll_offset) as u16
+}
+
+/// Render the chat messages
+fn render_chat(f: &mut Frame, app: &App, area: Rect) {
+    let mut lines: Vec<Line> = Vec::new();
+
+    lines.extend(render_pending_plan_banner(app));
+
+    // Get the model name from the current session
+    let model_name = app
+        .current_session
+        .as_ref()
+        .and_then(|s| s.model.as_deref())
+        .unwrap_or("AI");
+
+    for msg in &app.messages {
+        lines.extend(render_message_lines(msg, model_name));
     }
 
-    // Calculate scroll offset for ratatui
-    // app.scroll_offset represents "lines scrolled up from the bottom"
-    // 0 = at the bottom (auto-scroll, showing latest messages)
-    // N = scrolled up N lines from the bottom (showing older messages)
+    lines.extend(render_streaming_response(app, model_name));
+    lines.extend(render_processing_indicator(app, model_name));
+
     let total_lines = lines.len();
     let visible_height = area.height.saturating_sub(2) as usize; // Subtract borders
-    let max_scroll = total_lines.saturating_sub(visible_height);
-    let actual_scroll_offset = max_scroll.saturating_sub(app.scroll_offset);
+    let actual_scroll_offset =
+        compute_scroll_offset(total_lines, visible_height, app.scroll_offset);
 
     let chat = Paragraph::new(lines)
         .block(
@@ -647,480 +687,195 @@ fn render_mcp(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(widget, area);
 }
 
-/// Render the help screen
-fn render_help(f: &mut Frame, app: &App, area: Rect) {
-    let help_text = vec![
-        Line::from(vec![
-            Span::styled("🥐 ", Style::default().fg(Color::Rgb(218, 165, 32))),
-            Span::styled(
-                "Crustly Help",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
-            ),
-        ]),
+/// A single "key → description" row, the recurring building block of the help screen.
+fn help_row(key: &'static str, desc: impl Into<String>, key_color: Color) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            key,
+            Style::default().fg(key_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("→ ", Style::default().fg(Color::DarkGray)),
+        Span::styled(desc.into(), Style::default().fg(Color::White)),
+    ])
+}
+
+/// A single "✓ Name - description" row used in the FEATURES section.
+fn feature_row(name: &'static str, desc: &'static str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled("  ✓ ", Style::default().fg(Color::Green)),
+        Span::styled(
+            name,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(desc, Style::default().fg(Color::DarkGray)),
+    ])
+}
+
+/// Blank line + boxed section title + blank line, shared by every help section.
+fn help_section_header(title: &'static str) -> [Line<'static>; 3] {
+    [
         Line::from(""),
-        Line::from(Span::styled(
-            "╭─ GLOBAL COMMANDS ─────────────────────────────────────────╮",
-            Style::default().fg(Color::Cyan),
-        )),
+        Line::from(Span::styled(title, Style::default().fg(Color::Cyan))),
         Line::from(""),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+C       ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Quit application", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+N       ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Create new chat session", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+L       ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "List all sessions (switch sessions)",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+H       ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Show this help screen", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+K       ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Clear current session messages",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+O       ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Show Model Info panel (provider, model, context, perf)",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+W       ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Switch to a different local Ollama model",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Shift+Tab    ",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Cycle Auto Mode: Interactive → AutoPlan → FullAuto",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "╭─ CHAT MODE ───────────────────────────────────────────────╮",
-            Style::default().fg(Color::Cyan),
-        )),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled(
-                "  Enter        ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Send message to LLM", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                if app.kitty_keyboard_protocol_active {
-                    "  Shift+Enter  "
-                } else {
-                    "  Alt+Enter    "
-                },
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "New line in message (multi-line input)",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  ↑ / ↓        ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Recall previous messages (edit and resend; moves the cursor in a multi-line draft)",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+Enter   ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Send message (legacy alias)",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  ←/→/↑/↓      ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Move cursor (Ctrl+←/→ jumps by word)",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Home/End     ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Jump to start/end of line",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Backspace    ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Delete character at cursor (Ctrl+Backspace/Delete: whole word)",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+Y       ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Copy last response (or its code block) to clipboard",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+V       ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Paste from system clipboard at cursor",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Escape       ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Clear input buffer", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Page Up      ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Scroll chat history up", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Page Down    ",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Scroll chat history down",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "╭─ SESSION LIST ────────────────────────────────────────────╮",
-            Style::default().fg(Color::Cyan),
-        )),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled(
-                "  ↑/↓          ",
-                Style::default()
-                    .fg(Color::Magenta)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Navigate through sessions",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Enter        ",
-                Style::default()
-                    .fg(Color::Magenta)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Load selected session", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Escape       ",
-                Style::default()
-                    .fg(Color::Magenta)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Return to chat", Style::default().fg(Color::White)),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "╭─ PLAN MODE ───────────────────────────────────────────────╮",
-            Style::default().fg(Color::Cyan),
-        )),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+P       ",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled("Toggle Plan Mode view", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+A       ",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Approve plan and start execution",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Ctrl+R       ",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Reject plan and return to chat",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  ↑/↓          ",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Scroll through plan tasks",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  Page Up/Down ",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("→ ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                "Scroll plan tasks faster",
-                Style::default().fg(Color::White),
-            ),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "╭─ FEATURES ────────────────────────────────────────────────╮",
-            Style::default().fg(Color::Cyan),
-        )),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("  ✓ ", Style::default().fg(Color::Green)),
-            Span::styled(
-                "Markdown Rendering",
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " - Rich text with headings, lists, code",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("  ✓ ", Style::default().fg(Color::Green)),
-            Span::styled(
-                "Syntax Highlighting",
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " - 100+ languages supported",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("  ✓ ", Style::default().fg(Color::Green)),
-            Span::styled(
-                "Multi-line Input",
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " - Write long messages with ease",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("  ✓ ", Style::default().fg(Color::Green)),
-            Span::styled(
-                "Session Management",
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " - Persistent conversation history",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("  ✓ ", Style::default().fg(Color::Green)),
-            Span::styled(
-                "Streaming Responses",
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " - See responses as they're generated",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("  ✓ ", Style::default().fg(Color::Green)),
-            Span::styled(
-                "Token & Cost Tracking",
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " - Monitor usage in real-time",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]),
-        Line::from(vec![
-            Span::styled("  ✓ ", Style::default().fg(Color::Green)),
-            Span::styled(
-                "Plan Mode",
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                " - Structured task planning with approval",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]),
+    ]
+}
+
+fn help_global_commands() -> Vec<Line<'static>> {
+    let mut lines =
+        help_section_header("╭─ GLOBAL COMMANDS ─────────────────────────────────────────╮")
+            .to_vec();
+    lines.extend([
+        help_row("  Ctrl+C       ", "Quit application", Color::Yellow),
+        help_row("  Ctrl+N       ", "Create new chat session", Color::Yellow),
+        help_row(
+            "  Ctrl+L       ",
+            "List all sessions (switch sessions)",
+            Color::Yellow,
+        ),
+        help_row("  Ctrl+H       ", "Show this help screen", Color::Yellow),
+        help_row(
+            "  Ctrl+K       ",
+            "Clear current session messages",
+            Color::Yellow,
+        ),
+        help_row(
+            "  Ctrl+O       ",
+            "Show Model Info panel (provider, model, context, perf)",
+            Color::Yellow,
+        ),
+        help_row(
+            "  Ctrl+W       ",
+            "Switch to a different local Ollama model",
+            Color::Yellow,
+        ),
+        help_row(
+            "  Shift+Tab    ",
+            "Cycle Auto Mode: Interactive → AutoPlan → FullAuto",
+            Color::Yellow,
+        ),
+    ]);
+    lines
+}
+
+fn help_chat_mode(app: &App) -> Vec<Line<'static>> {
+    let newline_key = if app.kitty_keyboard_protocol_active {
+        "  Shift+Enter  "
+    } else {
+        "  Alt+Enter    "
+    };
+
+    let mut lines =
+        help_section_header("╭─ CHAT MODE ───────────────────────────────────────────────╮")
+            .to_vec();
+    lines.extend([
+        help_row("  Enter        ", "Send message to LLM", Color::Green),
+        help_row(
+            newline_key,
+            "New line in message (multi-line input)",
+            Color::Green,
+        ),
+        help_row(
+            "  ↑ / ↓        ",
+            "Recall previous messages (edit and resend; moves the cursor in a multi-line draft)",
+            Color::Green,
+        ),
+        help_row(
+            "  Ctrl+Enter   ",
+            "Send message (legacy alias)",
+            Color::Green,
+        ),
+        help_row(
+            "  ←/→/↑/↓      ",
+            "Move cursor (Ctrl+←/→ jumps by word)",
+            Color::Green,
+        ),
+        help_row("  Home/End     ", "Jump to start/end of line", Color::Green),
+        help_row(
+            "  Backspace    ",
+            "Delete character at cursor (Ctrl+Backspace/Delete: whole word)",
+            Color::Green,
+        ),
+        help_row(
+            "  Ctrl+Y       ",
+            "Copy last response (or its code block) to clipboard",
+            Color::Green,
+        ),
+        help_row(
+            "  Ctrl+V       ",
+            "Paste from system clipboard at cursor",
+            Color::Green,
+        ),
+        help_row("  Escape       ", "Clear input buffer", Color::Green),
+        help_row("  Page Up      ", "Scroll chat history up", Color::Green),
+        help_row("  Page Down    ", "Scroll chat history down", Color::Green),
+    ]);
+    lines
+}
+
+fn help_session_list() -> Vec<Line<'static>> {
+    let mut lines =
+        help_section_header("╭─ SESSION LIST ────────────────────────────────────────────╮")
+            .to_vec();
+    lines.extend([
+        help_row(
+            "  ↑/↓          ",
+            "Navigate through sessions",
+            Color::Magenta,
+        ),
+        help_row("  Enter        ", "Load selected session", Color::Magenta),
+        help_row("  Escape       ", "Return to chat", Color::Magenta),
+    ]);
+    lines
+}
+
+fn help_plan_mode() -> Vec<Line<'static>> {
+    let mut lines =
+        help_section_header("╭─ PLAN MODE ───────────────────────────────────────────────╮")
+            .to_vec();
+    lines.extend([
+        help_row("  Ctrl+P       ", "Toggle Plan Mode view", Color::Blue),
+        help_row(
+            "  Ctrl+A       ",
+            "Approve plan and start execution",
+            Color::Blue,
+        ),
+        help_row(
+            "  Ctrl+R       ",
+            "Reject plan and return to chat",
+            Color::Blue,
+        ),
+        help_row("  ↑/↓          ", "Scroll through plan tasks", Color::Blue),
+        help_row("  Page Up/Down ", "Scroll plan tasks faster", Color::Blue),
+    ]);
+    lines
+}
+
+fn help_features() -> Vec<Line<'static>> {
+    let mut lines =
+        help_section_header("╭─ FEATURES ────────────────────────────────────────────────╮")
+            .to_vec();
+    lines.extend([
+        feature_row(
+            "Markdown Rendering",
+            " - Rich text with headings, lists, code",
+        ),
+        feature_row("Syntax Highlighting", " - 100+ languages supported"),
+        feature_row("Multi-line Input", " - Write long messages with ease"),
+        feature_row("Session Management", " - Persistent conversation history"),
+        feature_row(
+            "Streaming Responses",
+            " - See responses as they're generated",
+        ),
+        feature_row("Token & Cost Tracking", " - Monitor usage in real-time"),
+        feature_row("Plan Mode", " - Structured task planning with approval"),
+    ]);
+    lines
+}
+
+fn help_footer() -> Vec<Line<'static>> {
+    vec![
         Line::from(""),
         Line::from(""),
         Line::from(vec![
@@ -1136,7 +891,29 @@ fn render_help(f: &mut Frame, app: &App, area: Rect) {
             ),
             Span::styled(" to return to chat", Style::default().fg(Color::DarkGray)),
         ]),
+    ]
+}
+
+/// Render the help screen
+fn render_help(f: &mut Frame, app: &App, area: Rect) {
+    let mut help_text = vec![
+        Line::from(vec![
+            Span::styled("🥐 ", Style::default().fg(Color::Rgb(218, 165, 32))),
+            Span::styled(
+                "Crustly Help",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+            ),
+        ]),
+        Line::from(""),
     ];
+    help_text.extend(help_global_commands());
+    help_text.extend(help_chat_mode(app));
+    help_text.extend(help_session_list());
+    help_text.extend(help_plan_mode());
+    help_text.extend(help_features());
+    help_text.extend(help_footer());
 
     let help = Paragraph::new(help_text)
         .block(
@@ -1212,13 +989,50 @@ fn render_plan_help(f: &mut Frame, area: Rect) {
 
 /// Render the plan mode view
 #[allow(clippy::vec_init_then_push)]
-fn render_plan(f: &mut Frame, app: &App, area: Rect) {
-    if let Some(plan) = &app.current_plan {
-        // Render the plan document
-        let mut lines = vec![];
+/// One task entry in the plan document: title/status line, type/complexity
+/// line, and its acceptance criteria (if any).
+fn render_plan_task_lines(task: &crate::plan::PlanTask, idx: usize) -> Vec<Line<'_>> {
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled(format!(" {} ", task.status.icon()), Style::default()),
+            Span::styled(
+                format!("{}. ", idx + 1),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(&task.title, Style::default().fg(Color::White)),
+        ]),
+        Line::from(vec![
+            Span::styled("    ", Style::default()),
+            Span::styled("Type: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(task.task_type.to_string(), Style::default().fg(Color::Cyan)),
+            Span::styled("  |  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("Complexity: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(task.complexity_stars(), Style::default().fg(Color::Yellow)),
+        ]),
+    ];
 
-        // Plan header
+    if !task.acceptance_criteria.is_empty() {
         lines.push(Line::from(vec![
+            Span::styled("    ", Style::default()),
+            Span::styled("✓ Acceptance Criteria:", Style::default().fg(Color::Green)),
+        ]));
+        for criterion in &task.acceptance_criteria {
+            lines.push(Line::from(vec![
+                Span::styled("      • ", Style::default().fg(Color::DarkGray)),
+                Span::styled(criterion, Style::default().fg(Color::White)),
+            ]));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines
+}
+
+/// Full plan document body: header, status, description, tech stack, test
+/// strategy, task list, and the bottom action bar.
+fn render_plan_document(plan: &crate::plan::PlanDocument, area_width: usize) -> Vec<Line<'_>> {
+    let mut lines = vec![
+        Line::from(vec![
             Span::styled("📋 ", Style::default().fg(Color::Cyan)),
             Span::styled(
                 &plan.title,
@@ -1226,126 +1040,109 @@ fn render_plan(f: &mut Frame, app: &App, area: Rect) {
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             ),
-        ]));
-
-        lines.push(Line::from(""));
-
-        // Status
-        lines.push(Line::from(vec![
+        ]),
+        Line::from(""),
+        Line::from(vec![
             Span::styled("Status: ", Style::default().fg(Color::DarkGray)),
             Span::styled(plan.status.to_string(), Style::default().fg(Color::Yellow)),
-        ]));
+        ]),
+        Line::from(""),
+    ];
 
-        lines.push(Line::from(""));
-
-        // Description
-        if !plan.description.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "📝 Description:",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            )));
-            lines.push(Line::from(Span::styled(
-                &plan.description,
-                Style::default().fg(Color::White),
-            )));
-            lines.push(Line::from(""));
-        }
-
-        // Technical Stack
-        if !plan.technical_stack.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "🛠️  Technical Stack:",
-                Style::default()
-                    .fg(Color::Blue)
-                    .add_modifier(Modifier::BOLD),
-            )));
-            for tech in &plan.technical_stack {
-                lines.push(Line::from(vec![
-                    Span::styled("    • ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(tech, Style::default().fg(Color::White)),
-                ]));
-            }
-            lines.push(Line::from(""));
-        }
-
-        // Test Strategy
-        if !plan.test_strategy.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "🧪 Test Strategy:",
-                Style::default()
-                    .fg(Color::Magenta)
-                    .add_modifier(Modifier::BOLD),
-            )));
-            lines.push(Line::from(Span::styled(
-                &plan.test_strategy,
-                Style::default().fg(Color::White),
-            )));
-            lines.push(Line::from(""));
-        }
-
-        // Tasks
+    if !plan.description.is_empty() {
         lines.push(Line::from(Span::styled(
-            format!("📋 Tasks ({}):", plan.tasks.len()),
+            "📝 Description:",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(Span::styled(
+            &plan.description,
+            Style::default().fg(Color::White),
+        )));
+        lines.push(Line::from(""));
+    }
+
+    if !plan.technical_stack.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "🛠️  Technical Stack:",
+            Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for tech in &plan.technical_stack {
+            lines.push(Line::from(vec![
+                Span::styled("    • ", Style::default().fg(Color::DarkGray)),
+                Span::styled(tech, Style::default().fg(Color::White)),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+
+    if !plan.test_strategy.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "🧪 Test Strategy:",
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(Span::styled(
+            &plan.test_strategy,
+            Style::default().fg(Color::White),
+        )));
+        lines.push(Line::from(""));
+    }
+
+    lines.push(Line::from(Span::styled(
+        format!("📋 Tasks ({}):", plan.tasks.len()),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
+
+    for (idx, task) in plan.tasks.iter().enumerate() {
+        lines.extend(render_plan_task_lines(task, idx));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "─".repeat(area_width),
+        Style::default().fg(Color::DarkGray),
+    )));
+    lines.push(Line::from(vec![
+        Span::styled("[Ctrl+A] ", Style::default().fg(Color::Green)),
+        Span::styled("Approve  ", Style::default().fg(Color::White)),
+        Span::styled("[Ctrl+R] ", Style::default().fg(Color::Yellow)),
+        Span::styled("Reject  ", Style::default().fg(Color::White)),
+        Span::styled("[Esc] ", Style::default().fg(Color::Red)),
+        Span::styled("Cancel", Style::default().fg(Color::White)),
+    ]));
+
+    lines
+}
+
+/// Placeholder shown in Plan Mode when there is no active plan yet.
+fn render_plan_empty_state() -> Vec<Line<'static>> {
+    vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "📋 Plan Mode",
             Style::default()
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
-        )));
-        lines.push(Line::from(""));
-
-        for (idx, task) in plan.tasks.iter().enumerate() {
-            // Task line
-            lines.push(Line::from(vec![
-                Span::styled(format!(" {} ", task.status.icon()), Style::default()),
-                Span::styled(
-                    format!("{}. ", idx + 1),
-                    Style::default().fg(Color::DarkGray),
-                ),
-                Span::styled(&task.title, Style::default().fg(Color::White)),
-            ]));
-
-            // Task details (type and complexity)
-            lines.push(Line::from(vec![
-                Span::styled("    ", Style::default()),
-                Span::styled("Type: ", Style::default().fg(Color::DarkGray)),
-                Span::styled(task.task_type.to_string(), Style::default().fg(Color::Cyan)),
-                Span::styled("  |  ", Style::default().fg(Color::DarkGray)),
-                Span::styled("Complexity: ", Style::default().fg(Color::DarkGray)),
-                Span::styled(task.complexity_stars(), Style::default().fg(Color::Yellow)),
-            ]));
-
-            // Acceptance Criteria
-            if !task.acceptance_criteria.is_empty() {
-                lines.push(Line::from(vec![
-                    Span::styled("    ", Style::default()),
-                    Span::styled("✓ Acceptance Criteria:", Style::default().fg(Color::Green)),
-                ]));
-                for criterion in &task.acceptance_criteria {
-                    lines.push(Line::from(vec![
-                        Span::styled("      • ", Style::default().fg(Color::DarkGray)),
-                        Span::styled(criterion, Style::default().fg(Color::White)),
-                    ]));
-                }
-            }
-
-            lines.push(Line::from(""));
-        }
-
-        // Action bar
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "─".repeat(area.width as usize),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "No active plan. Switch to Chat mode to create a plan.",
             Style::default().fg(Color::DarkGray),
-        )));
-        lines.push(Line::from(vec![
-            Span::styled("[Ctrl+A] ", Style::default().fg(Color::Green)),
-            Span::styled("Approve  ", Style::default().fg(Color::White)),
-            Span::styled("[Ctrl+R] ", Style::default().fg(Color::Yellow)),
-            Span::styled("Reject  ", Style::default().fg(Color::White)),
-            Span::styled("[Esc] ", Style::default().fg(Color::Red)),
-            Span::styled("Cancel", Style::default().fg(Color::White)),
-        ]));
+        )),
+    ]
+}
+
+fn render_plan(f: &mut Frame, app: &App, area: Rect) {
+    if let Some(plan) = &app.current_plan {
+        let lines = render_plan_document(plan, area.width as usize);
 
         let paragraph = Paragraph::new(lines)
             .block(
@@ -1359,23 +1156,7 @@ fn render_plan(f: &mut Frame, app: &App, area: Rect) {
 
         f.render_widget(paragraph, area);
     } else {
-        // No plan available
-        let text = vec![
-            Line::from(""),
-            Line::from(Span::styled(
-                "📋 Plan Mode",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            )),
-            Line::from(""),
-            Line::from(Span::styled(
-                "No active plan. Switch to Chat mode to create a plan.",
-                Style::default().fg(Color::DarkGray),
-            )),
-        ];
-
-        let paragraph = Paragraph::new(text)
+        let paragraph = Paragraph::new(render_plan_empty_state())
             .block(Block::default().borders(Borders::ALL))
             .alignment(ratatui::layout::Alignment::Center);
 
@@ -1409,203 +1190,237 @@ fn render_settings(f: &mut Frame, _app: &App, area: Rect) {
 }
 
 /// Render the tool approval dialog
-fn render_approval(f: &mut Frame, app: &App, area: Rect) {
-    if let Some(ref request) = app.pending_approval {
-        // Get the model name from the current session
-        let model_name = app
-            .current_session
-            .as_ref()
-            .and_then(|s| s.model.as_deref())
-            .unwrap_or("AI");
-        // Center the dialog
-        let dialog_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Min(0),
-                Constraint::Length(if app.show_approval_details { 30 } else { 20 }),
-                Constraint::Min(0),
-            ])
-            .split(area);
+/// Centers the approval dialog within `area`, sized to fit the extra JSON
+/// detail lines when `show_details` is on.
+fn approval_dialog_area(area: Rect, show_details: bool) -> Rect {
+    let dialog_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(if show_details { 30 } else { 20 }),
+            Constraint::Min(0),
+        ])
+        .split(area);
 
-        let center_chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Min(0),
-                Constraint::Length(80),
-                Constraint::Min(0),
-            ])
-            .split(dialog_chunks[1]);
+    let center_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(80),
+            Constraint::Min(0),
+        ])
+        .split(dialog_chunks[1]);
 
-        let dialog_area = center_chunks[1];
+    center_chunks[1]
+}
 
-        // Build dialog content - calculate time remaining
-        let time_remaining = request.time_remaining();
-        let seconds_remaining = time_remaining.as_secs();
-        let time_color = if seconds_remaining < 60 {
-            Color::Red
-        } else if seconds_remaining < 180 {
-            Color::Yellow
-        } else {
-            Color::Green
-        };
+/// Header lines: time-remaining countdown, tool name, and description.
+fn render_approval_header<'a>(
+    request: &'a super::events::ToolApprovalRequest,
+    model_name: &'a str,
+) -> Vec<Line<'a>> {
+    let seconds_remaining = request.time_remaining().as_secs();
+    let time_color = if seconds_remaining < 60 {
+        Color::Red
+    } else if seconds_remaining < 180 {
+        Color::Yellow
+    } else {
+        Color::Green
+    };
 
-        let mut lines = vec![
-            Line::from(""),
-            Line::from(vec![
-                Span::styled("🔒 ", Style::default().fg(Color::Yellow)),
-                Span::styled(
-                    "Permission Request",
-                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                ),
-                Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
-                Span::styled("⏱️  ", Style::default().fg(time_color)),
-                Span::styled(
-                    format!(
-                        "{}m {}s remaining",
-                        seconds_remaining / 60,
-                        seconds_remaining % 60
-                    ),
-                    Style::default().fg(time_color),
-                ),
-            ]),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled(
-                    format!("{} wants to use the tool: ", model_name),
-                    Style::default().fg(Color::White),
-                ),
-                Span::styled(
-                    &request.tool_name,
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ]),
-            Line::from(""),
-            Line::from(vec![
-                Span::styled("Description: ", Style::default().fg(Color::DarkGray)),
-                Span::styled(&request.tool_description, Style::default().fg(Color::White)),
-            ]),
-            Line::from(""),
-        ];
-
-        // Show capabilities
-        if !request.capabilities.is_empty() {
-            lines.push(Line::from(vec![Span::styled(
-                "⚠️  Capabilities: ",
-                Style::default().fg(Color::Yellow),
-            )]));
-            for cap in &request.capabilities {
-                lines.push(Line::from(vec![
-                    Span::styled("   • ", Style::default().fg(Color::DarkGray)),
-                    Span::styled(cap, Style::default().fg(Color::Red)),
-                ]));
-            }
-            lines.push(Line::from(""));
-        }
-
-        // Show input parameters (basic or detailed)
-        if app.show_approval_details {
-            lines.push(Line::from(vec![Span::styled(
-                "Tool Input (JSON):",
-                Style::default().fg(Color::DarkGray),
-            )]));
-            lines.push(Line::from(""));
-            let json_str = serde_json::to_string_pretty(&request.tool_input)
-                .unwrap_or_else(|_| "{}".to_string());
-            for line in json_str.lines() {
-                lines.push(Line::from(vec![Span::styled(
-                    line.to_string(),
-                    Style::default().fg(Color::Green),
-                )]));
-            }
-            lines.push(Line::from(""));
-        } else {
-            // Show simplified input
-            if let Some(obj) = request.tool_input.as_object() {
-                if !obj.is_empty() {
-                    lines.push(Line::from(vec![Span::styled(
-                        "Parameters: ",
-                        Style::default().fg(Color::DarkGray),
-                    )]));
-                    for (key, value) in obj.iter().take(3) {
-                        let value_str = match value {
-                            serde_json::Value::String(s) => {
-                                if s.len() > 50 {
-                                    format!(
-                                        "\"{}...\"",
-                                        crate::utils::truncate_at_char_boundary(s, 47)
-                                    )
-                                } else {
-                                    format!("\"{}\"", s)
-                                }
-                            }
-                            _ => value.to_string(),
-                        };
-                        lines.push(Line::from(vec![
-                            Span::styled(format!("   {}: ", key), Style::default().fg(Color::Cyan)),
-                            Span::styled(value_str, Style::default().fg(Color::White)),
-                        ]));
-                    }
-                    if obj.len() > 3 {
-                        lines.push(Line::from(vec![
-                            Span::styled("   ... ", Style::default().fg(Color::DarkGray)),
-                            Span::styled(
-                                format!("({} more)", obj.len() - 3),
-                                Style::default().fg(Color::DarkGray),
-                            ),
-                        ]));
-                    }
-                    lines.push(Line::from(""));
-                }
-            }
-        }
-
-        // Show action buttons
-        lines.push(Line::from(""));
-        lines.push(Line::from(vec![
+    vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("🔒 ", Style::default().fg(Color::Yellow)),
             Span::styled(
-                "[A]",
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("pprove  ", Style::default().fg(Color::White)),
-            Span::styled(
-                "[D]",
+                "Permission Request",
                 Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
             ),
-            Span::styled("eny  ", Style::default().fg(Color::White)),
+            Span::styled("  │  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("⏱️  ", Style::default().fg(time_color)),
             Span::styled(
-                "[V]",
+                format!(
+                    "{}m {}s remaining",
+                    seconds_remaining / 60,
+                    seconds_remaining % 60
+                ),
+                Style::default().fg(time_color),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                format!("{} wants to use the tool: ", model_name),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(
+                &request.tool_name,
                 Style::default()
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled("iew Details  ", Style::default().fg(Color::White)),
-            Span::styled(
-                "[Esc]",
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" Cancel", Style::default().fg(Color::White)),
-        ]));
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Description: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&request.tool_description, Style::default().fg(Color::White)),
+        ]),
+        Line::from(""),
+    ]
+}
 
-        let dialog = Paragraph::new(lines)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::Red))
-                    .title(Span::styled(
-                        " ⚠️  PERMISSION REQUIRED ",
-                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                    )),
-            )
-            .alignment(Alignment::Left);
-
-        f.render_widget(dialog, dialog_area);
+/// The "⚠️ Capabilities:" bullet list, empty when the tool declares none.
+fn render_approval_capabilities(request: &super::events::ToolApprovalRequest) -> Vec<Line<'_>> {
+    if request.capabilities.is_empty() {
+        return Vec::new();
     }
+
+    let mut lines = vec![Line::from(vec![Span::styled(
+        "⚠️  Capabilities: ",
+        Style::default().fg(Color::Yellow),
+    )])];
+    for cap in &request.capabilities {
+        lines.push(Line::from(vec![
+            Span::styled("   • ", Style::default().fg(Color::DarkGray)),
+            Span::styled(cap, Style::default().fg(Color::Red)),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines
+}
+
+/// Full pretty-printed JSON of the tool input, used when the user has
+/// toggled "View Details".
+fn render_approval_input_detailed(request: &super::events::ToolApprovalRequest) -> Vec<Line<'_>> {
+    let mut lines = vec![
+        Line::from(vec![Span::styled(
+            "Tool Input (JSON):",
+            Style::default().fg(Color::DarkGray),
+        )]),
+        Line::from(""),
+    ];
+    let json_str =
+        serde_json::to_string_pretty(&request.tool_input).unwrap_or_else(|_| "{}".to_string());
+    for line in json_str.lines() {
+        lines.push(Line::from(vec![Span::styled(
+            line.to_string(),
+            Style::default().fg(Color::Green),
+        )]));
+    }
+    lines.push(Line::from(""));
+    lines
+}
+
+/// The first three tool-input parameters (truncated), used in the compact
+/// (non-detailed) view of the approval dialog.
+fn render_approval_input_summary(request: &super::events::ToolApprovalRequest) -> Vec<Line<'_>> {
+    let Some(obj) = request.tool_input.as_object() else {
+        return Vec::new();
+    };
+    if obj.is_empty() {
+        return Vec::new();
+    }
+
+    let mut lines = vec![Line::from(vec![Span::styled(
+        "Parameters: ",
+        Style::default().fg(Color::DarkGray),
+    )])];
+    for (key, value) in obj.iter().take(3) {
+        let value_str = match value {
+            serde_json::Value::String(s) => {
+                if s.len() > 50 {
+                    format!("\"{}...\"", crate::utils::truncate_at_char_boundary(s, 47))
+                } else {
+                    format!("\"{}\"", s)
+                }
+            }
+            _ => value.to_string(),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("   {}: ", key), Style::default().fg(Color::Cyan)),
+            Span::styled(value_str, Style::default().fg(Color::White)),
+        ]));
+    }
+    if obj.len() > 3 {
+        lines.push(Line::from(vec![
+            Span::styled("   ... ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("({} more)", obj.len() - 3),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines
+}
+
+/// The bottom `[A]pprove [D]eny [V]iew Details [Esc] Cancel` action row.
+fn render_approval_actions() -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            "[A]",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("pprove  ", Style::default().fg(Color::White)),
+        Span::styled(
+            "[D]",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("eny  ", Style::default().fg(Color::White)),
+        Span::styled(
+            "[V]",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("iew Details  ", Style::default().fg(Color::White)),
+        Span::styled(
+            "[Esc]",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Cancel", Style::default().fg(Color::White)),
+    ])
+}
+
+fn render_approval(f: &mut Frame, app: &App, area: Rect) {
+    let Some(ref request) = app.pending_approval else {
+        return;
+    };
+
+    let model_name = app
+        .current_session
+        .as_ref()
+        .and_then(|s| s.model.as_deref())
+        .unwrap_or("AI");
+    let dialog_area = approval_dialog_area(area, app.show_approval_details);
+
+    let mut lines = render_approval_header(request, model_name);
+    lines.extend(render_approval_capabilities(request));
+    if app.show_approval_details {
+        lines.extend(render_approval_input_detailed(request));
+    } else {
+        lines.extend(render_approval_input_summary(request));
+    }
+    lines.push(Line::from(""));
+    lines.push(render_approval_actions());
+
+    let dialog = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Red))
+                .title(Span::styled(
+                    " ⚠️  PERMISSION REQUIRED ",
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                )),
+        )
+        .alignment(Alignment::Left);
+
+    f.render_widget(dialog, dialog_area);
 }
 
 /// Render the file picker


### PR DESCRIPTION
Herald's code-quality scan flagged several 100-500 line functions as a
maintainability risk. Split the worst offenders into small, single-purpose
helpers without changing behavior:

- render_help (505 lines) -> per-section builders (help_row, feature_row,
  help_section_header, help_global_commands/chat_mode/session_list/
  plan_mode/features/footer)
- render_chat (226 lines) -> render_pending_plan_banner, render_message_lines,
  render_thinking_block, render_perf_footer, render_streaming_response,
  render_processing_indicator, compute_scroll_offset
- cmd_chat (223 lines) -> build_tool_registry, connect_configured_mcp_servers,
  build_approval_callback
- render_plan (169 lines) -> render_plan_document, render_plan_task_lines,
  render_plan_empty_state
- render_approval (197 lines) -> approval_dialog_area, render_approval_header/
  capabilities/input_detailed/input_summary/actions
- parse_markdown (187 lines) -> MarkdownRenderer struct encapsulating the
  one-pass accumulator state, with a short method per event type

All 553 unit tests plus integration suites pass unchanged; cargo check and
cargo fmt are clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GGF97KjyfPjdfM9StRdJmM