### PR TITLE
Harden Qwen Hermes tool-call parsing against truncation and malformed JSON

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -600,9 +600,9 @@ fn build_tool_registry() -> crate::llm::tools::registry::ToolRegistry {
         code_exec::CodeExecTool, context::ContextTool, doc_parser::DocParserTool, edit::EditTool,
         glob::GlobTool, grep::GrepTool, http::HttpClientTool, ls::LsTool,
         notebook::NotebookEditTool, plan_tool::PlanTool, powershell::PowerShellTool,
-        read::ReadTool, registry::ToolRegistry, skill::SkillTool, task::TaskTool,
-        todo_write::TodoWriteTool, web_fetch::WebFetchTool, web_search::WebSearchTool,
-        write::WriteTool,
+        read::ReadTool, registry::ToolRegistry, save_memory::SaveMemoryTool, skill::SkillTool,
+        task::TaskTool, todo_write::TodoWriteTool, web_fetch::WebFetchTool,
+        web_search::WebSearchTool, write::WriteTool,
     };
 
     let mut tool_registry = ToolRegistry::new();
@@ -623,6 +623,7 @@ fn build_tool_registry() -> crate::llm::tools::registry::ToolRegistry {
     // Phase 3: Workflow & integration
     tool_registry.register(Arc::new(TaskTool));
     tool_registry.register(Arc::new(ContextTool));
+    tool_registry.register(Arc::new(SaveMemoryTool));
     tool_registry.register(Arc::new(HttpClientTool));
     tool_registry.register(Arc::new(PlanTool));
     // Phase 4: Claw Code parity
@@ -873,18 +874,7 @@ async fn cmd_run(
 ) -> Result<()> {
     use crate::{
         db::Database,
-        llm::{
-            agent::AgentService,
-            tools::{
-                agent::AgentTool, apply_patch::ApplyPatchTool, ask_user::AskUserTool,
-                bash::BashTool, code_exec::CodeExecTool, context::ContextTool,
-                doc_parser::DocParserTool, edit::EditTool, glob::GlobTool, grep::GrepTool,
-                http::HttpClientTool, ls::LsTool, notebook::NotebookEditTool, plan_tool::PlanTool,
-                powershell::PowerShellTool, read::ReadTool, registry::ToolRegistry,
-                skill::SkillTool, task::TaskTool, todo_write::TodoWriteTool,
-                web_fetch::WebFetchTool, web_search::WebSearchTool, write::WriteTool,
-            },
-        },
+        llm::agent::AgentService,
         services::{ServiceContext, SessionService},
     };
 
@@ -897,34 +887,9 @@ async fn cmd_run(
     // Select provider based on configuration using factory
     let provider = crate::llm::provider::create_provider(config)?;
 
-    // Create tool registry
-    let mut tool_registry = ToolRegistry::new();
-    // Phase 1: Essential file operations
-    tool_registry.register(Arc::new(ReadTool));
-    tool_registry.register(Arc::new(WriteTool));
-    tool_registry.register(Arc::new(EditTool));
-    tool_registry.register(Arc::new(ApplyPatchTool));
-    tool_registry.register(Arc::new(BashTool));
-    tool_registry.register(Arc::new(LsTool));
-    tool_registry.register(Arc::new(GlobTool));
-    tool_registry.register(Arc::new(GrepTool));
-    // Phase 2: Advanced features
-    tool_registry.register(Arc::new(WebSearchTool));
-    tool_registry.register(Arc::new(CodeExecTool));
-    tool_registry.register(Arc::new(NotebookEditTool));
-    tool_registry.register(Arc::new(DocParserTool));
-    // Phase 3: Workflow & integration
-    tool_registry.register(Arc::new(TaskTool));
-    tool_registry.register(Arc::new(ContextTool));
-    tool_registry.register(Arc::new(HttpClientTool));
-    tool_registry.register(Arc::new(PlanTool));
-    // Phase 4: Claw Code parity
-    tool_registry.register(Arc::new(WebFetchTool));
-    tool_registry.register(Arc::new(TodoWriteTool));
-    tool_registry.register(Arc::new(AskUserTool));
-    tool_registry.register(Arc::new(SkillTool));
-    tool_registry.register(Arc::new(AgentTool));
-    tool_registry.register(Arc::new(PowerShellTool));
+    // Create tool registry (same built-in set as the interactive chat agent
+    // - see build_tool_registry's doc comment).
+    let mut tool_registry = build_tool_registry();
 
     // Connect to configured MCP servers, same as cmd_chat - see its
     // comment for why this needs to happen at all (config.mcp.servers was
@@ -1552,7 +1517,7 @@ mod tests {
         let registry = build_tool_registry();
 
         // One entry per Phase 1-4 tool registered in build_tool_registry.
-        assert_eq!(registry.count(), 22);
+        assert_eq!(registry.count(), 23);
         for name in [
             "read_file",
             "write_file",
@@ -1568,6 +1533,7 @@ mod tests {
             "parse_document",
             "task_manager",
             "session_context",
+            "save_memory",
             "http_request",
             "plan",
             "web_fetch",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -596,12 +596,13 @@ async fn cmd_db(config: &crate::config::Config, operation: DbCommands) -> Result
 /// `connect_configured_mcp_servers`).
 fn build_tool_registry() -> crate::llm::tools::registry::ToolRegistry {
     use crate::llm::tools::{
-        agent::AgentTool, ask_user::AskUserTool, bash::BashTool, code_exec::CodeExecTool,
-        context::ContextTool, doc_parser::DocParserTool, edit::EditTool, glob::GlobTool,
-        grep::GrepTool, http::HttpClientTool, ls::LsTool, notebook::NotebookEditTool,
-        plan_tool::PlanTool, powershell::PowerShellTool, read::ReadTool, registry::ToolRegistry,
-        skill::SkillTool, task::TaskTool, todo_write::TodoWriteTool, web_fetch::WebFetchTool,
-        web_search::WebSearchTool, write::WriteTool,
+        agent::AgentTool, apply_patch::ApplyPatchTool, ask_user::AskUserTool, bash::BashTool,
+        code_exec::CodeExecTool, context::ContextTool, doc_parser::DocParserTool, edit::EditTool,
+        glob::GlobTool, grep::GrepTool, http::HttpClientTool, ls::LsTool,
+        notebook::NotebookEditTool, plan_tool::PlanTool, powershell::PowerShellTool,
+        read::ReadTool, registry::ToolRegistry, skill::SkillTool, task::TaskTool,
+        todo_write::TodoWriteTool, web_fetch::WebFetchTool, web_search::WebSearchTool,
+        write::WriteTool,
     };
 
     let mut tool_registry = ToolRegistry::new();
@@ -609,6 +610,7 @@ fn build_tool_registry() -> crate::llm::tools::registry::ToolRegistry {
     tool_registry.register(Arc::new(ReadTool));
     tool_registry.register(Arc::new(WriteTool));
     tool_registry.register(Arc::new(EditTool));
+    tool_registry.register(Arc::new(ApplyPatchTool));
     tool_registry.register(Arc::new(BashTool));
     tool_registry.register(Arc::new(LsTool));
     tool_registry.register(Arc::new(GlobTool));
@@ -874,13 +876,13 @@ async fn cmd_run(
         llm::{
             agent::AgentService,
             tools::{
-                agent::AgentTool, ask_user::AskUserTool, bash::BashTool, code_exec::CodeExecTool,
-                context::ContextTool, doc_parser::DocParserTool, edit::EditTool, glob::GlobTool,
-                grep::GrepTool, http::HttpClientTool, ls::LsTool, notebook::NotebookEditTool,
-                plan_tool::PlanTool, powershell::PowerShellTool, read::ReadTool,
-                registry::ToolRegistry, skill::SkillTool, task::TaskTool,
-                todo_write::TodoWriteTool, web_fetch::WebFetchTool, web_search::WebSearchTool,
-                write::WriteTool,
+                agent::AgentTool, apply_patch::ApplyPatchTool, ask_user::AskUserTool,
+                bash::BashTool, code_exec::CodeExecTool, context::ContextTool,
+                doc_parser::DocParserTool, edit::EditTool, glob::GlobTool, grep::GrepTool,
+                http::HttpClientTool, ls::LsTool, notebook::NotebookEditTool, plan_tool::PlanTool,
+                powershell::PowerShellTool, read::ReadTool, registry::ToolRegistry,
+                skill::SkillTool, task::TaskTool, todo_write::TodoWriteTool,
+                web_fetch::WebFetchTool, web_search::WebSearchTool, write::WriteTool,
             },
         },
         services::{ServiceContext, SessionService},
@@ -901,6 +903,7 @@ async fn cmd_run(
     tool_registry.register(Arc::new(ReadTool));
     tool_registry.register(Arc::new(WriteTool));
     tool_registry.register(Arc::new(EditTool));
+    tool_registry.register(Arc::new(ApplyPatchTool));
     tool_registry.register(Arc::new(BashTool));
     tool_registry.register(Arc::new(LsTool));
     tool_registry.register(Arc::new(GlobTool));
@@ -1549,11 +1552,12 @@ mod tests {
         let registry = build_tool_registry();
 
         // One entry per Phase 1-4 tool registered in build_tool_registry.
-        assert_eq!(registry.count(), 21);
+        assert_eq!(registry.count(), 22);
         for name in [
             "read_file",
             "write_file",
             "edit_file",
+            "apply_patch",
             "bash",
             "ls",
             "glob",

--- a/src/llm/agent/service.rs
+++ b/src/llm/agent/service.rs
@@ -11,7 +11,7 @@ use crate::llm::provider::{
     ProviderStream, StopReason, StreamEvent, TokenUsage,
 };
 use crate::llm::tools::cache::{CacheKey, ToolResultCache, ToolTtlConfig};
-use crate::llm::tools::{ToolCapability, ToolExecutionContext, ToolRegistry};
+use crate::llm::tools::{FileReadCache, ToolCapability, ToolExecutionContext, ToolRegistry};
 use crate::services::{MessageService, ServiceContext, SessionService};
 use futures::future::join_all;
 use futures::StreamExt as _;
@@ -101,6 +101,14 @@ pub struct AgentService {
 
     /// Session-scoped tool result cache (T037)
     tool_cache: Arc<ToolResultCache>,
+
+    /// Session-scoped file-read cache backing "prior read" enforcement in
+    /// edit_file/write_file/apply_patch (see `file_read_cache` module
+    /// docs). One `AgentService` instance is one session (matches
+    /// `tool_cache`'s treatment above), so a plain shared field - rather
+    /// than a map keyed by session_id - is enough for reads to persist
+    /// across every `send_message*` call on this instance.
+    file_read_cache: Arc<FileReadCache>,
 
     /// SQLite pool for compaction writes (T032)
     pool: Option<Arc<sqlx::SqlitePool>>,
@@ -349,6 +357,7 @@ impl AgentService {
             working_directory: std::env::current_dir().unwrap_or_default(),
             model_router: None,
             tool_cache: Arc::new(ToolResultCache::new(ToolTtlConfig::default())),
+            file_read_cache: Arc::new(FileReadCache::new()),
             pool: None,
             allow_sub_agents: true,
         }
@@ -703,7 +712,8 @@ impl AgentService {
         let mut tool_context = ToolExecutionContext::new(session_id)
             .with_auto_approve(self.auto_approve_tools)
             .with_working_directory(self.working_directory.clone())
-            .with_read_only_mode(read_only_mode);
+            .with_read_only_mode(read_only_mode)
+            .with_file_read_cache(self.file_read_cache.clone());
         if self.allow_sub_agents {
             let launcher = Arc::new(AgentServiceLauncher::new(
                 self.provider.clone(),
@@ -1196,6 +1206,7 @@ impl AgentService {
                                     timeout_secs: tool_context.timeout_secs,
                                     read_only_mode: tool_context.read_only_mode,
                                     sub_agent_launcher: tool_context.sub_agent_launcher.clone(),
+                                    file_read_cache: tool_context.file_read_cache.clone(),
                                 };
 
                                 // Execute the tool with approved context

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -253,14 +253,33 @@ impl QwenProvider {
                 let tool_call_content = &remaining[start + 11..start + end];
                 let trimmed = tool_call_content.trim();
 
-                // Parse the JSON inside
-                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(trimmed) {
-                    if let (Some(name), Some(arguments)) = (
+                // Parse the JSON inside. Failures are logged rather than
+                // silently dropped: without this, a malformed tool call
+                // vanishes with no trace, and the agent loop sees a model
+                // turn with no tool use and no explanation why.
+                match serde_json::from_str::<serde_json::Value>(trimmed) {
+                    Ok(parsed) => match (
                         parsed.get("name").and_then(|v| v.as_str()),
                         parsed.get("arguments"),
                     ) {
-                        let id = Self::generate_call_id();
-                        tool_calls.push((id, name.to_string(), arguments.clone()));
+                        (Some(name), Some(arguments)) => {
+                            let id = Self::generate_call_id();
+                            tool_calls.push((id, name.to_string(), arguments.clone()));
+                        }
+                        _ => {
+                            tracing::warn!(
+                                "Hermes <tool_call> block parsed as JSON but is missing \
+                                 'name' or 'arguments': {}",
+                                trimmed
+                            );
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to parse Hermes <tool_call> block as JSON: {} (content: {})",
+                            e,
+                            trimmed
+                        );
                     }
                 }
 
@@ -947,7 +966,13 @@ impl QwenProvider {
                         if !hermes_calls.is_empty() {
                             has_tool_calls = true;
 
-                            // Remove tool_call tags from text for display
+                            // Remove tool_call tags from text for display. An
+                            // opening tag with no closing tag (e.g. the
+                            // response was cut off mid-argument by
+                            // max_tokens) has no valid span to remove up to,
+                            // so drop everything from the opening tag to the
+                            // end of the text instead of leaving the raw,
+                            // truncated JSON fragment visible to the user.
                             let mut clean_text = remaining.clone();
                             while let Some(start) = clean_text.find("<tool_call>") {
                                 if let Some(end) = clean_text.find("</tool_call>") {
@@ -957,6 +982,12 @@ impl QwenProvider {
                                         &clean_text[end + 12..]
                                     );
                                 } else {
+                                    tracing::warn!(
+                                        "Dropping truncated <tool_call> block with no closing \
+                                         tag (likely cut off by max_tokens): {}",
+                                        &clean_text[start..]
+                                    );
+                                    clean_text.truncate(start);
                                     break;
                                 }
                             }
@@ -2018,6 +2049,99 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].1, "read_file");
         assert_eq!(calls[1].1, "write_file");
+    }
+
+    /// Malformed JSON inside an otherwise well-formed `<tool_call>` pair must
+    /// not panic, and must not be mistaken for a valid call.
+    #[test]
+    fn test_hermes_malformed_json_is_skipped_without_panicking() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let text = r#"I'll read that file.
+<tool_call>
+{"name": "read_file", "arguments": {path: unquoted}}
+</tool_call>"#;
+
+        let calls = provider.parse_hermes_tool_calls(text);
+        assert!(calls.is_empty());
+    }
+
+    /// JSON that parses but is missing `name`/`arguments` must also be
+    /// skipped rather than crashing or fabricating a call.
+    #[test]
+    fn test_hermes_json_missing_required_fields_is_skipped() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let text = r#"<tool_call>
+{"foo": "bar"}
+</tool_call>"#;
+
+        let calls = provider.parse_hermes_tool_calls(text);
+        assert!(calls.is_empty());
+    }
+
+    /// Regression: a response cut off mid-argument by `max_tokens` (finish_reason
+    /// "length") leaves a `<tool_call>` opening tag with no closing tag. Before
+    /// this fix, `from_qwen_response` would leave that dangling, truncated JSON
+    /// fragment in the displayed text verbatim. An earlier, complete tool call in
+    /// the same response must still be parsed correctly, and the truncated
+    /// fragment must never reach the displayed text.
+    #[test]
+    fn test_from_qwen_response_drops_truncated_trailing_hermes_tag_from_display() {
+        let provider = QwenProvider::local("http://localhost:8000/v1/chat/completions".to_string());
+
+        let content = "First I'll read the file.\n\
+             <tool_call>\n{\"name\": \"read_file\", \"arguments\": {\"path\": \"src/main.rs\"}}\n</tool_call>\n\
+             Now let me write the result.\n\
+             <tool_call>\n{\"name\": \"write_file\", \"arguments\": {\"path\": \"out.txt\", \"content\": \"a very long argument that got cut off mid-stream because max_tokens was reached before the closing tag could be emitted";
+
+        let response = QwenResponse {
+            id: "qwen-truncated-test".to_string(),
+            model: "qwen3-8b".to_string(),
+            choices: vec![QwenChoice {
+                index: 0,
+                message: QwenMessage {
+                    role: "assistant".to_string(),
+                    content: Some(content.to_string()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+                finish_reason: Some("length".to_string()),
+            }],
+            usage: QwenUsage {
+                prompt_tokens: 5,
+                completion_tokens: 10,
+            },
+        };
+
+        let known_tools = vec!["read_file".to_string(), "write_file".to_string()];
+        let llm_response = provider.from_qwen_response(response, &known_tools);
+
+        // The earlier, complete tool call must still be recognized.
+        let names: Vec<String> = llm_response
+            .content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, vec!["read_file"]);
+
+        // No raw tag markup or truncated JSON fragment may leak into the
+        // displayed text.
+        for block in &llm_response.content {
+            if let ContentBlock::Text { text } = block {
+                assert!(
+                    !text.contains("<tool_call>"),
+                    "truncated tool_call tag leaked into displayed text: {text:?}"
+                );
+                assert!(
+                    !text.contains("write_file"),
+                    "truncated tool call's raw JSON leaked into displayed text: {text:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/llm/tools/aliases.rs
+++ b/src/llm/tools/aliases.rs
@@ -44,7 +44,6 @@ pub const TOOL_ALIASES: &[(&str, &str)] = &[
     ("search_file_content", "grep"), // qwen-code's legacy pre-rename name
     ("edit", "edit_file"), // also Claude Code's name for the same tool (case-insensitive match covers `Edit` too)
     ("run_shell_command", "bash"),
-
     // Claude Code's documented/observed tool names. Crustly's own file/
     // search/shell tools were deliberately modeled on these (see
     // CLAUDE.md's "Claw Code parity" phase), so shape already matches.
@@ -59,7 +58,6 @@ pub const TOOL_ALIASES: &[(&str, &str)] = &[
     ("TodoWrite", "todo_write"),
     ("NotebookEdit", "notebook_edit"),
     ("Task", "agent"), // Claude Code's subagent-launch tool; same description/prompt/subagent_type shape as Crustly's `agent`.
-
     // Generic names models commonly reach for regardless of training
     // source, for single-argument tools where a shape mismatch isn't a
     // real risk.

--- a/src/llm/tools/aliases.rs
+++ b/src/llm/tools/aliases.rs
@@ -16,14 +16,16 @@
 //! qwen-code and Crustly's own tool schemas) - a name for a capability
 //! Crustly doesn't implement, or whose input format genuinely differs, is
 //! intentionally left out rather than pointed at something that would
-//! deserialize into nonsense. Two notable omissions:
-//! - qwen-code's `save_memory` - Crustly has no equivalent write-to-memory
-//!   tool (`session_context` is read-only).
-//! - Codex's `apply_patch` - not a renamed `edit_file`. It's a distinct
-//!   multi-file patch-script format (`*** Begin Patch` / `*** Update File:`
-//!   / `@@` hunks / `*** End Patch`); aliasing the name alone would still
-//!   fail because `edit_file` can't parse that payload. Needs its own
-//!   parser tool.
+//! deserialize into nonsense. One notable omission: qwen-code's
+//! `save_memory` - Crustly has no equivalent write-to-memory tool
+//! (`session_context` is read-only).
+//!
+//! Codex's `apply_patch` isn't in this table at all, by design: it's not a
+//! renamed `edit_file`, it's a distinct multi-file patch-script format
+//! (`*** Begin Patch` / `*** Update File:` / `@@` hunks / `*** End Patch`)
+//! that `edit_file` can't parse. It's registered as its own real tool -
+//! `apply_patch.rs` - under the exact name Codex uses, so no alias is
+//! needed.
 pub const TOOL_ALIASES: &[(&str, &str)] = &[
     // qwen-code (packages/core/src/tools/tool-names.ts and per-tool
     // schemas) - verified against source, not guessed. Field-shape

--- a/src/llm/tools/aliases.rs
+++ b/src/llm/tools/aliases.rs
@@ -1,0 +1,135 @@
+//! Tool name aliases.
+//!
+//! Coding agents don't agree on tool names for the same capability, and a
+//! model trained against one agent's tool surface calls it by that agent's
+//! name regardless of which agent is actually running it. `ToolRegistry`
+//! falls back to this table when an exact name match misses, so a call for
+//! e.g. `list_directory` (qwen-code's name for what Crustly calls `ls`)
+//! still resolves instead of failing with `ToolError::NotFound`.
+//!
+//! Entries are `(alias, canonical)`, matched case-insensitively so both
+//! qwen-code's snake_case (`list_directory`) and Claude Code's PascalCase
+//! (`Read`, `TodoWrite`) forms work without listing every case variant.
+//!
+//! Only maps to tools Crustly actually has a real equivalent for, and only
+//! where the argument *shape* also lines up (verified against the source of
+//! qwen-code and Crustly's own tool schemas) - a name for a capability
+//! Crustly doesn't implement, or whose input format genuinely differs, is
+//! intentionally left out rather than pointed at something that would
+//! deserialize into nonsense. Two notable omissions:
+//! - qwen-code's `save_memory` - Crustly has no equivalent write-to-memory
+//!   tool (`session_context` is read-only).
+//! - Codex's `apply_patch` - not a renamed `edit_file`. It's a distinct
+//!   multi-file patch-script format (`*** Begin Patch` / `*** Update File:`
+//!   / `@@` hunks / `*** End Patch`); aliasing the name alone would still
+//!   fail because `edit_file` can't parse that payload. Needs its own
+//!   parser tool.
+pub const TOOL_ALIASES: &[(&str, &str)] = &[
+    // qwen-code (packages/core/src/tools/tool-names.ts and per-tool
+    // schemas) - verified against source, not guessed. Field-shape
+    // compatibility confirmed (and where it wasn't, fixed alongside this
+    // table: edit_file's file_path/old_string/new_string/replace_all,
+    // bash's directory/timeout/description/is_background, grep's glob).
+    ("list_directory", "ls"),
+    ("grep_search", "grep"),
+    ("search_file_content", "grep"), // qwen-code's legacy pre-rename name
+    ("edit", "edit_file"), // also Claude Code's name for the same tool (case-insensitive match covers `Edit` too)
+    ("run_shell_command", "bash"),
+
+    // Claude Code's documented/observed tool names. Crustly's own file/
+    // search/shell tools were deliberately modeled on these (see
+    // CLAUDE.md's "Claw Code parity" phase), so shape already matches.
+    // (`Edit` is covered by the `edit` entry above - case-insensitive.)
+    ("Bash", "bash"),
+    ("Read", "read_file"),
+    ("Write", "write_file"),
+    ("Glob", "glob"),
+    ("Grep", "grep"),
+    ("WebFetch", "web_fetch"),
+    ("WebSearch", "web_search"),
+    ("TodoWrite", "todo_write"),
+    ("NotebookEdit", "notebook_edit"),
+    ("Task", "agent"), // Claude Code's subagent-launch tool; same description/prompt/subagent_type shape as Crustly's `agent`.
+
+    // Generic names models commonly reach for regardless of training
+    // source, for single-argument tools where a shape mismatch isn't a
+    // real risk.
+    ("list_files", "ls"),
+    ("list_dir", "ls"),
+    ("dir", "ls"),
+    ("cat", "read_file"),
+    ("open_file", "read_file"),
+    ("save_file", "write_file"),
+    ("find_files", "glob"),
+    ("rg", "grep"),
+    ("shell", "bash"),
+    ("execute", "bash"),
+    ("run_command", "bash"),
+    ("terminal", "bash"),
+    ("exec", "bash"),
+];
+
+/// Resolve `name` to its canonical tool name via [`TOOL_ALIASES`], matched
+/// case-insensitively. Returns `None` if `name` isn't a known alias -
+/// callers should fall back to treating `name` as already canonical (or
+/// genuinely unknown).
+pub fn resolve(name: &str) -> Option<&'static str> {
+    TOOL_ALIASES
+        .iter()
+        .find(|(alias, _)| alias.eq_ignore_ascii_case(name))
+        .map(|(_, canonical)| *canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_known_qwen_code_alias() {
+        assert_eq!(resolve("list_directory"), Some("ls"));
+    }
+
+    #[test]
+    fn resolves_known_claude_code_alias() {
+        assert_eq!(resolve("TodoWrite"), Some("todo_write"));
+    }
+
+    #[test]
+    fn resolution_is_case_insensitive() {
+        assert_eq!(resolve("LIST_DIRECTORY"), Some("ls"));
+        assert_eq!(resolve("list_Directory"), Some("ls"));
+        assert_eq!(resolve("READ"), Some("read_file"));
+    }
+
+    #[test]
+    fn unknown_name_resolves_to_none() {
+        assert_eq!(resolve("definitely_not_a_real_tool"), None);
+    }
+
+    /// Resolution must be a single hop: an alias's target must not itself
+    /// resolve to something else, or a caller doing one `resolve()` call
+    /// (as `ToolRegistry` does) would stop short of the real tool. A target
+    /// that case-insensitively matches its own alias entry (e.g. `Bash` ->
+    /// `bash`) is fine - that's a no-op, not a chain.
+    #[test]
+    fn alias_resolution_is_a_single_hop() {
+        for (alias, canonical) in TOOL_ALIASES {
+            if let Some(next) = resolve(canonical) {
+                assert!(
+                    next.eq_ignore_ascii_case(canonical),
+                    "alias '{alias}' -> '{canonical}' resolves further to '{next}' - \
+                     resolution must be a single hop"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn no_duplicate_alias_entries() {
+        let mut seen = std::collections::HashSet::new();
+        for (alias, _) in TOOL_ALIASES {
+            let lower = alias.to_ascii_lowercase();
+            assert!(seen.insert(lower), "duplicate alias entry: {alias}");
+        }
+    }
+}

--- a/src/llm/tools/aliases.rs
+++ b/src/llm/tools/aliases.rs
@@ -12,20 +12,27 @@
 //! (`Read`, `TodoWrite`) forms work without listing every case variant.
 //!
 //! Only maps to tools Crustly actually has a real equivalent for, and only
-//! where the argument *shape* also lines up (verified against the source of
-//! qwen-code and Crustly's own tool schemas) - a name for a capability
-//! Crustly doesn't implement, or whose input format genuinely differs, is
-//! intentionally left out rather than pointed at something that would
-//! deserialize into nonsense. One notable omission: qwen-code's
-//! `save_memory` - Crustly has no equivalent write-to-memory tool
-//! (`session_context` is read-only).
+//! where the argument *shape* AND *behavior* also line up (verified against
+//! the source of qwen-code and Crustly's own tool schemas) - a name for a
+//! capability Crustly doesn't implement, or whose input format or semantics
+//! genuinely differ, is intentionally left out rather than pointed at
+//! something that would deserialize fine but quietly do the wrong thing.
 //!
-//! Codex's `apply_patch` isn't in this table at all, by design: it's not a
-//! renamed `edit_file`, it's a distinct multi-file patch-script format
-//! (`*** Begin Patch` / `*** Update File:` / `@@` hunks / `*** End Patch`)
-//! that `edit_file` can't parse. It's registered as its own real tool -
-//! `apply_patch.rs` - under the exact name Codex uses, so no alias is
-//! needed.
+//! Two tools are absent from this table entirely, by design, because they
+//! turned out to need real implementations rather than a rename:
+//! - Codex's `apply_patch` - not a renamed `edit_file`. It's a distinct
+//!   multi-file patch-script format (`*** Begin Patch` / `*** Update File:`
+//!   / `@@` hunks / `*** End Patch`) that `edit_file` can't parse.
+//!   Registered as its own real tool (`apply_patch.rs`) under the exact
+//!   name Codex uses, so no alias is needed.
+//! - qwen-code's `save_memory` - not the same thing as `session_context`'s
+//!   `add_fact` operation, which is scoped to `context_{session_id}.json`
+//!   and disappears once the session ends. `save_memory`'s whole point is
+//!   that the fact outlives the session, so aliasing it to `add_fact` would
+//!   make the call succeed while silently breaking that guarantee.
+//!   Registered as its own real tool (`save_memory.rs`) that persists to a
+//!   working-directory-keyed file instead, so no alias is needed here
+//!   either.
 pub const TOOL_ALIASES: &[(&str, &str)] = &[
     // qwen-code (packages/core/src/tools/tool-names.ts and per-tool
     // schemas) - verified against source, not guessed. Field-shape

--- a/src/llm/tools/apply_patch.rs
+++ b/src/llm/tools/apply_patch.rs
@@ -36,6 +36,7 @@
 //! whitespace-fuzzy hunk matching, and the `*** End of File` hunk marker.
 
 use super::error::{validate_file_path, validate_path_safety, Result, ToolError};
+use super::file_read_cache::{FileFingerprint, ReadGate};
 use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -301,7 +302,8 @@ impl Tool for ApplyPatchTool {
          `@@` hunks with ' ' context, '-' removed, and '+' added lines; may be followed by \
          `*** Move to: <new path>` to rename), then `*** End Patch`. The whole patch is validated \
          against the current file contents before anything is written - if any hunk fails to \
-         match, no files are changed."
+         match, no files are changed. Every `Update File` target must have been read with \
+         read_file at least once in this session first; `Add File`/`Delete File` need no prior read."
     }
 
     fn input_schema(&self) -> Value {
@@ -409,6 +411,31 @@ impl Tool for ApplyPatchTool {
                             return Ok(ToolResult::error(format!("Update File '{path}': {msg}")))
                         }
                     };
+
+                    // Prior-read enforcement (matches Claude Code's/
+                    // qwen-code's edit tools): only applies to Update File,
+                    // not Add File (nothing existing to have read) or
+                    // Delete File (no content is being trusted/modified).
+                    let metadata_before = fs::metadata(&full).await.map_err(ToolError::Io)?;
+                    match context
+                        .file_read_cache
+                        .check(&full, FileFingerprint::of(&metadata_before))
+                    {
+                        ReadGate::NeverRead => {
+                            return Ok(ToolResult::error(format!(
+                                "Update File '{path}': you must read this file with read_file \
+                                 before editing it."
+                            )));
+                        }
+                        ReadGate::Stale => {
+                            return Ok(ToolResult::error(format!(
+                                "Update File '{path}': it has changed on disk since it was \
+                                 last read. Re-read it with read_file before editing."
+                            )));
+                        }
+                        ReadGate::Ok => {}
+                    }
+
                     let original = fs::read_to_string(&full).await.map_err(ToolError::Io)?;
                     let new_content = match apply_hunks(&original, hunks) {
                         Ok(c) => c,
@@ -465,6 +492,16 @@ impl Tool for ApplyPatchTool {
                         fs::create_dir_all(parent).await.map_err(ToolError::Io)?;
                     }
                     fs::write(&path, &content).await.map_err(ToolError::Io)?;
+
+                    // Seed the cache with the post-write fingerprint (new
+                    // file, updated file, or a rename's destination) so a
+                    // follow-up edit in the same session doesn't need an
+                    // intervening re-read.
+                    let metadata_after = fs::metadata(&path).await.map_err(ToolError::Io)?;
+                    context
+                        .file_read_cache
+                        .record(&path, FileFingerprint::of(&metadata_after));
+
                     summary.push(format!("wrote {}", path.display()));
                 }
                 PlannedAction::Delete { path } => {
@@ -490,6 +527,20 @@ mod tests {
     fn context(temp_dir: &TempDir) -> ToolExecutionContext {
         ToolExecutionContext::new(Uuid::new_v4())
             .with_working_directory(temp_dir.path().to_path_buf())
+    }
+
+    /// A context with `relative_path` already recorded in the file-read
+    /// cache, simulating "the model read this file earlier in the
+    /// session" - needed before any `Update File` op, which (like
+    /// edit_file) requires a prior read. `Add`/`Delete File` need no such
+    /// seeding.
+    async fn seeded_context(temp_dir: &TempDir, relative_path: &str) -> ToolExecutionContext {
+        let ctx = context(temp_dir);
+        let full_path = temp_dir.path().join(relative_path);
+        let metadata = fs::metadata(&full_path).await.unwrap();
+        ctx.file_read_cache
+            .record(&full_path, FileFingerprint::of(&metadata));
+        ctx
     }
 
     #[test]
@@ -605,7 +656,10 @@ mod tests {
             "input": "*** Begin Patch\n*** Update File: a.txt\n@@\n-hello\n+goodbye\n world\n*** End Patch"
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "a.txt").await)
+            .await
+            .unwrap();
         assert!(result.success, "{:?}", result.error);
         let contents = tokio::fs::read_to_string(temp_dir.path().join("a.txt"))
             .await
@@ -681,7 +735,10 @@ mod tests {
             "input": "*** Begin Patch\n*** Update File: old.txt\n*** Move to: new.txt\n@@\n-content\n+updated\n*** End Patch"
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "old.txt").await)
+            .await
+            .unwrap();
         assert!(result.success, "{:?}", result.error);
         assert!(!temp_dir.path().join("old.txt").exists());
         assert_eq!(
@@ -711,7 +768,10 @@ mod tests {
                  *** End Patch"
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "update.txt").await)
+            .await
+            .unwrap();
         assert!(result.success, "{:?}", result.error);
         assert!(temp_dir.path().join("add.txt").exists());
         assert!(!temp_dir.path().join("delete.txt").exists());
@@ -746,7 +806,14 @@ mod tests {
                  *** End Patch"
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let ctx = seeded_context(&temp_dir, "first.txt").await;
+        let metadata = fs::metadata(temp_dir.path().join("second.txt"))
+            .await
+            .unwrap();
+        ctx.file_read_cache
+            .record(&temp_dir.path().join("second.txt"), FileFingerprint::of(&metadata));
+
+        let result = tool.execute(input, &ctx).await.unwrap();
         assert!(!result.success);
         // Neither file may have been modified.
         assert_eq!(
@@ -789,5 +856,50 @@ mod tests {
         let tool = ApplyPatchTool;
         let input = serde_json::json!({ "input": "not a patch at all" });
         assert!(tool.validate_input(&input).is_err());
+    }
+
+    /// Regression: Update File must not blindly rewrite a file this
+    /// session never read - matches edit_file's own prior-read enforcement.
+    #[tokio::test]
+    async fn execute_update_rejects_a_file_never_read_this_session() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("a.txt"), "hello\n")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n*** Update File: a.txt\n@@\n-hello\n+goodbye\n*** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("must read"));
+        assert_eq!(
+            tokio::fs::read_to_string(temp_dir.path().join("a.txt"))
+                .await
+                .unwrap(),
+            "hello\n"
+        );
+    }
+
+    /// Add File and Delete File need no prior read - only Update File does.
+    #[tokio::test]
+    async fn execute_add_and_delete_need_no_prior_read() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("gone.txt"), "bye")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n\
+                 *** Add File: new.txt\n+hi\n\
+                 *** Delete File: gone.txt\n\
+                 *** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
     }
 }

--- a/src/llm/tools/apply_patch.rs
+++ b/src/llm/tools/apply_patch.rs
@@ -1,0 +1,793 @@
+//! Apply Patch Tool (Codex-compatible)
+//!
+//! Implements OpenAI Codex's `apply_patch` tool: a single string argument
+//! containing a custom multi-file patch script (verified against
+//! `codex-rs/apply-patch/src/lib.rs`), distinct from `edit_file`'s
+//! old_string/new_string format:
+//!
+//! ```text
+//! *** Begin Patch
+//! *** Update File: path/to/file.rs
+//! *** Move to: path/to/renamed.rs
+//! @@ optional context marker (e.g. a function name), purely for readability
+//!  unchanged context line
+//! -line to remove
+//! +line to add
+//!  unchanged context line
+//! *** Add File: path/to/new_file.rs
+//! +line of the new file
+//! +another line
+//! *** Delete File: path/to/old_file.rs
+//! *** End Patch
+//! ```
+//!
+//! A single call may touch multiple files. `Update File` hunks are matched
+//! by content (the contiguous run of context + removed lines), not line
+//! numbers - the same context-based matching `edit_file`'s `old_string`
+//! uses, just scoped to a hunk instead of the whole file. All hunks across
+//! all files are validated (and, for updates, matched against their
+//! target's current content) before anything is written, so a patch either
+//! applies completely or leaves the filesystem untouched - a model that
+//! sends a five-file patch shouldn't end up with three files changed and
+//! two left stale because hunk four didn't match.
+//!
+//! Deliberately not implemented (real Codex patches rarely need them, and
+//! getting them wrong silently would be worse than not having them):
+//! whitespace-fuzzy hunk matching, and the `*** End of File` hunk marker.
+
+use super::error::{validate_file_path, validate_path_safety, Result, ToolError};
+use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::PathBuf;
+use tokio::fs;
+
+pub struct ApplyPatchTool;
+
+#[derive(Debug, Deserialize)]
+struct ApplyPatchInput {
+    /// The entire patch script, including the `*** Begin Patch`/`*** End Patch` wrapper.
+    input: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HunkLine {
+    Context(String),
+    Remove(String),
+    Add(String),
+}
+
+#[derive(Debug, Clone, Default)]
+struct Hunk {
+    lines: Vec<HunkLine>,
+}
+
+#[derive(Debug, Clone)]
+enum FileOp {
+    Add {
+        path: String,
+        content: String,
+    },
+    Delete {
+        path: String,
+    },
+    Update {
+        path: String,
+        move_to: Option<String>,
+        hunks: Vec<Hunk>,
+    },
+}
+
+const BEGIN: &str = "*** Begin Patch";
+const END: &str = "*** End Patch";
+const ADD_PREFIX: &str = "*** Add File: ";
+const DELETE_PREFIX: &str = "*** Delete File: ";
+const UPDATE_PREFIX: &str = "*** Update File: ";
+const MOVE_PREFIX: &str = "*** Move to: ";
+
+/// Parse a full `*** Begin Patch` ... `*** End Patch` script into a list of
+/// file operations, in the order they appear.
+fn parse_patch(text: &str) -> std::result::Result<Vec<FileOp>, String> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() && lines[i].trim().is_empty() {
+        i += 1;
+    }
+    if i >= lines.len() || lines[i].trim() != BEGIN {
+        return Err(format!("Patch must start with '{BEGIN}'"));
+    }
+    i += 1;
+
+    let mut ops = Vec::new();
+
+    loop {
+        while i < lines.len() && lines[i].trim().is_empty() {
+            i += 1;
+        }
+        if i >= lines.len() {
+            return Err(format!("Patch is missing the closing '{END}' marker"));
+        }
+        if lines[i].trim() == END {
+            break;
+        }
+
+        if let Some(path) = lines[i].strip_prefix(ADD_PREFIX) {
+            let path = path.trim().to_string();
+            i += 1;
+            let mut content_lines = Vec::new();
+            while i < lines.len() && !lines[i].starts_with("*** ") {
+                let l = lines[i];
+                if let Some(rest) = l.strip_prefix('+') {
+                    content_lines.push(rest.to_string());
+                } else if l.is_empty() {
+                    content_lines.push(String::new());
+                } else {
+                    return Err(format!(
+                        "Add File '{path}' body line must start with '+': {l:?}"
+                    ));
+                }
+                i += 1;
+            }
+            ops.push(FileOp::Add {
+                path,
+                content: content_lines.join("\n"),
+            });
+        } else if let Some(path) = lines[i].strip_prefix(DELETE_PREFIX) {
+            let path = path.trim().to_string();
+            i += 1;
+            ops.push(FileOp::Delete { path });
+        } else if let Some(path) = lines[i].strip_prefix(UPDATE_PREFIX) {
+            let path = path.trim().to_string();
+            i += 1;
+
+            let move_to = if i < lines.len() {
+                lines[i]
+                    .strip_prefix(MOVE_PREFIX)
+                    .map(|p| p.trim().to_string())
+            } else {
+                None
+            };
+            if move_to.is_some() {
+                i += 1;
+            }
+
+            let mut hunks = Vec::new();
+            while i < lines.len() && !lines[i].starts_with("*** ") {
+                if !lines[i].starts_with("@@") {
+                    return Err(format!(
+                        "Update File '{path}': expected a '@@' hunk header, got {:?}",
+                        lines[i]
+                    ));
+                }
+                i += 1;
+                let mut hunk = Hunk::default();
+                while i < lines.len() && !lines[i].starts_with("@@") && !lines[i].starts_with("*** ")
+                {
+                    let l = lines[i];
+                    if let Some(rest) = l.strip_prefix('+') {
+                        hunk.lines.push(HunkLine::Add(rest.to_string()));
+                    } else if let Some(rest) = l.strip_prefix('-') {
+                        hunk.lines.push(HunkLine::Remove(rest.to_string()));
+                    } else if let Some(rest) = l.strip_prefix(' ') {
+                        hunk.lines.push(HunkLine::Context(rest.to_string()));
+                    } else if l.is_empty() {
+                        hunk.lines.push(HunkLine::Context(String::new()));
+                    } else {
+                        return Err(format!(
+                            "Update File '{path}': hunk line must start with ' ', '-', or '+': {l:?}"
+                        ));
+                    }
+                    i += 1;
+                }
+                if hunk.lines.is_empty() {
+                    return Err(format!("Update File '{path}': empty hunk"));
+                }
+                hunks.push(hunk);
+            }
+            if hunks.is_empty() {
+                return Err(format!(
+                    "Update File '{path}' has no hunks (expected at least one '@@' block)"
+                ));
+            }
+            ops.push(FileOp::Update {
+                path,
+                move_to,
+                hunks,
+            });
+        } else {
+            return Err(format!(
+                "Expected '*** Add File:', '*** Delete File:', '*** Update File:', or '{END}', got: {:?}",
+                lines[i]
+            ));
+        }
+    }
+
+    if ops.is_empty() {
+        return Err("Patch contains no file operations".to_string());
+    }
+
+    Ok(ops)
+}
+
+/// Find `needle` as a contiguous run within `haystack`, searching from
+/// `start` onward (hunks within one file are matched in order, so later
+/// hunks never match earlier text).
+fn find_subsequence(haystack: &[String], needle: &[&str], start: usize) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(start.min(haystack.len()));
+    }
+    if start + needle.len() > haystack.len() {
+        return None;
+    }
+    (start..=haystack.len() - needle.len())
+        .find(|&pos| (0..needle.len()).all(|k| haystack[pos + k] == needle[k]))
+}
+
+/// Apply a sequence of hunks to `original`, returning the new content.
+/// Hunks are applied in order, each searched for starting at the position
+/// the previous hunk's replacement ended - so identical text appearing
+/// earlier in the file is never matched by a later hunk.
+fn apply_hunks(original: &str, hunks: &[Hunk]) -> std::result::Result<String, String> {
+    let mut lines: Vec<String> = original.lines().map(String::from).collect();
+    let had_trailing_newline = original.is_empty() || original.ends_with('\n');
+    let mut cursor = 0usize;
+
+    for (idx, hunk) in hunks.iter().enumerate() {
+        let old_seq: Vec<&str> = hunk
+            .lines
+            .iter()
+            .filter_map(|l| match l {
+                HunkLine::Context(s) | HunkLine::Remove(s) => Some(s.as_str()),
+                HunkLine::Add(_) => None,
+            })
+            .collect();
+        let new_seq: Vec<String> = hunk
+            .lines
+            .iter()
+            .filter_map(|l| match l {
+                HunkLine::Context(s) => Some(s.clone()),
+                HunkLine::Add(s) => Some(s.clone()),
+                HunkLine::Remove(_) => None,
+            })
+            .collect();
+
+        if old_seq.is_empty() {
+            // Pure insertion (no context/removed lines) - insert at cursor.
+            for (offset, s) in new_seq.iter().enumerate() {
+                lines.insert(cursor + offset, s.clone());
+            }
+            cursor += new_seq.len();
+            continue;
+        }
+
+        let pos = find_subsequence(&lines, &old_seq, cursor).ok_or_else(|| {
+            format!(
+                "hunk #{} could not be matched (its context/removed lines were not found \
+                 in order from where the previous hunk left off)",
+                idx + 1
+            )
+        })?;
+
+        lines.splice(pos..pos + old_seq.len(), new_seq.iter().cloned());
+        cursor = pos + new_seq.len();
+    }
+
+    let mut result = lines.join("\n");
+    if had_trailing_newline && !result.is_empty() {
+        result.push('\n');
+    }
+    Ok(result)
+}
+
+/// A validated, ready-to-apply filesystem action, computed in a read-only
+/// pass over every operation in the patch before anything is written.
+enum PlannedAction {
+    Write { path: PathBuf, content: String },
+    Delete { path: PathBuf },
+}
+
+#[async_trait]
+impl Tool for ApplyPatchTool {
+    fn name(&self) -> &str {
+        "apply_patch"
+    }
+
+    fn description(&self) -> &str {
+        "Apply a multi-file patch (OpenAI Codex's apply_patch format). The `input` argument is \
+         the entire patch script: `*** Begin Patch`, one or more `*** Add File: <path>` / \
+         `*** Delete File: <path>` / `*** Update File: <path>` sections (Update sections contain \
+         `@@` hunks with ' ' context, '-' removed, and '+' added lines; may be followed by \
+         `*** Move to: <new path>` to rename), then `*** End Patch`. The whole patch is validated \
+         against the current file contents before anything is written - if any hunk fails to \
+         match, no files are changed."
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "input": {
+                    "type": "string",
+                    "description": "The entire apply_patch script, including the '*** Begin Patch' / '*** End Patch' wrapper."
+                }
+            },
+            "required": ["input"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![
+            ToolCapability::ReadFiles,
+            ToolCapability::WriteFiles,
+            ToolCapability::SystemModification,
+        ]
+    }
+
+    fn requires_approval(&self) -> bool {
+        true
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<()> {
+        let input: ApplyPatchInput = serde_json::from_value(input.clone())
+            .map_err(|e| ToolError::InvalidInput(format!("Invalid input: {}", e)))?;
+        parse_patch(&input.input).map_err(ToolError::InvalidInput)?;
+        Ok(())
+    }
+
+    async fn execute(&self, input: Value, context: &ToolExecutionContext) -> Result<ToolResult> {
+        if context.read_only_mode {
+            return Ok(ToolResult::error(
+                "apply_patch is not allowed in Plan mode. Please approve the plan and switch to \
+                 execution mode (Ctrl+A) to modify files."
+                    .to_string(),
+            ));
+        }
+
+        let input: ApplyPatchInput = serde_json::from_value(input)?;
+        let ops = match parse_patch(&input.input) {
+            Ok(ops) => ops,
+            Err(msg) => return Ok(ToolResult::error(format!("Invalid patch: {msg}"))),
+        };
+
+        // Phase 1: validate every operation and compute its resulting
+        // content without writing anything, so a bad hunk in file N of an
+        // N-file patch can't leave files 1..N-1 already modified.
+        let mut planned = Vec::with_capacity(ops.len());
+        for op in &ops {
+            match op {
+                FileOp::Add { path, content } => {
+                    if let Err(reason) =
+                        crate::llm::tools::sandbox::check_path(path, &context.working_directory)
+                    {
+                        return Ok(ToolResult::error(reason));
+                    }
+                    let full = match validate_path_safety(path, &context.working_directory) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            return Ok(ToolResult::error(format!("Add File '{path}': {e}")))
+                        }
+                    };
+                    if full.exists() {
+                        return Ok(ToolResult::error(format!(
+                            "Add File '{path}': already exists - use Update File to modify it"
+                        )));
+                    }
+                    planned.push(PlannedAction::Write {
+                        path: full,
+                        content: content.clone(),
+                    });
+                }
+                FileOp::Delete { path } => {
+                    if let Err(reason) =
+                        crate::llm::tools::sandbox::check_path(path, &context.working_directory)
+                    {
+                        return Ok(ToolResult::error(reason));
+                    }
+                    let full = match validate_file_path(path, &context.working_directory) {
+                        Ok(p) => p,
+                        Err(msg) => {
+                            return Ok(ToolResult::error(format!("Delete File '{path}': {msg}")))
+                        }
+                    };
+                    planned.push(PlannedAction::Delete { path: full });
+                }
+                FileOp::Update {
+                    path,
+                    move_to,
+                    hunks,
+                } => {
+                    if let Err(reason) =
+                        crate::llm::tools::sandbox::check_path(path, &context.working_directory)
+                    {
+                        return Ok(ToolResult::error(reason));
+                    }
+                    let full = match validate_file_path(path, &context.working_directory) {
+                        Ok(p) => p,
+                        Err(msg) => {
+                            return Ok(ToolResult::error(format!("Update File '{path}': {msg}")))
+                        }
+                    };
+                    let original = fs::read_to_string(&full).await.map_err(ToolError::Io)?;
+                    let new_content = match apply_hunks(&original, hunks) {
+                        Ok(c) => c,
+                        Err(msg) => {
+                            return Ok(ToolResult::error(format!("Update File '{path}': {msg}")))
+                        }
+                    };
+
+                    match move_to {
+                        Some(new_path) => {
+                            if let Err(reason) = crate::llm::tools::sandbox::check_path(
+                                new_path,
+                                &context.working_directory,
+                            ) {
+                                return Ok(ToolResult::error(reason));
+                            }
+                            let new_full =
+                                match validate_path_safety(new_path, &context.working_directory) {
+                                    Ok(p) => p,
+                                    Err(e) => {
+                                        return Ok(ToolResult::error(format!(
+                                            "Update File '{path}' Move to '{new_path}': {e}"
+                                        )))
+                                    }
+                                };
+                            if new_full.exists() {
+                                return Ok(ToolResult::error(format!(
+                                    "Update File '{path}' Move to '{new_path}': target already exists"
+                                )));
+                            }
+                            planned.push(PlannedAction::Delete { path: full });
+                            planned.push(PlannedAction::Write {
+                                path: new_full,
+                                content: new_content,
+                            });
+                        }
+                        None => {
+                            planned.push(PlannedAction::Write {
+                                path: full,
+                                content: new_content,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // Phase 2: everything validated - apply it.
+        let mut summary = Vec::with_capacity(planned.len());
+        for action in planned {
+            match action {
+                PlannedAction::Write { path, content } => {
+                    if let Some(parent) = path.parent() {
+                        fs::create_dir_all(parent).await.map_err(ToolError::Io)?;
+                    }
+                    fs::write(&path, &content).await.map_err(ToolError::Io)?;
+                    summary.push(format!("wrote {}", path.display()));
+                }
+                PlannedAction::Delete { path } => {
+                    fs::remove_file(&path).await.map_err(ToolError::Io)?;
+                    summary.push(format!("deleted {}", path.display()));
+                }
+            }
+        }
+
+        Ok(ToolResult::success(format!(
+            "Applied patch:\n{}",
+            summary.join("\n")
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    fn context(temp_dir: &TempDir) -> ToolExecutionContext {
+        ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf())
+    }
+
+    #[test]
+    fn parse_rejects_missing_begin_marker() {
+        let err = parse_patch("*** Update File: a.txt\n*** End Patch").unwrap_err();
+        assert!(err.contains("Begin Patch"));
+    }
+
+    #[test]
+    fn parse_rejects_missing_end_marker() {
+        let err = parse_patch("*** Begin Patch\n*** Add File: a.txt\n+hi").unwrap_err();
+        assert!(err.contains("End Patch"));
+    }
+
+    #[test]
+    fn parse_add_file_collects_plus_prefixed_lines() {
+        let text = "*** Begin Patch\n*** Add File: a.txt\n+line one\n+line two\n*** End Patch";
+        let ops = parse_patch(text).unwrap();
+        match &ops[0] {
+            FileOp::Add { path, content } => {
+                assert_eq!(path, "a.txt");
+                assert_eq!(content, "line one\nline two");
+            }
+            other => panic!("expected Add, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_multiple_file_ops_in_one_patch() {
+        let text = "*** Begin Patch\n\
+             *** Add File: new.txt\n+hello\n\
+             *** Delete File: old.txt\n\
+             *** Update File: existing.txt\n@@\n-old\n+new\n\
+             *** End Patch";
+        let ops = parse_patch(text).unwrap();
+        assert_eq!(ops.len(), 3);
+        assert!(matches!(&ops[0], FileOp::Add { .. }));
+        assert!(matches!(&ops[1], FileOp::Delete { .. }));
+        assert!(matches!(&ops[2], FileOp::Update { .. }));
+    }
+
+    #[test]
+    fn parse_update_with_move_to() {
+        let text =
+            "*** Begin Patch\n*** Update File: old.txt\n*** Move to: new.txt\n@@\n-a\n+b\n*** End Patch";
+        let ops = parse_patch(text).unwrap();
+        match &ops[0] {
+            FileOp::Update { path, move_to, .. } => {
+                assert_eq!(path, "old.txt");
+                assert_eq!(move_to.as_deref(), Some("new.txt"));
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_hunks_replaces_matched_context() {
+        let original = "one\ntwo\nthree\n";
+        let hunks = vec![Hunk {
+            lines: vec![
+                HunkLine::Context("one".to_string()),
+                HunkLine::Remove("two".to_string()),
+                HunkLine::Add("TWO".to_string()),
+                HunkLine::Context("three".to_string()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "one\nTWO\nthree\n");
+    }
+
+    #[test]
+    fn apply_hunks_second_hunk_searches_after_first() {
+        // "dup" appears twice; two hunks target each occurrence in order.
+        let original = "dup\na\ndup\nb\n";
+        let hunks = vec![
+            Hunk {
+                lines: vec![
+                    HunkLine::Remove("dup".to_string()),
+                    HunkLine::Add("FIRST".to_string()),
+                ],
+            },
+            Hunk {
+                lines: vec![
+                    HunkLine::Context("a".to_string()),
+                    HunkLine::Remove("dup".to_string()),
+                    HunkLine::Add("SECOND".to_string()),
+                ],
+            },
+        ];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "FIRST\na\nSECOND\nb\n");
+    }
+
+    #[test]
+    fn apply_hunks_errors_when_context_not_found() {
+        let original = "one\ntwo\nthree\n";
+        let hunks = vec![Hunk {
+            lines: vec![HunkLine::Remove("nonexistent".to_string())],
+        }];
+        let err = apply_hunks(original, &hunks).unwrap_err();
+        assert!(err.contains("hunk #1"));
+    }
+
+    #[tokio::test]
+    async fn execute_updates_an_existing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("a.txt"), "hello\nworld\n")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n*** Update File: a.txt\n@@\n-hello\n+goodbye\n world\n*** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        let contents = tokio::fs::read_to_string(temp_dir.path().join("a.txt"))
+            .await
+            .unwrap();
+        assert_eq!(contents, "goodbye\nworld\n");
+    }
+
+    #[tokio::test]
+    async fn execute_adds_a_new_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n*** Add File: new.txt\n+line one\n+line two\n*** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        let contents = tokio::fs::read_to_string(temp_dir.path().join("new.txt"))
+            .await
+            .unwrap();
+        assert_eq!(contents, "line one\nline two");
+    }
+
+    #[tokio::test]
+    async fn execute_add_file_that_already_exists_fails() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("exists.txt"), "already here")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n*** Add File: exists.txt\n+new content\n*** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("already exists"));
+        // Must not have overwritten the file.
+        assert_eq!(
+            tokio::fs::read_to_string(temp_dir.path().join("exists.txt"))
+                .await
+                .unwrap(),
+            "already here"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_deletes_a_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("gone.txt");
+        tokio::fs::write(&path, "bye").await.unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n*** Delete File: gone.txt\n*** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn execute_renames_via_move_to() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("old.txt"), "content\n")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n*** Update File: old.txt\n*** Move to: new.txt\n@@\n-content\n+updated\n*** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(!temp_dir.path().join("old.txt").exists());
+        assert_eq!(
+            tokio::fs::read_to_string(temp_dir.path().join("new.txt"))
+                .await
+                .unwrap(),
+            "updated\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_applies_multiple_file_ops_in_one_patch() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("update.txt"), "before\n")
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("delete.txt"), "x")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n\
+                 *** Add File: add.txt\n+new\n\
+                 *** Delete File: delete.txt\n\
+                 *** Update File: update.txt\n@@\n-before\n+after\n\
+                 *** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(temp_dir.path().join("add.txt").exists());
+        assert!(!temp_dir.path().join("delete.txt").exists());
+        assert_eq!(
+            tokio::fs::read_to_string(temp_dir.path().join("update.txt"))
+                .await
+                .unwrap(),
+            "after\n"
+        );
+    }
+
+    /// Regression: a patch touching multiple files where a later hunk
+    /// fails to match must leave EVERY file untouched, not just the one
+    /// that failed - otherwise a partially-applied multi-file patch leaves
+    /// the tree in a state the model never asked for and doesn't know
+    /// about.
+    #[tokio::test]
+    async fn execute_is_atomic_across_files_on_failure() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("first.txt"), "before\n")
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("second.txt"), "unrelated\n")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n\
+                 *** Update File: first.txt\n@@\n-before\n+after\n\
+                 *** Update File: second.txt\n@@\n-this text does not exist\n+replacement\n\
+                 *** End Patch"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(!result.success);
+        // Neither file may have been modified.
+        assert_eq!(
+            tokio::fs::read_to_string(temp_dir.path().join("first.txt"))
+                .await
+                .unwrap(),
+            "before\n",
+            "first.txt must be untouched when a later hunk in the same patch fails"
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(temp_dir.path().join("second.txt"))
+                .await
+                .unwrap(),
+            "unrelated\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_blocked_in_read_only_mode() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("a.txt"), "x\n")
+            .await
+            .unwrap();
+
+        let tool = ApplyPatchTool;
+        let mut ctx = context(&temp_dir);
+        ctx.read_only_mode = true;
+
+        let input = serde_json::json!({
+            "input": "*** Begin Patch\n*** Update File: a.txt\n@@\n-x\n+y\n*** End Patch"
+        });
+
+        let result = tool.execute(input, &ctx).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Plan mode"));
+    }
+
+    #[test]
+    fn validate_input_rejects_malformed_patch() {
+        let tool = ApplyPatchTool;
+        let input = serde_json::json!({ "input": "not a patch at all" });
+        assert!(tool.validate_input(&input).is_err());
+    }
+}

--- a/src/llm/tools/apply_patch.rs
+++ b/src/llm/tools/apply_patch.rs
@@ -164,7 +164,9 @@ fn parse_patch(text: &str) -> std::result::Result<Vec<FileOp>, String> {
                 }
                 i += 1;
                 let mut hunk = Hunk::default();
-                while i < lines.len() && !lines[i].starts_with("@@") && !lines[i].starts_with("*** ")
+                while i < lines.len()
+                    && !lines[i].starts_with("@@")
+                    && !lines[i].starts_with("*** ")
                 {
                     let l = lines[i];
                     if let Some(rest) = l.strip_prefix('+') {
@@ -367,9 +369,7 @@ impl Tool for ApplyPatchTool {
                     }
                     let full = match validate_path_safety(path, &context.working_directory) {
                         Ok(p) => p,
-                        Err(e) => {
-                            return Ok(ToolResult::error(format!("Add File '{path}': {e}")))
-                        }
+                        Err(e) => return Ok(ToolResult::error(format!("Add File '{path}': {e}"))),
                     };
                     if full.exists() {
                         return Ok(ToolResult::error(format!(
@@ -810,8 +810,10 @@ mod tests {
         let metadata = fs::metadata(temp_dir.path().join("second.txt"))
             .await
             .unwrap();
-        ctx.file_read_cache
-            .record(&temp_dir.path().join("second.txt"), FileFingerprint::of(&metadata));
+        ctx.file_read_cache.record(
+            &temp_dir.path().join("second.txt"),
+            FileFingerprint::of(&metadata),
+        );
 
         let result = tool.execute(input, &ctx).await.unwrap();
         assert!(!result.success);

--- a/src/llm/tools/bash.rs
+++ b/src/llm/tools/bash.rs
@@ -79,14 +79,44 @@ fn resolve_shell() -> (String, &'static str) {
 /// Bash execution tool
 pub struct BashTool;
 
+/// Maximum per-call timeout override, in milliseconds. Matches qwen-code's
+/// `run_shell_command` documented maximum (600000ms / 10 minutes), so a
+/// value copied from a qwen-code-trained model's tool call behaves the same
+/// way here rather than being silently capped to something else.
+const MAX_TIMEOUT_OVERRIDE_MS: u64 = 600_000;
+
 #[derive(Debug, Deserialize, Serialize)]
 struct BashInput {
     /// Command to execute
     command: String,
 
-    /// Optional working directory (overrides context)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Optional working directory (overrides context). Accepts `directory`
+    /// as an alias - the field name sent by qwen-code's `run_shell_command`
+    /// tool.
+    #[serde(alias = "directory", skip_serializing_if = "Option::is_none")]
     working_dir: Option<String>,
+
+    /// Optional per-call timeout override in milliseconds, matching
+    /// qwen-code's `run_shell_command` field of the same name. Overrides
+    /// `context.timeout_secs` when present; capped at
+    /// [`MAX_TIMEOUT_OVERRIDE_MS`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout: Option<u64>,
+
+    /// Optional human-readable description of the command, matching
+    /// qwen-code's `run_shell_command` field of the same name. Logged for
+    /// debuggability; has no effect on execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+
+    /// Matches qwen-code's `run_shell_command` field of the same name.
+    /// Crustly does not yet implement real background execution (that
+    /// needs a process registry this tool doesn't have) - when set, the
+    /// command still runs synchronously and the result says so, rather
+    /// than silently ignoring the model's intent and leaving a long-running
+    /// process (e.g. a dev server) to simply time out with no explanation.
+    #[serde(default)]
+    is_background: bool,
 }
 
 /// Check if a bash command is safe for read-only mode (Plan mode)
@@ -221,7 +251,23 @@ impl Tool for BashTool {
                 },
                 "working_dir": {
                     "type": "string",
-                    "description": "Optional: Working directory for command execution"
+                    "description": "Optional: Working directory for command execution. Alias: directory."
+                },
+                "directory": {
+                    "type": "string",
+                    "description": "Alias of 'working_dir'."
+                },
+                "timeout": {
+                    "type": "number",
+                    "description": "Optional timeout override in milliseconds (max 600000)."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional: Brief description of the command, for logging. Has no effect on execution."
+                },
+                "is_background": {
+                    "type": "boolean",
+                    "description": "Optional: intended for long-running background processes. Not yet supported - the command still runs synchronously and the result notes this."
                 }
             },
             "required": ["command"]
@@ -281,6 +327,18 @@ impl Tool for BashTool {
             )));
         }
 
+        if let Some(ref desc) = input.description {
+            tracing::debug!("bash: {}", desc);
+        }
+
+        // A per-call override (qwen-code's `run_shell_command` field) takes
+        // precedence over the context default, capped at
+        // MAX_TIMEOUT_OVERRIDE_MS the same way qwen-code documents.
+        let timeout_secs = input
+            .timeout
+            .map(|ms| ms.clamp(1000, MAX_TIMEOUT_OVERRIDE_MS) / 1000)
+            .unwrap_or(context.timeout_secs);
+
         // Pick the shell. This tool is advertised to the model as `bash`, and
         // models accordingly emit POSIX (`ls -la`, `grep -r`, pipelines). On
         // Windows those must not be handed to `cmd.exe`, which understands none
@@ -296,8 +354,7 @@ impl Tool for BashTool {
             .current_dir(&working_dir)
             .output();
 
-        let output = match timeout(Duration::from_secs(context.timeout_secs), command_future).await
-        {
+        let output = match timeout(Duration::from_secs(timeout_secs), command_future).await {
             Ok(Ok(output)) => output,
             Ok(Err(e)) => {
                 return Ok(ToolResult::error(format!(
@@ -306,7 +363,7 @@ impl Tool for BashTool {
                 )));
             }
             Err(_) => {
-                return Err(ToolError::Timeout(context.timeout_secs));
+                return Err(ToolError::Timeout(timeout_secs));
             }
         };
 
@@ -317,6 +374,14 @@ impl Tool for BashTool {
 
         // Build output message
         let mut result_text = String::new();
+
+        if input.is_background {
+            result_text.push_str(
+                "NOTE: is_background was requested, but Crustly does not yet support \
+                 background command execution - this command ran synchronously and \
+                 already completed (or timed out) before this result was returned.\n\n",
+            );
+        }
 
         if !stdout.is_empty() {
             result_text.push_str("STDOUT:\n");
@@ -503,6 +568,88 @@ mod tests {
         let capabilities = tool.capabilities();
         assert!(capabilities.contains(&ToolCapability::ExecuteShell));
         assert!(capabilities.contains(&ToolCapability::SystemModification));
+    }
+
+    /// Regression: qwen-code's `run_shell_command` sends `directory`, not
+    /// `working_dir`. A model trained on it must still be able to override
+    /// the working directory.
+    #[tokio::test]
+    async fn test_bash_accepts_directory_alias() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let canonical = temp.path().canonicalize().expect("canonicalize");
+
+        let context = ToolExecutionContext::new(Uuid::new_v4()).with_auto_approve(true);
+
+        let result = BashTool
+            .execute(
+                serde_json::json!({
+                    "command": "pwd",
+                    "directory": canonical.to_str().unwrap()
+                }),
+                &context,
+            )
+            .await
+            .expect("pwd runs");
+
+        assert!(result.success, "{:?}", result.error);
+        let leaf = canonical
+            .file_name()
+            .expect("temp dir has a name")
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            result.output.contains(&leaf),
+            "expected output to contain {:?}, got {:?}",
+            leaf,
+            result.output
+        );
+    }
+
+    /// A per-call `timeout` (milliseconds, qwen-code's field) overrides the
+    /// context default and is what actually triggers the timeout error.
+    #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
+    async fn test_bash_timeout_field_overrides_context_default() {
+        let tool = BashTool;
+        // Context default is generous; the per-call override should be what
+        // actually fires here.
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_auto_approve(true)
+            .with_timeout(60);
+
+        let input = serde_json::json!({
+            "command": "sleep 5",
+            "timeout": 1000
+        });
+
+        let result = tool.execute(input, &context).await;
+        assert!(result.is_err(), "expected timeout error, got: {:?}", result);
+        assert!(matches!(result.unwrap_err(), ToolError::Timeout(1)));
+    }
+
+    /// `is_background: true` must not be silently ignored - the result must
+    /// tell the model the command actually ran synchronously, since Crustly
+    /// has no background-execution support yet.
+    #[tokio::test]
+    async fn test_bash_is_background_notes_synchronous_fallback() {
+        let tool = BashTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4()).with_auto_approve(true);
+
+        let command = if cfg!(target_os = "windows") {
+            "echo Hello"
+        } else {
+            "echo 'Hello'"
+        };
+
+        let input = serde_json::json!({
+            "command": command,
+            "is_background": true
+        });
+
+        let result = tool.execute(input, &context).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("does not yet support"));
+        assert!(result.output.contains("Hello"));
     }
 
     #[test]

--- a/src/llm/tools/edit.rs
+++ b/src/llm/tools/edit.rs
@@ -3,6 +3,7 @@
 //! Intelligently modify portions of files (find/replace, line-based edits).
 
 use super::error::{validate_file_path, Result, ToolError};
+use super::file_read_cache::{FileFingerprint, ReadGate};
 use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -112,7 +113,8 @@ impl Tool for EditTool {
     fn description(&self) -> &str {
         "Edit a file intelligently using various operations: replace text, replace lines, insert lines, delete lines, or regex replace. \
          For a simple text replacement, `file_path`/`old_string`/`new_string` (with optional `replace_all`) may be sent with no \
-         `operation` field - it defaults to 'replace'. `old_string` must match exactly once in the file unless `replace_all` is true."
+         `operation` field - it defaults to 'replace'. `old_string` must match exactly once in the file unless `replace_all` is true. \
+         You must read the file with read_file at least once in this session before editing it."
     }
 
     fn input_schema(&self) -> Value {
@@ -231,6 +233,30 @@ impl Tool for EditTool {
             Ok(p) => p,
             Err(msg) => return Ok(ToolResult::error(msg)),
         };
+
+        // Prior-read enforcement (matches Claude Code's/qwen-code's edit
+        // tools): reject blindly editing a file this session never read,
+        // or one that changed on disk since it was last read.
+        let metadata_before = fs::metadata(&path).await.map_err(ToolError::Io)?;
+        match context
+            .file_read_cache
+            .check(&path, FileFingerprint::of(&metadata_before))
+        {
+            ReadGate::NeverRead => {
+                return Ok(ToolResult::error(format!(
+                    "You must read '{}' with read_file before editing it.",
+                    path.display()
+                )));
+            }
+            ReadGate::Stale => {
+                return Ok(ToolResult::error(format!(
+                    "'{}' has changed on disk since it was last read. Re-read it with \
+                     read_file before editing.",
+                    path.display()
+                )));
+            }
+            ReadGate::Ok => {}
+        }
 
         // Read file content
         let content = fs::read_to_string(&path).await.map_err(ToolError::Io)?;
@@ -369,6 +395,13 @@ impl Tool for EditTool {
             .await
             .map_err(ToolError::Io)?;
 
+        // Seed the cache with the post-edit fingerprint so a follow-up edit
+        // in the same session doesn't need an intervening re-read.
+        let metadata_after = fs::metadata(&path).await.map_err(ToolError::Io)?;
+        context
+            .file_read_cache
+            .record(&path, FileFingerprint::of(&metadata_after));
+
         let lines_before = content.lines().count();
         let lines_after = new_content.lines().count();
 
@@ -392,6 +425,20 @@ mod tests {
             .with_working_directory(temp_dir.path().to_path_buf())
     }
 
+    /// A context whose file-read cache already has `relative_path` recorded
+    /// against its current on-disk fingerprint, simulating "the model read
+    /// this file earlier in the session." Most of edit_file's own tests
+    /// exist to exercise the edit logic itself, not prior-read enforcement,
+    /// so they use this rather than tripping over the gate incidentally.
+    async fn seeded_context(temp_dir: &TempDir, relative_path: &str) -> ToolExecutionContext {
+        let ctx = context(temp_dir);
+        let full_path = temp_dir.path().join(relative_path);
+        let metadata = fs::metadata(&full_path).await.unwrap();
+        ctx.file_read_cache
+            .record(&full_path, FileFingerprint::of(&metadata));
+        ctx
+    }
+
     #[tokio::test]
     async fn test_replace_with_explicit_operation_still_works() {
         let temp_dir = TempDir::new().unwrap();
@@ -407,7 +454,10 @@ mod tests {
             "create_backup": false
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "test.txt").await)
+            .await
+            .unwrap();
         assert!(result.success, "{:?}", result.error);
         assert_eq!(
             fs::read_to_string(&file_path).await.unwrap(),
@@ -433,7 +483,10 @@ mod tests {
             "new_string": "there"
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "test.txt").await)
+            .await
+            .unwrap();
         assert!(result.success, "{:?}", result.error);
         assert_eq!(
             fs::read_to_string(&file_path).await.unwrap(),
@@ -458,7 +511,10 @@ mod tests {
             "new_string": "bar"
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "test.txt").await)
+            .await
+            .unwrap();
         assert!(!result.success);
         assert!(result.error.unwrap().contains("3 times"));
         // File must be untouched.
@@ -482,7 +538,10 @@ mod tests {
             "replace_all": true
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "test.txt").await)
+            .await
+            .unwrap();
         assert!(result.success, "{:?}", result.error);
         assert_eq!(
             fs::read_to_string(&file_path).await.unwrap(),
@@ -503,7 +562,10 @@ mod tests {
             "new_string": "x"
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "test.txt").await)
+            .await
+            .unwrap();
         assert!(!result.success);
         assert!(result.error.unwrap().contains("not found"));
     }
@@ -544,7 +606,10 @@ mod tests {
             "create_backup": false
         });
 
-        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        let result = tool
+            .execute(input, &seeded_context(&temp_dir, "test.txt").await)
+            .await
+            .unwrap();
         assert!(result.success, "{:?}", result.error);
         assert_eq!(
             fs::read_to_string(&file_path).await.unwrap(),
@@ -561,5 +626,134 @@ mod tests {
             "new_string": "b"
         });
         assert!(tool.validate_input(&input).is_ok());
+    }
+
+    /// Regression: matches Claude Code's/qwen-code's edit tools - a file
+    /// this session has never read must not be blindly editable.
+    #[tokio::test]
+    async fn test_edit_rejects_a_file_never_read_this_session() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("test.txt"), "hello world")
+            .await
+            .unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "old_string": "world",
+            "new_string": "there"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("must read"));
+    }
+
+    /// Regression: a file read earlier, then changed on disk by something
+    /// else (another process, a human, a build step) before the edit
+    /// arrives, must not be silently overwritten with stale assumptions.
+    #[tokio::test]
+    async fn test_edit_rejects_a_file_changed_since_it_was_read() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "hello world").await.unwrap();
+
+        let ctx = seeded_context(&temp_dir, "test.txt").await;
+
+        // The file changes on disk after the recorded read.
+        fs::write(&file_path, "hello world, extended").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "old_string": "world",
+            "new_string": "there"
+        });
+
+        let result = tool.execute(input, &ctx).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("changed on disk"));
+        // Must not have touched the file.
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "hello world, extended"
+        );
+    }
+
+    /// End-to-end: an actual read_file call (not a hand-seeded cache)
+    /// clears enforcement for a subsequent edit_file call sharing the same
+    /// context - proving the two tools' cache usage actually interoperate.
+    #[tokio::test]
+    async fn test_read_file_then_edit_file_succeeds() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "hello world").await.unwrap();
+        let ctx = context(&temp_dir);
+
+        let read_result = crate::llm::tools::read::ReadTool
+            .execute(serde_json::json!({ "path": "test.txt" }), &ctx)
+            .await
+            .unwrap();
+        assert!(read_result.success);
+
+        let edit_result = EditTool
+            .execute(
+                serde_json::json!({
+                    "file_path": "test.txt",
+                    "old_string": "world",
+                    "new_string": "there"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(edit_result.success, "{:?}", edit_result.error);
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "hello there"
+        );
+    }
+
+    /// A second edit in the same session, on the same file, must not need
+    /// an intervening re-read - the first edit's own post-write record
+    /// clears the gate for the next one (matches qwen-code's recordWrite
+    /// note: the model authored those bytes, so it has "seen" them).
+    #[tokio::test]
+    async fn test_consecutive_edits_do_not_require_a_re_read_between_them() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "one two three").await.unwrap();
+        let ctx = seeded_context(&temp_dir, "test.txt").await;
+
+        let first = EditTool
+            .execute(
+                serde_json::json!({
+                    "file_path": "test.txt",
+                    "old_string": "one",
+                    "new_string": "ONE"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(first.success, "{:?}", first.error);
+
+        // No re-read in between.
+        let second = EditTool
+            .execute(
+                serde_json::json!({
+                    "file_path": "test.txt",
+                    "old_string": "two",
+                    "new_string": "TWO"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(second.success, "{:?}", second.error);
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "ONE TWO three"
+        );
     }
 }

--- a/src/llm/tools/edit.rs
+++ b/src/llm/tools/edit.rs
@@ -459,10 +459,7 @@ mod tests {
             .await
             .unwrap();
         assert!(result.success, "{:?}", result.error);
-        assert_eq!(
-            fs::read_to_string(&file_path).await.unwrap(),
-            "hello there"
-        );
+        assert_eq!(fs::read_to_string(&file_path).await.unwrap(), "hello there");
     }
 
     /// Regression: Claude Code's and qwen-code's edit tools send
@@ -488,10 +485,7 @@ mod tests {
             .await
             .unwrap();
         assert!(result.success, "{:?}", result.error);
-        assert_eq!(
-            fs::read_to_string(&file_path).await.unwrap(),
-            "hello there"
-        );
+        assert_eq!(fs::read_to_string(&file_path).await.unwrap(), "hello there");
     }
 
     /// Regression: a non-unique `old_string` with `replace_all` unset (or
@@ -661,7 +655,9 @@ mod tests {
         let ctx = seeded_context(&temp_dir, "test.txt").await;
 
         // The file changes on disk after the recorded read.
-        fs::write(&file_path, "hello world, extended").await.unwrap();
+        fs::write(&file_path, "hello world, extended")
+            .await
+            .unwrap();
 
         let tool = EditTool;
         let input = serde_json::json!({
@@ -708,10 +704,7 @@ mod tests {
             .await
             .unwrap();
         assert!(edit_result.success, "{:?}", edit_result.error);
-        assert_eq!(
-            fs::read_to_string(&file_path).await.unwrap(),
-            "hello there"
-        );
+        assert_eq!(fs::read_to_string(&file_path).await.unwrap(), "hello there");
     }
 
     /// A second edit in the same session, on the same file, must not need

--- a/src/llm/tools/edit.rs
+++ b/src/llm/tools/edit.rs
@@ -15,9 +15,24 @@ pub struct EditTool;
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "operation")]
 enum EditOperation {
-    /// Replace old_text with new_text
+    /// Replace old_text with new_text. Accepts `old_string`/`new_string` as
+    /// aliases - the field names sent by Claude Code's and qwen-code's edit
+    /// tools - so a model trained on either can drive this operation
+    /// without knowing Crustly's names for the same fields.
     #[serde(rename = "replace")]
-    Replace { old_text: String, new_text: String },
+    Replace {
+        #[serde(alias = "old_string")]
+        old_text: String,
+        #[serde(alias = "new_string")]
+        new_text: String,
+        /// Replace every occurrence of `old_text`. When false (default),
+        /// `old_text` must match exactly once in the file - matching
+        /// Claude Code's and qwen-code's edit tool semantics, which
+        /// require enough surrounding context to make the match unique
+        /// rather than silently rewriting every occurrence.
+        #[serde(default)]
+        replace_all: bool,
+    },
 
     /// Replace text at specific line range
     #[serde(rename = "replace_lines")]
@@ -45,7 +60,9 @@ enum EditOperation {
 
 #[derive(Debug, Deserialize, Serialize)]
 struct EditInput {
-    /// Path to the file to edit
+    /// Path to the file to edit. Accepts `file_path` as an alias - the
+    /// field name sent by Claude Code's and qwen-code's edit tools.
+    #[serde(alias = "file_path")]
     path: String,
 
     /// Edit operation to perform
@@ -61,6 +78,31 @@ fn default_true() -> bool {
     true
 }
 
+/// Normalize model-provided input into the shape `EditInput` expects.
+///
+/// Every reference coding agent's edit tool (Claude Code, qwen-code) sends a
+/// flat `{file_path, old_string, new_string, replace_all?}` payload with no
+/// operation discriminator. `EditInput`'s internally-tagged `operation` enum
+/// requires that discriminator to be present in the JSON to deserialize at
+/// all, so without this step a model trained on either agent would fail to
+/// call this tool. When `operation` is absent but `old_string`/`old_text` is
+/// present, inject `"operation": "replace"` so the common case works
+/// without the caller needing to know about Crustly's multi-operation
+/// format.
+fn normalize_input(mut input: Value) -> Value {
+    if let Some(obj) = input.as_object_mut() {
+        if !obj.contains_key("operation")
+            && (obj.contains_key("old_string") || obj.contains_key("old_text"))
+        {
+            obj.insert(
+                "operation".to_string(),
+                Value::String("replace".to_string()),
+            );
+        }
+    }
+    input
+}
+
 #[async_trait]
 impl Tool for EditTool {
     fn name(&self) -> &str {
@@ -68,7 +110,9 @@ impl Tool for EditTool {
     }
 
     fn description(&self) -> &str {
-        "Edit a file intelligently using various operations: replace text, replace lines, insert lines, delete lines, or regex replace."
+        "Edit a file intelligently using various operations: replace text, replace lines, insert lines, delete lines, or regex replace. \
+         For a simple text replacement, `file_path`/`old_string`/`new_string` (with optional `replace_all`) may be sent with no \
+         `operation` field - it defaults to 'replace'. `old_string` must match exactly once in the file unless `replace_all` is true."
     }
 
     fn input_schema(&self) -> Value {
@@ -77,20 +121,36 @@ impl Tool for EditTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Path to the file to edit"
+                    "description": "Path to the file to edit (alias: file_path)"
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": "Alias of 'path'."
                 },
                 "operation": {
                     "type": "string",
-                    "description": "Type of edit operation",
+                    "description": "Type of edit operation. Optional: defaults to 'replace' when old_string/old_text is present.",
                     "enum": ["replace", "replace_lines", "insert_line", "delete_lines", "regex_replace"]
                 },
                 "old_text": {
                     "type": "string",
-                    "description": "Text to find and replace (for 'replace' operation)"
+                    "description": "Text to find and replace (for 'replace' operation). Alias: old_string."
                 },
                 "new_text": {
                     "type": "string",
-                    "description": "Replacement text (for 'replace' and 'replace_lines' operations)"
+                    "description": "Replacement text (for 'replace' and 'replace_lines' operations). Alias: new_string."
+                },
+                "old_string": {
+                    "type": "string",
+                    "description": "Alias of 'old_text', for the 'replace' operation."
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "Alias of 'new_text', for the 'replace' operation."
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": "For the 'replace' operation: replace every occurrence of old_text/old_string. Defaults to false, which requires old_text/old_string to match exactly once."
                 },
                 "start_line": {
                     "type": "integer",
@@ -125,7 +185,7 @@ impl Tool for EditTool {
                     "default": true
                 }
             },
-            "required": ["path", "operation"]
+            "required": ["path"]
         })
     }
 
@@ -142,7 +202,7 @@ impl Tool for EditTool {
     }
 
     fn validate_input(&self, input: &Value) -> Result<()> {
-        let _: EditInput = serde_json::from_value(input.clone())
+        let _: EditInput = serde_json::from_value(normalize_input(input.clone()))
             .map_err(|e| ToolError::InvalidInput(format!("Invalid input: {}", e)))?;
         Ok(())
     }
@@ -157,7 +217,7 @@ impl Tool for EditTool {
             ));
         }
 
-        let input: EditInput = serde_json::from_value(input)?;
+        let input: EditInput = serde_json::from_value(normalize_input(input))?;
 
         // Enforce project boundary (T056)
         if let Err(reason) =
@@ -188,11 +248,24 @@ impl Tool for EditTool {
 
         // Perform edit operation
         let new_content = match input.operation {
-            EditOperation::Replace { old_text, new_text } => {
-                if !content.contains(&old_text) {
+            EditOperation::Replace {
+                old_text,
+                new_text,
+                replace_all,
+            } => {
+                let occurrences = content.matches(&old_text).count();
+                if occurrences == 0 {
                     return Ok(ToolResult::error(format!(
                         "Text not found in file: '{}'",
                         old_text
+                    )));
+                }
+                if occurrences > 1 && !replace_all {
+                    return Ok(ToolResult::error(format!(
+                        "Text '{}' appears {} times in the file - the match must be unique. \
+                         Include more surrounding context to narrow it to one occurrence, or \
+                         set replace_all to true to replace every occurrence.",
+                        old_text, occurrences
                     )));
                 }
                 content.replace(&old_text, &new_text)
@@ -305,5 +378,188 @@ impl Tool for EditTool {
             lines_before,
             lines_after
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    fn context(temp_dir: &TempDir) -> ToolExecutionContext {
+        ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf())
+    }
+
+    #[tokio::test]
+    async fn test_replace_with_explicit_operation_still_works() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "hello world").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "path": "test.txt",
+            "operation": "replace",
+            "old_text": "world",
+            "new_text": "there",
+            "create_backup": false
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "hello there"
+        );
+    }
+
+    /// Regression: Claude Code's and qwen-code's edit tools send
+    /// `file_path`/`old_string`/`new_string` with no `operation` field at
+    /// all. Before the alias/normalization fix, this payload would fail to
+    /// deserialize entirely (missing tag) - a model trained on either agent
+    /// could not call this tool.
+    #[tokio::test]
+    async fn test_qwen_code_and_claude_code_style_payload_works_with_no_operation_field() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "hello world").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "old_string": "world",
+            "new_string": "there"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "hello there"
+        );
+    }
+
+    /// Regression: a non-unique `old_string` with `replace_all` unset (or
+    /// explicitly false) must be rejected rather than silently rewriting
+    /// every occurrence - the old default behavior could corrupt unrelated
+    /// code that happened to share the matched text.
+    #[tokio::test]
+    async fn test_replace_rejects_non_unique_match_by_default() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "foo\nfoo\nfoo\n").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "old_string": "foo",
+            "new_string": "bar"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("3 times"));
+        // File must be untouched.
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "foo\nfoo\nfoo\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replace_all_true_replaces_every_occurrence() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "foo\nfoo\nfoo\n").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "old_string": "foo",
+            "new_string": "bar",
+            "replace_all": true
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "bar\nbar\nbar\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_replace_missing_text_errors() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "hello world").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "old_string": "not present",
+            "new_string": "x"
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("not found"));
+    }
+
+    /// Non-replace operations must still require an explicit `operation`
+    /// field - normalization only injects the default for the replace
+    /// shape, so a line-based edit without `operation` is a genuine error.
+    #[tokio::test]
+    async fn test_line_operation_without_operation_field_is_rejected() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "one\ntwo\nthree\n").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "start_line": 0,
+            "end_line": 0,
+            "new_text": "ONE"
+        });
+
+        assert!(tool.validate_input(&input).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_replace_lines_still_works() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        fs::write(&file_path, "one\ntwo\nthree\n").await.unwrap();
+
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "path": "test.txt",
+            "operation": "replace_lines",
+            "start_line": 1,
+            "end_line": 1,
+            "new_text": "TWO",
+            "create_backup": false
+        });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(
+            fs::read_to_string(&file_path).await.unwrap(),
+            "one\nTWO\nthree"
+        );
+    }
+
+    #[test]
+    fn test_validate_input_accepts_file_path_alias() {
+        let tool = EditTool;
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "old_string": "a",
+            "new_string": "b"
+        });
+        assert!(tool.validate_input(&input).is_ok());
     }
 }

--- a/src/llm/tools/file_read_cache.rs
+++ b/src/llm/tools/file_read_cache.rs
@@ -106,10 +106,7 @@ mod tests {
     #[test]
     fn never_read_path_is_rejected() {
         let cache = FileReadCache::new();
-        assert_eq!(
-            cache.check(Path::new("a.txt"), fp(1)),
-            ReadGate::NeverRead
-        );
+        assert_eq!(cache.check(Path::new("a.txt"), fp(1)), ReadGate::NeverRead);
     }
 
     #[test]
@@ -130,10 +127,7 @@ mod tests {
     fn distinct_paths_are_tracked_independently() {
         let cache = FileReadCache::new();
         cache.record(Path::new("a.txt"), fp(10));
-        assert_eq!(
-            cache.check(Path::new("b.txt"), fp(10)),
-            ReadGate::NeverRead
-        );
+        assert_eq!(cache.check(Path::new("b.txt"), fp(10)), ReadGate::NeverRead);
     }
 
     #[test]

--- a/src/llm/tools/file_read_cache.rs
+++ b/src/llm/tools/file_read_cache.rs
@@ -1,0 +1,147 @@
+//! Session-scoped file-read cache backing "prior read" enforcement for
+//! mutating file tools (`edit_file`, `write_file`'s overwrite path,
+//! `apply_patch`'s Update File operation).
+//!
+//! Verified against qwen-code's `priorReadEnforcement.ts`, which documents
+//! this as deliberately matching "Claude Code's `readFileState`": a file
+//! must be read (via `read_file`) at least once in the session before it
+//! can be edited or overwritten, and its on-disk mtime/size must still
+//! match what was read - any drift (an external process modified it since)
+//! blocks the edit until the model re-reads it. Creating a brand-new file
+//! needs no prior read (there is nothing to have read); the tool that
+//! writes it seeds its own cache entry afterward, since the model authored
+//! those bytes.
+//!
+//! Crustly's version is deliberately simpler than qwen-code's: mtime+size
+//! only (no content-type/cacheable distinction, since none of Crustly's
+//! mutating tools operate on binary content), and no config-level opt-out
+//! - if that turns out to be needed in practice, it can be added later.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+/// A cheap fingerprint of a file's on-disk state, used to detect whether it
+/// changed since it was last read. mtime + size (not a content hash) -
+/// matches qwen-code's approach and costs only a `stat`, no read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileFingerprint {
+    modified: Option<SystemTime>,
+    size: u64,
+}
+
+impl FileFingerprint {
+    pub fn of(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            modified: metadata.modified().ok(),
+            size: metadata.len(),
+        }
+    }
+}
+
+/// Outcome of checking whether a mutating tool may proceed against a path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadGate {
+    /// Cleared to proceed.
+    Ok,
+    /// Never read (or written) in this session.
+    NeverRead,
+    /// Read earlier, but the file has since changed on disk.
+    Stale,
+}
+
+/// Shared, session-scoped record of "this session has seen these bytes of
+/// this path." One instance is created per session (see
+/// `AgentService::file_read_cache_for_session`) and threaded through every
+/// `ToolExecutionContext` built for that session via
+/// [`ToolExecutionContext::with_file_read_cache`], so reads recorded by one
+/// tool call are visible to the next.
+#[derive(Debug, Default)]
+pub struct FileReadCache {
+    entries: Mutex<HashMap<PathBuf, FileFingerprint>>,
+}
+
+impl FileReadCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `path` was read (or authored, for a newly-written file)
+    /// with the given fingerprint. Call this after every successful
+    /// `read_file`, and after every successful mutation by `edit_file`,
+    /// `write_file`, or `apply_patch` (using the *post*-write fingerprint,
+    /// so a follow-up edit in the same session doesn't need an intervening
+    /// re-read).
+    pub fn record(&self, path: &Path, fingerprint: FileFingerprint) {
+        self.entries
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(path.to_path_buf(), fingerprint);
+    }
+
+    /// Check whether a mutating tool may proceed against `path`, given its
+    /// current on-disk fingerprint.
+    pub fn check(&self, path: &Path, current: FileFingerprint) -> ReadGate {
+        let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
+        match entries.get(path) {
+            None => ReadGate::NeverRead,
+            Some(recorded) if *recorded == current => ReadGate::Ok,
+            Some(_) => ReadGate::Stale,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp(size: u64) -> FileFingerprint {
+        FileFingerprint {
+            modified: None,
+            size,
+        }
+    }
+
+    #[test]
+    fn never_read_path_is_rejected() {
+        let cache = FileReadCache::new();
+        assert_eq!(
+            cache.check(Path::new("a.txt"), fp(1)),
+            ReadGate::NeverRead
+        );
+    }
+
+    #[test]
+    fn matching_fingerprint_after_record_is_ok() {
+        let cache = FileReadCache::new();
+        cache.record(Path::new("a.txt"), fp(10));
+        assert_eq!(cache.check(Path::new("a.txt"), fp(10)), ReadGate::Ok);
+    }
+
+    #[test]
+    fn mismatched_fingerprint_is_stale() {
+        let cache = FileReadCache::new();
+        cache.record(Path::new("a.txt"), fp(10));
+        assert_eq!(cache.check(Path::new("a.txt"), fp(20)), ReadGate::Stale);
+    }
+
+    #[test]
+    fn distinct_paths_are_tracked_independently() {
+        let cache = FileReadCache::new();
+        cache.record(Path::new("a.txt"), fp(10));
+        assert_eq!(
+            cache.check(Path::new("b.txt"), fp(10)),
+            ReadGate::NeverRead
+        );
+    }
+
+    #[test]
+    fn re_recording_updates_the_fingerprint() {
+        let cache = FileReadCache::new();
+        cache.record(Path::new("a.txt"), fp(10));
+        cache.record(Path::new("a.txt"), fp(20));
+        assert_eq!(cache.check(Path::new("a.txt"), fp(10)), ReadGate::Stale);
+        assert_eq!(cache.check(Path::new("a.txt"), fp(20)), ReadGate::Ok);
+    }
+}

--- a/src/llm/tools/glob.rs
+++ b/src/llm/tools/glob.rs
@@ -118,47 +118,40 @@ impl Tool for GlobTool {
             )));
         }
 
-        // Build full pattern with base directory
-        let full_pattern = base_dir.join(&input.pattern);
-        let pattern_str = full_pattern
-            .to_str()
-            .ok_or_else(|| ToolError::InvalidInput("Invalid path encoding".to_string()))?;
-
-        // Use glob crate to find matches
-        let glob_result = glob::glob(pattern_str)
+        let glob_pattern = glob::Pattern::new(&input.pattern)
             .map_err(|e| ToolError::InvalidInput(format!("Invalid glob pattern: {}", e)))?;
 
-        let mut matches: Vec<PathBuf> = Vec::new();
+        // Enumerate candidate files via a gitignore-aware walk (matches
+        // ripgrep's - and therefore qwen-code's `glob` and Claude Code's
+        // `Glob` - default behavior: `**/*.rs` should not wade into
+        // target/, node_modules/, etc.), then filter by the glob pattern
+        // relative to base_dir. The walk itself is blocking I/O, so it
+        // runs on a blocking thread; only directory traversal moves there,
+        // not the (cheap, in-memory) pattern matching below.
+        let dir_for_walk = base_dir.clone();
+        let include_hidden = input.include_hidden;
+        let candidates: Vec<PathBuf> = tokio::task::spawn_blocking(move || {
+            ignore::WalkBuilder::new(&dir_for_walk)
+                .hidden(!include_hidden)
+                .build()
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+                .map(|entry| entry.into_path())
+                .collect::<Vec<_>>()
+        })
+        .await
+        .map_err(|e| ToolError::Internal(format!("directory walk failed: {e}")))?;
 
-        for entry in glob_result {
-            match entry {
-                Ok(path) => {
-                    // Filter hidden files if not requested
-                    if !input.include_hidden {
-                        if let Some(file_name) = path.file_name() {
-                            if file_name
-                                .to_str()
-                                .map(|s| s.starts_with('.'))
-                                .unwrap_or(false)
-                            {
-                                continue;
-                            }
-                        }
-                    }
+        let mut matches: Vec<PathBuf> = candidates
+            .into_iter()
+            .filter(|path| {
+                let rel = path.strip_prefix(&base_dir).unwrap_or(path);
+                glob_pattern.matches_path(rel)
+            })
+            .collect();
 
-                    matches.push(path);
-
-                    // Apply limit
-                    if let Some(limit) = input.limit {
-                        if matches.len() >= limit {
-                            break;
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("Error reading glob entry: {}", e);
-                }
-            }
+        if let Some(limit) = input.limit {
+            matches.truncate(limit);
         }
 
         if matches.is_empty() {
@@ -195,5 +188,99 @@ impl Tool for GlobTool {
         }
 
         Ok(ToolResult::success(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    fn context(temp_dir: &TempDir) -> ToolExecutionContext {
+        ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf())
+    }
+
+    #[tokio::test]
+    async fn test_glob_matches_recursive_pattern() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::create_dir_all(temp_dir.path().join("src/nested"))
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("src/a.rs"), "").await.unwrap();
+        tokio::fs::write(temp_dir.path().join("src/nested/b.rs"), "")
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("readme.md"), "").await.unwrap();
+
+        let tool = GlobTool;
+        let input = serde_json::json!({ "pattern": "**/*.rs" });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(result.output.contains("a.rs"));
+        assert!(result.output.contains("b.rs"));
+        assert!(!result.output.contains("readme.md"));
+    }
+
+    /// Regression: an unbounded `**` glob must not wade into directories
+    /// the project's `.gitignore` excludes - both qwen-code's `glob` and
+    /// Claude Code's `Glob` are ripgrep-backed and respect `.gitignore` by
+    /// default.
+    #[tokio::test]
+    async fn test_glob_respects_gitignore() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join(".gitignore"), "target/\n")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(temp_dir.path().join(".git")).await.unwrap();
+        tokio::fs::create_dir_all(temp_dir.path().join("target/debug"))
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("target/debug/build.rs"), "")
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("src.rs"), "").await.unwrap();
+
+        let tool = GlobTool;
+        let input = serde_json::json!({ "pattern": "**/*.rs" });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(result.output.contains("src.rs"));
+        assert!(
+            !result.output.contains("build.rs"),
+            "gitignored target/ must be skipped, got: {:?}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn test_glob_no_matches() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = GlobTool;
+        let input = serde_json::json!({ "pattern": "**/*.nonexistent" });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("No files found"));
+    }
+
+    #[tokio::test]
+    async fn test_glob_respects_limit() {
+        let temp_dir = TempDir::new().unwrap();
+        for i in 0..5 {
+            tokio::fs::write(temp_dir.path().join(format!("f{i}.txt")), "")
+                .await
+                .unwrap();
+        }
+
+        let tool = GlobTool;
+        let input = serde_json::json!({ "pattern": "*.txt", "limit": 2 });
+
+        let result = tool.execute(input, &context(&temp_dir)).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(result.output.contains("Found 2 files"));
     }
 }

--- a/src/llm/tools/glob.rs
+++ b/src/llm/tools/glob.rs
@@ -208,11 +208,15 @@ mod tests {
         tokio::fs::create_dir_all(temp_dir.path().join("src/nested"))
             .await
             .unwrap();
-        tokio::fs::write(temp_dir.path().join("src/a.rs"), "").await.unwrap();
+        tokio::fs::write(temp_dir.path().join("src/a.rs"), "")
+            .await
+            .unwrap();
         tokio::fs::write(temp_dir.path().join("src/nested/b.rs"), "")
             .await
             .unwrap();
-        tokio::fs::write(temp_dir.path().join("readme.md"), "").await.unwrap();
+        tokio::fs::write(temp_dir.path().join("readme.md"), "")
+            .await
+            .unwrap();
 
         let tool = GlobTool;
         let input = serde_json::json!({ "pattern": "**/*.rs" });
@@ -234,14 +238,18 @@ mod tests {
         tokio::fs::write(temp_dir.path().join(".gitignore"), "target/\n")
             .await
             .unwrap();
-        tokio::fs::create_dir(temp_dir.path().join(".git")).await.unwrap();
+        tokio::fs::create_dir(temp_dir.path().join(".git"))
+            .await
+            .unwrap();
         tokio::fs::create_dir_all(temp_dir.path().join("target/debug"))
             .await
             .unwrap();
         tokio::fs::write(temp_dir.path().join("target/debug/build.rs"), "")
             .await
             .unwrap();
-        tokio::fs::write(temp_dir.path().join("src.rs"), "").await.unwrap();
+        tokio::fs::write(temp_dir.path().join("src.rs"), "")
+            .await
+            .unwrap();
 
         let tool = GlobTool;
         let input = serde_json::json!({ "pattern": "**/*.rs" });

--- a/src/llm/tools/grep.rs
+++ b/src/llm/tools/grep.rs
@@ -38,8 +38,9 @@ struct GrepInput {
     #[serde(default)]
     context: Option<usize>,
 
-    /// File pattern to filter (e.g., "*.rs")
-    #[serde(default)]
+    /// File pattern to filter (e.g., "*.rs"). Accepts `glob` as an alias -
+    /// the field name sent by Claude Code's and qwen-code's grep tools.
+    #[serde(alias = "glob", default)]
     file_pattern: Option<String>,
 
     /// Maximum number of matches to return
@@ -95,7 +96,11 @@ impl Tool for GrepTool {
                 },
                 "file_pattern": {
                     "type": "string",
-                    "description": "File pattern to filter (e.g., '*.rs', '*.{js,ts}')"
+                    "description": "File pattern to filter (e.g., '*.rs', '*.{js,ts}'). Alias: glob."
+                },
+                "glob": {
+                    "type": "string",
+                    "description": "Alias of 'file_pattern'."
                 },
                 "limit": {
                     "type": "integer",
@@ -338,5 +343,40 @@ impl GrepTool {
 
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    /// Regression: Claude Code's and qwen-code's grep tools send `glob`,
+    /// not `file_pattern`. A model trained on either must still be able to
+    /// filter by file pattern.
+    #[tokio::test]
+    async fn test_grep_accepts_glob_alias_for_file_pattern() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("match.rs"), "needle here")
+            .await
+            .unwrap();
+        tokio::fs::write(temp_dir.path().join("match.txt"), "needle here")
+            .await
+            .unwrap();
+
+        let tool = GrepTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let input = serde_json::json!({
+            "pattern": "needle",
+            "glob": "*.rs"
+        });
+
+        let result = tool.execute(input, &context).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(result.output.contains("match.rs"));
+        assert!(!result.output.contains("match.txt"));
     }
 }

--- a/src/llm/tools/grep.rs
+++ b/src/llm/tools/grep.rs
@@ -22,8 +22,13 @@ struct GrepInput {
     #[serde(default)]
     path: Option<String>,
 
-    /// Use regex instead of literal string
-    #[serde(default)]
+    /// Whether to treat `pattern` as a regex. Defaults to true - Claude
+    /// Code's and qwen-code's grep tools always treat pattern as a full
+    /// regex with no literal/regex toggle at all, so a model trained on
+    /// either never sends this field and expects regex semantics by
+    /// default. Set to false to search for `pattern` as a literal string
+    /// instead (regex metacharacters are escaped).
+    #[serde(default = "default_true")]
     regex: bool,
 
     /// Case insensitive search
@@ -59,7 +64,7 @@ impl Tool for GrepTool {
     }
 
     fn description(&self) -> &str {
-        "Search for patterns in file contents. Supports literal string or regex search with context lines."
+        "Search for patterns in file contents. Supports full regex syntax (e.g. \"log.*Error\", \"function\\s+\\w+\") with context lines. Set regex: false to search for pattern as a literal string instead."
     }
 
     fn input_schema(&self) -> Value {
@@ -68,7 +73,7 @@ impl Tool for GrepTool {
             "properties": {
                 "pattern": {
                     "type": "string",
-                    "description": "Pattern to search for (literal string or regex)"
+                    "description": "The regular expression pattern to search for in file contents"
                 },
                 "path": {
                     "type": "string",
@@ -76,8 +81,8 @@ impl Tool for GrepTool {
                 },
                 "regex": {
                     "type": "boolean",
-                    "description": "Treat pattern as regex instead of literal string",
-                    "default": false
+                    "description": "Whether to treat pattern as a regex. Defaults to true; set to false to search for pattern as a literal string instead.",
+                    "default": true
                 },
                 "case_insensitive": {
                     "type": "boolean",
@@ -378,5 +383,67 @@ mod tests {
         assert!(result.success, "{:?}", result.error);
         assert!(result.output.contains("match.rs"));
         assert!(!result.output.contains("match.txt"));
+    }
+
+    /// Regression: Claude Code's and qwen-code's grep tools always treat
+    /// `pattern` as a regex - there's no literal/regex toggle in either -
+    /// so a model trained on either never sends `regex` and expects regex
+    /// semantics by default. Before this fix, an omitted `regex` field
+    /// defaulted to literal-string matching, so `.` in a pattern like
+    /// `fn.run` would only match a literal dot instead of "any character",
+    /// silently missing matches a Claude Code/qwen-code-trained model
+    /// expects to find.
+    #[tokio::test]
+    async fn test_pattern_is_regex_by_default() {
+        let temp_dir = TempDir::new().unwrap();
+        // "fn.run" as a regex matches this via `.` = "any character"; as a
+        // literal string it would not (no literal dot between fn and run).
+        tokio::fs::write(temp_dir.path().join("code.rs"), "fnXrun")
+            .await
+            .unwrap();
+
+        let tool = GrepTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        // No `regex` field at all - matches what a Claude Code/qwen-code-
+        // trained model actually sends.
+        let input = serde_json::json!({ "pattern": "fn.run" });
+
+        let result = tool.execute(input, &context).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(
+            result.output.contains("code.rs"),
+            "expected regex '.' to match any character by default, got: {:?}",
+            result.output
+        );
+    }
+
+    /// `regex: false` must still work as an explicit opt-out into literal
+    /// string matching (regex metacharacters escaped).
+    #[tokio::test]
+    async fn test_regex_false_still_searches_literally() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join("code.rs"), "fnXrun\nfn.run")
+            .await
+            .unwrap();
+
+        let tool = GrepTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let input = serde_json::json!({ "pattern": "fn.run", "regex": false });
+
+        let result = tool.execute(input, &context).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(
+            result.output.contains("fn.run"),
+            "literal '.' must match the literal dot"
+        );
+        assert!(
+            !result.output.contains("fnXrun"),
+            "with regex: false, '.' must not match an arbitrary character, got: {:?}",
+            result.output
+        );
     }
 }

--- a/src/llm/tools/grep.rs
+++ b/src/llm/tools/grep.rs
@@ -197,14 +197,15 @@ impl Tool for GrepTool {
             )
             .await?;
         } else {
-            self.search_directory(
-                &search_path,
-                &regex,
-                &input,
-                &mut matches,
-                &mut total_matches,
-            )
-            .await?;
+            for path in collect_searchable_files(&search_path).await? {
+                if let Some(limit) = input.limit {
+                    if matches.len() >= limit {
+                        break;
+                    }
+                }
+                self.search_file(&path, &regex, &input, &mut matches, &mut total_matches)
+                    .await?;
+            }
         }
 
         if matches.is_empty() {
@@ -309,46 +310,33 @@ impl GrepTool {
 
         Ok(())
     }
+}
 
-    fn search_directory<'a>(
-        &'a self,
-        dir: &'a PathBuf,
-        regex: &'a regex::Regex,
-        input: &'a GrepInput,
-        matches: &'a mut Vec<String>,
-        total_matches: &'a mut usize,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
-        Box::pin(async move {
-            let mut entries = fs::read_dir(dir).await.map_err(ToolError::Io)?;
+/// Enumerate every regular file under `dir`, respecting `.gitignore`,
+/// `.git/info/exclude`, and the global gitignore (matches ripgrep's - and
+/// therefore qwen-code's `grep_search` and Claude Code's `Grep` - default
+/// behavior). Hidden files/directories are skipped, matching the previous
+/// manual-walk behavior this replaces. Sorted for deterministic output.
+///
+/// The `ignore` crate's walker is synchronous (blocking I/O per step), so
+/// the walk itself runs on a blocking thread; only the per-file content
+/// search remains on the async path.
+async fn collect_searchable_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let dir = dir.to_path_buf();
+    let mut files = tokio::task::spawn_blocking(move || {
+        ignore::WalkBuilder::new(&dir)
+            .hidden(true)
+            .build()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+            .map(|entry| entry.into_path())
+            .collect::<Vec<_>>()
+    })
+    .await
+    .map_err(|e| ToolError::Internal(format!("directory walk failed: {e}")))?;
 
-            while let Some(entry) = entries.next_entry().await.map_err(ToolError::Io)? {
-                let path = entry.path();
-
-                // Check limit
-                if let Some(limit) = input.limit {
-                    if matches.len() >= limit {
-                        return Ok(());
-                    }
-                }
-
-                if path.is_file() {
-                    self.search_file(&path, regex, input, matches, total_matches)
-                        .await?;
-                } else if path.is_dir() {
-                    // Skip hidden directories
-                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                        if name.starts_with('.') {
-                            continue;
-                        }
-                    }
-                    self.search_directory(&path, regex, input, matches, total_matches)
-                        .await?;
-                }
-            }
-
-            Ok(())
-        })
-    }
+    files.sort();
+    Ok(files)
 }
 
 #[cfg(test)]
@@ -443,6 +431,55 @@ mod tests {
         assert!(
             !result.output.contains("fnXrun"),
             "with regex: false, '.' must not match an arbitrary character, got: {:?}",
+            result.output
+        );
+    }
+
+    /// Regression: an unbounded recursive search must not wade into
+    /// directories the project's own `.gitignore` excludes (build output,
+    /// vendored deps, etc.) - both ripgrep-backed grep_search (qwen-code)
+    /// and Claude Code's Grep respect `.gitignore` by default.
+    #[tokio::test]
+    async fn test_search_respects_gitignore() {
+        let temp_dir = TempDir::new().unwrap();
+        tokio::fs::write(temp_dir.path().join(".gitignore"), "ignored_dir/\n")
+            .await
+            .unwrap();
+        tokio::fs::create_dir(temp_dir.path().join("ignored_dir"))
+            .await
+            .unwrap();
+        tokio::fs::write(
+            temp_dir.path().join("ignored_dir/noise.txt"),
+            "needle in a haystack that should be ignored",
+        )
+        .await
+        .unwrap();
+        tokio::fs::write(
+            temp_dir.path().join("real.txt"),
+            "needle in a haystack that should be found",
+        )
+        .await
+        .unwrap();
+
+        // A gitignore-aware walker only activates inside an actual repo
+        // (or with a `.git` directory present) for some ignore-crate
+        // configurations; make this deterministic by giving it one.
+        tokio::fs::create_dir(temp_dir.path().join(".git"))
+            .await
+            .unwrap();
+
+        let tool = GrepTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let input = serde_json::json!({ "pattern": "needle", "regex": false });
+        let result = tool.execute(input, &context).await.unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        assert!(result.output.contains("real.txt"));
+        assert!(
+            !result.output.contains("ignored_dir"),
+            "gitignored directory must be skipped, got: {:?}",
             result.output
         );
     }

--- a/src/llm/tools/mod.rs
+++ b/src/llm/tools/mod.rs
@@ -11,6 +11,7 @@ pub mod sandbox;
 mod r#trait;
 
 // Tool implementations - Phase 1: Essential File Operations
+pub mod apply_patch;
 pub mod bash;
 pub mod edit;
 pub mod glob;

--- a/src/llm/tools/mod.rs
+++ b/src/llm/tools/mod.rs
@@ -3,6 +3,7 @@
 //! Provides an abstraction for tools that can be called by LLM agents,
 //! including file operations, shell commands, and more.
 
+pub mod aliases;
 pub mod cache;
 pub mod error;
 pub mod registry;

--- a/src/llm/tools/mod.rs
+++ b/src/llm/tools/mod.rs
@@ -30,6 +30,7 @@ pub mod web_search;
 pub mod context;
 pub mod http;
 pub mod plan_tool;
+pub mod save_memory;
 pub mod task;
 
 // Tool implementations - Phase 4: Claw Code parity

--- a/src/llm/tools/mod.rs
+++ b/src/llm/tools/mod.rs
@@ -6,6 +6,7 @@
 pub mod aliases;
 pub mod cache;
 pub mod error;
+pub mod file_read_cache;
 pub mod registry;
 pub mod sandbox;
 mod r#trait;
@@ -43,5 +44,6 @@ pub mod web_fetch;
 
 // Re-exports
 pub use error::{Result, ToolError};
+pub use file_read_cache::{FileFingerprint, FileReadCache, ReadGate};
 pub use r#trait::{SubAgentLauncher, Tool, ToolCapability, ToolExecutionContext, ToolResult};
 pub use registry::ToolRegistry;

--- a/src/llm/tools/read.rs
+++ b/src/llm/tools/read.rs
@@ -131,6 +131,17 @@ impl Tool for ReadTool {
                 (contents, line_count, None)
             };
 
+        // Record this read against the session's file-read cache. Any
+        // successful read - even a partial/paginated one - clears prior-read
+        // enforcement for edit_file/write_file/apply_patch, matching Claude
+        // Code's/qwen-code's stance that "has the model seen current bytes"
+        // is the bar, not "has it seen every byte" (see file_read_cache
+        // module docs).
+        context.file_read_cache.record(
+            &path,
+            crate::llm::tools::FileFingerprint::of(&metadata),
+        );
+
         let output_len = output.len();
         let mut result = ToolResult::success(output)
             .with_metadata("path".to_string(), path.display().to_string())

--- a/src/llm/tools/read.rs
+++ b/src/llm/tools/read.rs
@@ -137,10 +137,9 @@ impl Tool for ReadTool {
         // Code's/qwen-code's stance that "has the model seen current bytes"
         // is the bar, not "has it seen every byte" (see file_read_cache
         // module docs).
-        context.file_read_cache.record(
-            &path,
-            crate::llm::tools::FileFingerprint::of(&metadata),
-        );
+        context
+            .file_read_cache
+            .record(&path, crate::llm::tools::FileFingerprint::of(&metadata));
 
         let output_len = output.len();
         let mut result = ToolResult::success(output)

--- a/src/llm/tools/read.rs
+++ b/src/llm/tools/read.rs
@@ -24,7 +24,9 @@ pub struct ReadTool;
 
 #[derive(Debug, Deserialize, Serialize)]
 struct ReadInput {
-    /// Path to the file to read
+    /// Path to the file to read. Accepts `file_path` as an alias - the
+    /// field name sent by Claude Code's and qwen-code's read tools.
+    #[serde(alias = "file_path")]
     path: String,
 
     /// Optional: Start line (0-indexed)
@@ -52,7 +54,11 @@ impl Tool for ReadTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Path to the file to read (absolute or relative to working directory)"
+                    "description": "Path to the file to read (absolute or relative to working directory). Alias: file_path."
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": "Alias of 'path'."
                 },
                 "start_line": {
                     "type": "integer",
@@ -298,6 +304,31 @@ mod tests {
         assert!(!result.success);
         assert!(result.error.is_some());
         assert!(result.error.unwrap().contains("not found"));
+    }
+
+    /// Regression: Claude Code's and qwen-code's read tools send `file_path`,
+    /// not `path`. A model trained on either must still be able to call this
+    /// tool.
+    #[tokio::test]
+    async fn test_read_file_accepts_file_path_alias() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_file_path = temp_dir.path().join("test.txt");
+        let mut temp_file = std::fs::File::create(&temp_file_path).unwrap();
+        writeln!(temp_file, "aliased read").unwrap();
+        temp_file.flush().unwrap();
+
+        let tool = ReadTool;
+        let session_id = Uuid::new_v4();
+        let context = ToolExecutionContext::new(session_id)
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let input = serde_json::json!({
+            "file_path": temp_file_path.to_str().unwrap()
+        });
+
+        let result = tool.execute(input, &context).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+        assert!(result.output.contains("aliased read"));
     }
 
     #[test]

--- a/src/llm/tools/registry.rs
+++ b/src/llm/tools/registry.rs
@@ -556,7 +556,11 @@ mod tests {
         let context = ToolExecutionContext::new(Uuid::new_v4());
 
         let result = registry
-            .execute("definitely_not_a_real_tool", serde_json::json!({}), &context)
+            .execute(
+                "definitely_not_a_real_tool",
+                serde_json::json!({}),
+                &context,
+            )
             .await;
 
         match result {

--- a/src/llm/tools/registry.rs
+++ b/src/llm/tools/registry.rs
@@ -57,10 +57,18 @@ impl ToolRegistry {
     ///
     /// False when no policy is configured: absent an explicit allowlist, nothing
     /// is trusted, and `requires_approval` tools keep prompting as before.
+    ///
+    /// Resolves `name` through the alias table first, same as `execute()`,
+    /// so a policy rule written against the canonical name (e.g. an
+    /// allowlist entry for `bash`) still applies when a model calls the
+    /// same tool by an alias (e.g. `run_shell_command`). Without this, the
+    /// approval-prompt precheck in `llm::agent::service` and `execute()`'s
+    /// own policy check could disagree about the same call.
     pub fn is_trusted(&self, name: &str, input: &serde_json::Value) -> bool {
         use crate::llm::tools::sandbox::PolicyDecision;
+        let canonical = self.canonical_name(name);
         matches!(
-            self.policy.as_ref().map(|p| p.evaluate(name, input)),
+            self.policy.as_ref().map(|p| p.evaluate(canonical, input)),
             Some(PolicyDecision::Trusted)
         )
     }
@@ -72,14 +80,34 @@ impl ToolRegistry {
         self.tools.insert(name, tool);
     }
 
-    /// Get a tool by name
-    pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
-        self.tools.get(name).cloned()
+    /// Resolve `name` to the key actually present in the registry: `name`
+    /// itself if it's registered directly, otherwise its alias target (see
+    /// [`super::aliases::resolve`]) if *that* is registered, otherwise
+    /// `name` unchanged - so a genuinely unknown name still produces a
+    /// clear "not found" error naming what the model actually sent, rather
+    /// than silently becoming something else.
+    ///
+    /// An exact match always wins over an alias: if a real tool is ever
+    /// registered under a name that happens to collide with an alias entry,
+    /// the real tool takes precedence.
+    fn canonical_name<'a>(&self, name: &'a str) -> &'a str {
+        if self.tools.contains_key(name) {
+            return name;
+        }
+        match super::aliases::resolve(name) {
+            Some(target) if self.tools.contains_key(target) => target,
+            _ => name,
+        }
     }
 
-    /// Check if a tool is registered
+    /// Get a tool by name (resolving aliases - see [`Self::canonical_name`])
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.tools.get(self.canonical_name(name)).cloned()
+    }
+
+    /// Check if a tool is registered (resolving aliases - see [`Self::canonical_name`])
     pub fn has_tool(&self, name: &str) -> bool {
-        self.tools.contains_key(name)
+        self.tools.contains_key(self.canonical_name(name))
     }
 
     /// List all registered tool names
@@ -99,15 +127,26 @@ impl ToolRegistry {
             .collect()
     }
 
-    /// Execute a tool by name
+    /// Execute a tool by name. `name` is resolved through the alias table
+    /// (see [`Self::canonical_name`]) once, up front, and that canonical
+    /// name is used for the tool lookup, the permission policy check, and
+    /// logging - so a call for e.g. `list_directory` (qwen-code's name for
+    /// `ls`) is indistinguishable, from the policy's perspective, from a
+    /// call for `ls` itself. Evaluating the policy against the raw alias
+    /// instead would let a configured `security.allow_bash`-style rule
+    /// silently fail to match a call that used a different name for the
+    /// same tool.
     pub async fn execute(
         &self,
         name: &str,
         input: Value,
         context: &ToolExecutionContext,
     ) -> Result<ToolResult> {
+        let canonical = self.canonical_name(name);
         let tool = self
-            .get(name)
+            .tools
+            .get(canonical)
+            .cloned()
             .ok_or_else(|| ToolError::NotFound(name.to_string()))?;
 
         // Validate input
@@ -117,7 +156,7 @@ impl ToolRegistry {
         let mut trusted = false;
         if let Some(ref policy) = self.policy {
             use crate::llm::tools::sandbox::PolicyDecision;
-            match policy.evaluate(name, &input) {
+            match policy.evaluate(canonical, &input) {
                 PolicyDecision::Allow => {}
                 PolicyDecision::Trusted => trusted = true,
                 PolicyDecision::Deny(reason) => {
@@ -132,8 +171,12 @@ impl ToolRegistry {
         if tool.requires_approval() && !context.auto_approve && !trusted {
             return Err(ToolError::ApprovalRequired(format!(
                 "Tool '{}' requires approval before execution",
-                name
+                canonical
             )));
+        }
+
+        if canonical != name {
+            tracing::debug!("Resolved tool alias '{}' -> '{}'", name, canonical);
         }
 
         // Execute the tool. Log the arguments, not just the name: when a model
@@ -143,7 +186,7 @@ impl ToolRegistry {
         // for the wrong thing.
         tracing::info!(
             "Executing tool: {} with input: {}",
-            name,
+            canonical,
             preview_input(&input)
         );
         let result = tool.execute(input, context).await?;
@@ -157,7 +200,7 @@ impl ToolRegistry {
             let preview: String = result.output.chars().take(PREVIEW).collect();
             tracing::info!(
                 "Tool '{}' executed successfully -> {}{}",
-                name,
+                canonical,
                 preview,
                 if result.output.chars().count() > PREVIEW {
                     " …[truncated]"
@@ -168,7 +211,7 @@ impl ToolRegistry {
         } else {
             tracing::warn!(
                 "Tool '{}' failed: {:?}",
-                name,
+                canonical,
                 result.error.as_deref().unwrap_or("unknown error")
             );
         }
@@ -443,5 +486,137 @@ mod tests {
         assert!(result.is_err());
         // No tools should have been registered from a failed connection.
         assert_eq!(registry.count(), 0);
+    }
+
+    // ── Alias resolution ────────────────────────────────────────────────────
+
+    #[test]
+    fn get_resolves_a_known_alias_to_the_registered_canonical_tool() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(MockTool {
+            name: "bash".to_string(),
+            requires_approval: false,
+        }));
+
+        // "run_shell_command" is qwen-code's name for the same tool.
+        assert!(registry.get("run_shell_command").is_some());
+        assert!(registry.has_tool("run_shell_command"));
+    }
+
+    #[test]
+    fn has_tool_is_false_for_an_alias_whose_target_is_not_registered() {
+        let registry = ToolRegistry::new();
+        // "run_shell_command" is a real alias entry, but nothing named
+        // "bash" was ever registered in this registry.
+        assert!(!registry.has_tool("run_shell_command"));
+    }
+
+    #[test]
+    fn an_exact_match_wins_over_an_alias_entry() {
+        let mut registry = ToolRegistry::new();
+        // Register a real tool under a name that also happens to be a
+        // listed alias key, to prove the exact match takes precedence
+        // rather than being redirected to the alias's target.
+        registry.register(Arc::new(MockTool {
+            name: "cat".to_string(),
+            requires_approval: false,
+        }));
+
+        let tool = registry.get("cat").expect("exact match must be found");
+        // If alias resolution had won, this would be Crustly's real
+        // `read_file` tool instead of the mock registered above.
+        assert_eq!(tool.name(), "cat");
+    }
+
+    #[tokio::test]
+    async fn execute_resolves_an_alias_name_to_the_registered_tool() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(MockTool {
+            name: "bash".to_string(),
+            requires_approval: false,
+        }));
+
+        let context = ToolExecutionContext::new(Uuid::new_v4());
+        let input = serde_json::json!({ "message": "test" });
+
+        // "Bash" (Claude Code's name) and "shell" (a generic alias) both
+        // resolve to the "bash" tool registered above.
+        for alias in ["Bash", "shell", "run_shell_command"] {
+            let result = registry
+                .execute(alias, input.clone(), &context)
+                .await
+                .unwrap_or_else(|e| panic!("alias '{alias}' should resolve: {e}"));
+            assert!(result.success);
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_reports_not_found_using_the_original_unresolved_name() {
+        let registry = ToolRegistry::new();
+        let context = ToolExecutionContext::new(Uuid::new_v4());
+
+        let result = registry
+            .execute("definitely_not_a_real_tool", serde_json::json!({}), &context)
+            .await;
+
+        match result {
+            Err(ToolError::NotFound(name)) => assert_eq!(name, "definitely_not_a_real_tool"),
+            other => panic!("expected NotFound with the original name, got {other:?}"),
+        }
+    }
+
+    /// Regression: a permission policy rule written against the canonical
+    /// tool name must still apply when a model calls the same tool by an
+    /// alias - otherwise a `security.allow_bash`-style allowlist (or a
+    /// deny rule) silently stops working the moment a model uses a
+    /// different name for the same tool.
+    #[tokio::test]
+    async fn execute_evaluates_policy_against_the_canonical_name_not_the_alias() {
+        use crate::llm::tools::sandbox::DenyToolRule;
+
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(MockTool {
+            name: "bash".to_string(),
+            requires_approval: false,
+        }));
+        // Denies by the canonical name "bash" - not "run_shell_command".
+        registry.set_policy(Arc::new(DenyToolRule::new("bash")));
+
+        let context = ToolExecutionContext::new(Uuid::new_v4());
+        let result = registry
+            .execute(
+                "run_shell_command",
+                serde_json::json!({ "message": "test" }),
+                &context,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(ToolError::PermissionDenied(_))),
+            "expected the canonical-name deny rule to catch the alias call, got {result:?}"
+        );
+    }
+
+    /// The same consistency must hold for the pre-execution trust check
+    /// (`is_trusted`), which `llm::agent::service` calls separately from
+    /// `execute()` to decide whether to prompt for approval.
+    #[test]
+    fn is_trusted_evaluates_policy_against_the_canonical_name_not_the_alias() {
+        use crate::llm::tools::sandbox::AllowToolRule;
+
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(MockTool {
+            name: "bash".to_string(),
+            requires_approval: true,
+        }));
+        // AllowToolRule only ever returns Allow (never Trusted), so this
+        // confirms canonical-name evaluation happens, not that it's
+        // Trusted - is_trusted's own tests elsewhere cover the Trusted case.
+        registry.set_policy(Arc::new(AllowToolRule::new("bash")));
+
+        // Both must evaluate identically because both resolve to "bash".
+        let direct = registry.is_trusted("bash", &serde_json::json!({}));
+        let via_alias = registry.is_trusted("run_shell_command", &serde_json::json!({}));
+        assert_eq!(direct, via_alias);
     }
 }

--- a/src/llm/tools/sandbox.rs
+++ b/src/llm/tools/sandbox.rs
@@ -159,13 +159,19 @@ impl PathBoundaryRule {
                 ))
             }
         } else {
-            // Non-existent path (e.g. a file about to be written). Only the
-            // candidate can be normalized - there is nothing on disk to
-            // canonicalize - so the root may still carry a `\\?\` verbatim prefix
-            // while the candidate does not. Strip it from both sides before
-            // comparing, or an absolute path *inside* the root is rejected as an
-            // escape: `D:\proj\new.md` does not `starts_with` `\\?\D:\proj`.
-            let resolved = strip_verbatim_prefix(&normalize_path(candidate));
+            // Non-existent path (e.g. a file about to be written). Resolve
+            // symlinks in whatever prefix of it *does* exist - e.g. on
+            // macOS, TempDir's base is under `/var`, itself a symlink to
+            // `/private/var`. `self.root` was canonicalized by `check_path`
+            // (resolving that symlink) before reaching here, but a brand
+            // new file under it, left untouched, would not be - making an
+            // otherwise-valid path look like it escapes the (canonicalized)
+            // root. The root may still carry a `\\?\` verbatim prefix while
+            // the candidate does not (or vice versa after this resolution),
+            // so strip it from both sides before comparing, or an absolute
+            // path *inside* the root is rejected as an escape: `D:\proj\new.md`
+            // does not `starts_with` `\\?\D:\proj`.
+            let resolved = strip_verbatim_prefix(&resolve_existing_prefix(candidate));
             let root_normalized = strip_verbatim_prefix(&normalize_path(&self.root));
             if resolved.starts_with(&root_normalized) {
                 PolicyDecision::Allow
@@ -426,6 +432,44 @@ fn normalize_path(path: &Path) -> PathBuf {
     result
 }
 
+/// Resolve symlinks in the longest existing prefix of `path`, then append
+/// whatever trailing components don't exist yet, lexically normalized.
+///
+/// A path that doesn't fully exist can't be `canonicalize`d outright, but
+/// leaving it completely untouched breaks comparison against an
+/// already-canonicalized root the moment any *existing* ancestor of the
+/// path is itself a symlink - e.g. on macOS, where a temp directory lives
+/// under `/var`, a symlink to `/private/var`: `root.canonicalize()`
+/// resolves it, but a brand new file path under that same root, left as
+/// plain `/var/...`, no longer shares a prefix with the resolved
+/// `/private/var/...` root even though it's the same location.
+fn resolve_existing_prefix(path: &Path) -> PathBuf {
+    if path.exists() {
+        return std::fs::canonicalize(path).unwrap_or_else(|_| normalize_path(path));
+    }
+
+    let mut tail = Vec::new();
+    let mut current = path;
+    loop {
+        let (parent, name) = match (current.parent(), current.file_name()) {
+            (Some(parent), Some(name)) => (parent, name),
+            // Ran out of ancestors (reached a root component) without
+            // finding anything that exists - nothing to resolve.
+            _ => return normalize_path(path),
+        };
+        tail.push(name.to_os_string());
+        if parent.exists() {
+            let mut resolved =
+                std::fs::canonicalize(parent).unwrap_or_else(|_| normalize_path(parent));
+            for component in tail.into_iter().rev() {
+                resolved.push(component);
+            }
+            return resolved;
+        }
+        current = parent;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -505,6 +549,39 @@ mod tests {
         assert!(
             check_path(outside.to_str().unwrap(), root).is_err(),
             "a non-existent path outside the root must still be denied",
+        );
+    }
+
+    /// Regression (macOS CI failure): reproduces the exact failure mode
+    /// with a real symlink, so it's caught on any platform rather than
+    /// only on macOS, where a temp directory's own base lives under
+    /// `/var`, itself a symlink to `/private/var`. `check_path`
+    /// canonicalizes the root (resolving the symlink), but a non-existent
+    /// candidate built from the unresolved symlinked root (exactly what
+    /// `TempDir::path()` returns on macOS) was previously left completely
+    /// untouched, so it no longer shared a prefix with the canonicalized
+    /// root and was wrongly denied as an escape.
+    #[cfg(unix)]
+    #[test]
+    fn absolute_path_to_nonexistent_file_through_a_symlinked_root_allowed() {
+        let real_dir = TempDir::new().unwrap();
+        let link_path = real_dir
+            .path()
+            .parent()
+            .unwrap()
+            .join(format!("symlink-root-{}", std::process::id()));
+        std::os::unix::fs::symlink(real_dir.path(), &link_path).unwrap();
+
+        // The caller passes the *symlinked* root, unresolved.
+        let new_file = link_path.join("new-file.md");
+        assert!(!new_file.exists());
+
+        let result = check_path(new_file.to_str().unwrap(), &link_path);
+        let _ = std::fs::remove_file(&link_path);
+        assert_eq!(
+            result,
+            Ok(()),
+            "a non-existent path under a symlinked root must be allowed"
         );
     }
 

--- a/src/llm/tools/save_memory.rs
+++ b/src/llm/tools/save_memory.rs
@@ -1,0 +1,300 @@
+//! Save Memory Tool (qwen-code/Gemini CLI compatible)
+//!
+//! qwen-code's `save_memory` tool (inherited from Gemini CLI, whose fork it
+//! is - `memory-config.ts` re-exports `getCurrentGeminiMdFilename` and
+//! friends, confirming the shared lineage) lets the model persist a fact
+//! *across sessions*: `{"fact": "<self-contained statement>"}`, no other
+//! fields.
+//!
+//! This is deliberately a real tool, not an alias to `session_context`'s
+//! `add_fact` operation: that operation's store is keyed by
+//! `context_{session_id}.json`, so it disappears once the session ends.
+//! Pointing `save_memory` at it would make the call succeed while silently
+//! breaking the one thing a model relying on "remembered" actually needs -
+//! that the fact outlives this conversation. This tool instead appends to a
+//! file keyed by working directory (`.crustly/memory.md`), so it persists
+//! for every future session in the same project.
+
+use super::error::{Result, ToolError};
+use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+pub struct SaveMemoryTool;
+
+#[derive(Debug, Deserialize)]
+struct SaveMemoryInput {
+    fact: String,
+}
+
+const MEMORY_FILE: &str = "memory.md";
+const MEMORY_HEADER: &str = "## Memories";
+
+fn memory_path(working_directory: &Path) -> PathBuf {
+    working_directory.join(".crustly").join(MEMORY_FILE)
+}
+
+/// Append `fact` as a new bullet under `MEMORY_HEADER`, adding the header if
+/// it's missing (empty file, or a file that predates this tool). A no-op
+/// (returns `existing` unchanged, with `false`) if `fact` is already present
+/// verbatim, so re-remembering the same thing doesn't pile up duplicates.
+fn append_fact(existing: &str, fact: &str) -> (String, bool) {
+    let bullet = format!("- {fact}");
+
+    let mut lines: Vec<String> = if existing.trim().is_empty() {
+        vec![MEMORY_HEADER.to_string()]
+    } else if existing.lines().next().map(str::trim) == Some(MEMORY_HEADER) {
+        existing.lines().map(String::from).collect()
+    } else {
+        let mut v = vec![MEMORY_HEADER.to_string()];
+        v.extend(existing.lines().map(String::from));
+        v
+    };
+
+    if lines.iter().any(|l| l.trim() == bullet) {
+        return (existing.to_string(), false);
+    }
+
+    lines.push(bullet);
+    let mut result = lines.join("\n");
+    result.push('\n');
+    (result, true)
+}
+
+#[async_trait]
+impl Tool for SaveMemoryTool {
+    fn name(&self) -> &str {
+        "save_memory"
+    }
+
+    fn description(&self) -> &str {
+        "Save a specific, self-contained fact to long-term project memory, so it's available in \
+         future sessions in this project (not just the rest of this conversation). Use for \
+         durable facts worth remembering across sessions - user preferences, project \
+         conventions, standing decisions. For task-scoped state that shouldn't outlive this \
+         conversation, use todo_write or session_context instead."
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "fact": {
+                    "type": "string",
+                    "description": "The specific fact to remember. Should be a clear, self-contained statement (e.g. 'The user prefers tabs over spaces', not 'use tabs')."
+                }
+            },
+            "required": ["fact"]
+        })
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![ToolCapability::WriteFiles]
+    }
+
+    fn requires_approval(&self) -> bool {
+        false // Remembering a fact is low-risk, same as todo_write/session_context.
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<()> {
+        let input: SaveMemoryInput = serde_json::from_value(input.clone())
+            .map_err(|e| ToolError::InvalidInput(format!("Invalid input: {}", e)))?;
+        if input.fact.trim().is_empty() {
+            return Err(ToolError::InvalidInput("fact cannot be empty".to_string()));
+        }
+        Ok(())
+    }
+
+    async fn execute(&self, input: Value, context: &ToolExecutionContext) -> Result<ToolResult> {
+        // Matches todo_write's precedent: bookkeeping writes under
+        // .crustly/ are still blocked in Plan mode, since Plan mode's
+        // guarantee is "nothing changes until the plan is approved."
+        if context.read_only_mode {
+            return Err(ToolError::PermissionDenied(
+                "Cannot save memory in read-only (plan) mode".to_string(),
+            ));
+        }
+
+        let input: SaveMemoryInput = serde_json::from_value(input)?;
+        let fact = input.fact.trim();
+        if fact.is_empty() {
+            return Ok(ToolResult::error("fact cannot be empty".to_string()));
+        }
+
+        let path = memory_path(&context.working_directory);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.map_err(ToolError::Io)?;
+        }
+
+        let existing = if path.exists() {
+            fs::read_to_string(&path).await.map_err(ToolError::Io)?
+        } else {
+            String::new()
+        };
+
+        let (new_content, added) = append_fact(&existing, fact);
+        if added {
+            fs::write(&path, &new_content).await.map_err(ToolError::Io)?;
+        }
+
+        let message = if added {
+            format!("Remembered: {fact}")
+        } else {
+            format!("Already remembered: {fact}")
+        };
+
+        Ok(ToolResult::success(message)
+            .with_metadata("path".to_string(), path.display().to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    fn context(temp_dir: &TempDir) -> ToolExecutionContext {
+        ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf())
+    }
+
+    #[tokio::test]
+    async fn execute_creates_memory_file_with_header_and_fact() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = SaveMemoryTool;
+
+        let result = tool
+            .execute(
+                serde_json::json!({ "fact": "The user prefers tabs over spaces" }),
+                &context(&temp_dir),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        let contents = tokio::fs::read_to_string(temp_dir.path().join(".crustly/memory.md"))
+            .await
+            .unwrap();
+        assert_eq!(
+            contents,
+            "## Memories\n- The user prefers tabs over spaces\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_appends_to_existing_memory_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = SaveMemoryTool;
+        let ctx = context(&temp_dir);
+
+        tool.execute(serde_json::json!({ "fact": "first fact" }), &ctx)
+            .await
+            .unwrap();
+        tool.execute(serde_json::json!({ "fact": "second fact" }), &ctx)
+            .await
+            .unwrap();
+
+        let contents = tokio::fs::read_to_string(temp_dir.path().join(".crustly/memory.md"))
+            .await
+            .unwrap();
+        assert_eq!(contents, "## Memories\n- first fact\n- second fact\n");
+    }
+
+    /// Regression: re-remembering the exact same fact must not duplicate it.
+    #[tokio::test]
+    async fn execute_does_not_duplicate_an_identical_fact() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = SaveMemoryTool;
+        let ctx = context(&temp_dir);
+
+        tool.execute(serde_json::json!({ "fact": "same fact" }), &ctx)
+            .await
+            .unwrap();
+        let second = tool
+            .execute(serde_json::json!({ "fact": "same fact" }), &ctx)
+            .await
+            .unwrap();
+
+        assert!(second.success);
+        assert!(second.output.contains("Already remembered"));
+        let contents = tokio::fs::read_to_string(temp_dir.path().join(".crustly/memory.md"))
+            .await
+            .unwrap();
+        assert_eq!(contents, "## Memories\n- same fact\n");
+    }
+
+    /// Regression: this is the whole point of the tool over session_context's
+    /// add_fact - the memory file is keyed by working directory, not session
+    /// id, so a second "session" (a fresh ToolExecutionContext, same working
+    /// directory) sees facts saved by an earlier one.
+    #[tokio::test]
+    async fn memory_persists_across_different_sessions_in_the_same_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = SaveMemoryTool;
+
+        let session_one = context(&temp_dir);
+        tool.execute(
+            serde_json::json!({ "fact": "remembered in session one" }),
+            &session_one,
+        )
+        .await
+        .unwrap();
+
+        // A different session_id (a fresh conversation), same directory.
+        let session_two = context(&temp_dir);
+        assert_ne!(session_one.session_id, session_two.session_id);
+
+        let contents = tokio::fs::read_to_string(temp_dir.path().join(".crustly/memory.md"))
+            .await
+            .unwrap();
+        assert!(contents.contains("remembered in session one"));
+
+        tool.execute(
+            serde_json::json!({ "fact": "remembered in session two" }),
+            &session_two,
+        )
+        .await
+        .unwrap();
+
+        let contents = tokio::fs::read_to_string(temp_dir.path().join(".crustly/memory.md"))
+            .await
+            .unwrap();
+        assert!(contents.contains("remembered in session one"));
+        assert!(contents.contains("remembered in session two"));
+    }
+
+    #[tokio::test]
+    async fn execute_blocked_in_read_only_mode() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = SaveMemoryTool;
+        let mut ctx = context(&temp_dir);
+        ctx.read_only_mode = true;
+
+        let result = tool
+            .execute(serde_json::json!({ "fact": "x" }), &ctx)
+            .await;
+        assert!(matches!(result, Err(ToolError::PermissionDenied(_))));
+    }
+
+    #[test]
+    fn validate_input_rejects_empty_fact() {
+        let tool = SaveMemoryTool;
+        assert!(tool
+            .validate_input(&serde_json::json!({ "fact": "   " }))
+            .is_err());
+    }
+
+    #[test]
+    fn append_fact_adds_header_to_a_file_that_lacks_one() {
+        let (content, added) = append_fact("- pre-existing line without a header\n", "new fact");
+        assert!(added);
+        assert_eq!(
+            content,
+            "## Memories\n- pre-existing line without a header\n- new fact\n"
+        );
+    }
+}

--- a/src/llm/tools/save_memory.rs
+++ b/src/llm/tools/save_memory.rs
@@ -137,7 +137,9 @@ impl Tool for SaveMemoryTool {
 
         let (new_content, added) = append_fact(&existing, fact);
         if added {
-            fs::write(&path, &new_content).await.map_err(ToolError::Io)?;
+            fs::write(&path, &new_content)
+                .await
+                .map_err(ToolError::Io)?;
         }
 
         let message = if added {
@@ -274,9 +276,7 @@ mod tests {
         let mut ctx = context(&temp_dir);
         ctx.read_only_mode = true;
 
-        let result = tool
-            .execute(serde_json::json!({ "fact": "x" }), &ctx)
-            .await;
+        let result = tool.execute(serde_json::json!({ "fact": "x" }), &ctx).await;
         assert!(matches!(result, Err(ToolError::PermissionDenied(_))));
     }
 

--- a/src/llm/tools/trait.rs
+++ b/src/llm/tools/trait.rs
@@ -1,6 +1,7 @@
 //! Tool trait definition
 
 use super::error::Result;
+use super::file_read_cache::FileReadCache;
 use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -48,6 +49,18 @@ pub struct ToolExecutionContext {
     /// Optional spawner used by the Agent tool to launch sub-agent sessions.
     /// `None` in unit tests or when the caller has not wired up a launcher.
     pub sub_agent_launcher: Option<Arc<dyn SubAgentLauncher>>,
+
+    /// Session-scoped record of which files this session has read (or
+    /// written), backing "prior read" enforcement in `edit_file`,
+    /// `write_file`'s overwrite path, and `apply_patch`'s Update File
+    /// operation - see `file_read_cache` module docs.
+    ///
+    /// Defaults to a fresh, empty cache scoped to just this context - fine
+    /// for tests and other single-call usages. Real sessions should use
+    /// [`Self::with_file_read_cache`] to inject the same `Arc` across every
+    /// context built for that session, so a read recorded by one tool call
+    /// is visible to the next (see `AgentService`).
+    pub file_read_cache: Arc<FileReadCache>,
 }
 
 impl ToolExecutionContext {
@@ -61,6 +74,7 @@ impl ToolExecutionContext {
             timeout_secs: 30,
             read_only_mode: false,
             sub_agent_launcher: None,
+            file_read_cache: Arc::new(FileReadCache::new()),
         }
     }
 
@@ -91,6 +105,14 @@ impl ToolExecutionContext {
     /// Set the sub-agent launcher (for Agent tool)
     pub fn with_sub_agent_launcher(mut self, launcher: Arc<dyn SubAgentLauncher>) -> Self {
         self.sub_agent_launcher = Some(launcher);
+        self
+    }
+
+    /// Inject a session-scoped file-read cache, shared across every context
+    /// built for the same session, so reads persist across tool calls (and
+    /// across separate `send_message` turns) instead of resetting per call.
+    pub fn with_file_read_cache(mut self, cache: Arc<FileReadCache>) -> Self {
+        self.file_read_cache = cache;
         self
     }
 }

--- a/src/llm/tools/write.rs
+++ b/src/llm/tools/write.rs
@@ -399,7 +399,9 @@ mod tests {
     async fn test_overwrite_rejects_a_file_changed_since_it_was_read() {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("test.txt");
-        tokio::fs::write(&file_path, "Initial content").await.unwrap();
+        tokio::fs::write(&file_path, "Initial content")
+            .await
+            .unwrap();
 
         let context = ToolExecutionContext::new(Uuid::new_v4())
             .with_working_directory(temp_dir.path().to_path_buf());

--- a/src/llm/tools/write.rs
+++ b/src/llm/tools/write.rs
@@ -3,6 +3,7 @@
 //! Allows writing content to files on the filesystem.
 
 use super::error::{validate_path_safety, Result, ToolError};
+use super::file_read_cache::{FileFingerprint, ReadGate};
 use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -35,7 +36,9 @@ impl Tool for WriteTool {
     }
 
     fn description(&self) -> &str {
-        "Write content to a file on the filesystem. Creates the file if it doesn't exist, overwrites if it does."
+        "Write content to a file on the filesystem. Creates the file if it doesn't exist. If it \
+         does exist, this overwrites it, and you must have read it with read_file at least once \
+         in this session first."
     }
 
     fn input_schema(&self) -> Value {
@@ -167,10 +170,45 @@ impl Tool for WriteTool {
             }
         }
 
+        // Prior-read enforcement (matches Claude Code's/qwen-code's write
+        // tools) only applies to overwriting an EXISTING file - there is
+        // nothing to have read before creating a brand-new one.
+        if let Ok(metadata_before) = fs::metadata(&path).await {
+            match context
+                .file_read_cache
+                .check(&path, FileFingerprint::of(&metadata_before))
+            {
+                ReadGate::NeverRead => {
+                    return Ok(ToolResult::error(format!(
+                        "'{}' already exists. You must read it with read_file before \
+                         overwriting it.",
+                        path.display()
+                    )));
+                }
+                ReadGate::Stale => {
+                    return Ok(ToolResult::error(format!(
+                        "'{}' has changed on disk since it was last read. Re-read it with \
+                         read_file before overwriting.",
+                        path.display()
+                    )));
+                }
+                ReadGate::Ok => {}
+            }
+        }
+
         // Write the file
         fs::write(&path, &input.content)
             .await
             .map_err(ToolError::Io)?;
+
+        // Seed the cache with the post-write fingerprint - for a new file
+        // this is the read cache's first record; for an overwrite it
+        // clears the way for a follow-up edit without an intervening
+        // re-read (the model authored these bytes).
+        let metadata_after = fs::metadata(&path).await.map_err(ToolError::Io)?;
+        context
+            .file_read_cache
+            .record(&path, FileFingerprint::of(&metadata_after));
 
         let message = format!(
             "Successfully wrote {} bytes to {}",
@@ -308,16 +346,131 @@ mod tests {
         let context = ToolExecutionContext::new(session_id)
             .with_working_directory(temp_dir.path().to_path_buf());
 
+        // Overwriting an existing file requires having read it first.
+        let metadata = fs::metadata(&file_path).await.unwrap();
+        context
+            .file_read_cache
+            .record(&file_path, FileFingerprint::of(&metadata));
+
         let input = serde_json::json!({
             "path": "test.txt",
             "content": "New content"
         });
 
         let result = tool.execute(input, &context).await.unwrap();
-        assert!(result.success);
+        assert!(result.success, "{:?}", result.error);
 
         // Verify file was overwritten
         let contents = tokio::fs::read_to_string(&file_path).await.unwrap();
         assert_eq!(contents, "New content");
+    }
+
+    /// Regression: matches Claude Code's/qwen-code's write tools - a model
+    /// must not blindly overwrite a file it never read. Creating a brand
+    /// new file (the common case, and every other test in this module) is
+    /// unaffected - there's nothing to have read.
+    #[tokio::test]
+    async fn test_overwrite_rejects_a_file_never_read_this_session() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        tokio::fs::write(&file_path, "Initial content")
+            .await
+            .unwrap();
+
+        let tool = WriteTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let input = serde_json::json!({ "path": "test.txt", "content": "New content" });
+        let result = tool.execute(input, &context).await.unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("must read"));
+        // Must not have touched the file.
+        assert_eq!(
+            tokio::fs::read_to_string(&file_path).await.unwrap(),
+            "Initial content"
+        );
+    }
+
+    /// A file that changed on disk after it was read must not be silently
+    /// clobbered with stale assumptions.
+    #[tokio::test]
+    async fn test_overwrite_rejects_a_file_changed_since_it_was_read() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        tokio::fs::write(&file_path, "Initial content").await.unwrap();
+
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+        let metadata = fs::metadata(&file_path).await.unwrap();
+        context
+            .file_read_cache
+            .record(&file_path, FileFingerprint::of(&metadata));
+
+        // Changes on disk after the recorded read.
+        tokio::fs::write(&file_path, "Initial content, extended")
+            .await
+            .unwrap();
+
+        let tool = WriteTool;
+        let input = serde_json::json!({ "path": "test.txt", "content": "New content" });
+        let result = tool.execute(input, &context).await.unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("changed on disk"));
+        assert_eq!(
+            tokio::fs::read_to_string(&file_path).await.unwrap(),
+            "Initial content, extended"
+        );
+    }
+
+    /// Writing a brand-new file needs no prior read - the model is
+    /// authoring the content, not reading existing bytes.
+    #[tokio::test]
+    async fn test_creating_a_new_file_needs_no_prior_read() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = WriteTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let input = serde_json::json!({ "path": "brand_new.txt", "content": "hello" });
+        let result = tool.execute(input, &context).await.unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+    }
+
+    /// A write's own post-write record clears the gate for a follow-up
+    /// edit_file call in the same session, without an intervening re-read.
+    #[tokio::test]
+    async fn test_write_then_overwrite_does_not_require_a_re_read() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        let tool = WriteTool;
+        let context = ToolExecutionContext::new(Uuid::new_v4())
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let first = tool
+            .execute(
+                serde_json::json!({ "path": "test.txt", "content": "first" }),
+                &context,
+            )
+            .await
+            .unwrap();
+        assert!(first.success, "{:?}", first.error);
+
+        // No re-read in between.
+        let second = tool
+            .execute(
+                serde_json::json!({ "path": "test.txt", "content": "second" }),
+                &context,
+            )
+            .await
+            .unwrap();
+        assert!(second.success, "{:?}", second.error);
+        assert_eq!(
+            tokio::fs::read_to_string(&file_path).await.unwrap(),
+            "second"
+        );
     }
 }

--- a/src/llm/tools/write.rs
+++ b/src/llm/tools/write.rs
@@ -15,7 +15,9 @@ pub struct WriteTool;
 
 #[derive(Debug, Deserialize, Serialize)]
 struct WriteInput {
-    /// Path to the file to write
+    /// Path to the file to write. Accepts `file_path` as an alias - the
+    /// field name sent by Claude Code's and qwen-code's write tools.
+    #[serde(alias = "file_path")]
     path: String,
 
     /// Content to write to the file
@@ -42,7 +44,11 @@ impl Tool for WriteTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Path to the file to write (absolute or relative to working directory)"
+                    "description": "Path to the file to write (absolute or relative to working directory). Alias: file_path."
+                },
+                "file_path": {
+                    "type": "string",
+                    "description": "Alias of 'path'."
                 },
                 "content": {
                     "type": "string",
@@ -249,6 +255,31 @@ mod tests {
         let result = tool.execute(input, &context).await.unwrap();
         assert!(!result.success);
         assert!(result.error.is_some());
+    }
+
+    /// Regression: Claude Code's and qwen-code's write tools send
+    /// `file_path`, not `path`. A model trained on either must still be
+    /// able to call this tool.
+    #[tokio::test]
+    async fn test_write_file_accepts_file_path_alias() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let tool = WriteTool;
+        let session_id = Uuid::new_v4();
+        let context = ToolExecutionContext::new(session_id)
+            .with_working_directory(temp_dir.path().to_path_buf());
+
+        let input = serde_json::json!({
+            "file_path": "test.txt",
+            "content": "Hello via file_path"
+        });
+
+        let result = tool.execute(input, &context).await.unwrap();
+        assert!(result.success, "{:?}", result.error);
+
+        let contents = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(contents, "Hello via file_path");
     }
 
     #[test]

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -201,13 +201,60 @@ pub struct McpTool {
     client: Arc<Mutex<MCPClient>>,
 }
 
+/// Build the namespaced tool name exposed to the model for an MCP tool.
+///
+/// `__` (not `::`) because most providers validate function-call names
+/// against `^[a-zA-Z0-9_-]{1,64}$` - a `:` is rejected by OpenAI/Qwen
+/// (DashScope) tool-calling and would make every MCP tool uncallable the
+/// moment a server is configured. `__` also matches the namespacing
+/// convention used by Claude Code and qwen-code (`mcp__{server}__{tool}`),
+/// so a model trained on either guesses Crustly's MCP tool names correctly.
+pub fn namespaced_tool_name(server_name: &str, tool_name: &str) -> String {
+    format!("mcp__{}__{}", server_name, tool_name)
+}
+
 impl McpTool {
     pub fn new(server_name: &str, def: McpToolDef, client: Arc<Mutex<MCPClient>>) -> Self {
         Self {
-            namespaced_name: format!("mcp::{}::{}", server_name, def.name),
+            namespaced_name: namespaced_tool_name(server_name, &def.name),
             def,
             client,
         }
+    }
+}
+
+#[cfg(test)]
+mod mcp_tool_naming_tests {
+    use super::*;
+
+    /// Regression: a `:` in the tool name is rejected by OpenAI/Qwen
+    /// function-calling name validation (`^[a-zA-Z0-9_-]{1,64}$`), which
+    /// would make every MCP tool uncallable under those providers.
+    #[test]
+    fn namespaced_tool_name_contains_no_colons() {
+        let name = namespaced_tool_name("github", "get_me");
+        assert!(!name.contains(':'), "tool name must not contain ':': {name}");
+    }
+
+    /// Must match the `mcp__{server}__{tool}` convention used by Claude
+    /// Code and qwen-code, so models trained on either guess correctly.
+    #[test]
+    fn namespaced_tool_name_uses_double_underscore_convention() {
+        assert_eq!(
+            namespaced_tool_name("github", "get_me"),
+            "mcp__github__get_me"
+        );
+    }
+
+    #[test]
+    fn namespaced_tool_name_matches_provider_function_name_pattern() {
+        let name = namespaced_tool_name("my-server_1", "some_tool");
+        assert!(
+            name.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "tool name must match ^[a-zA-Z0-9_-]+$: {name}"
+        );
+        assert!(name.len() <= 64, "tool name must be <=64 chars: {name}");
     }
 }
 

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -267,7 +267,10 @@ mod mcp_tool_naming_tests {
     #[test]
     fn namespaced_tool_name_contains_no_colons() {
         let name = namespaced_tool_name("github", "get_me");
-        assert!(!name.contains(':'), "tool name must not contain ':': {name}");
+        assert!(
+            !name.contains(':'),
+            "tool name must not contain ':': {name}"
+        );
     }
 
     /// Must match the `mcp__{server}__{tool}` convention used by Claude

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -223,6 +223,40 @@ impl McpTool {
     }
 }
 
+#[async_trait]
+impl Tool for McpTool {
+    fn name(&self) -> &str {
+        &self.namespaced_name
+    }
+
+    fn description(&self) -> &str {
+        self.def.description.as_deref().unwrap_or("MCP tool")
+    }
+
+    fn input_schema(&self) -> Value {
+        self.def
+            .input_schema
+            .clone()
+            .unwrap_or_else(|| serde_json::json!({}))
+    }
+
+    fn capabilities(&self) -> Vec<ToolCapability> {
+        vec![] // MCP tools declare no built-in capabilities
+    }
+
+    async fn execute(
+        &self,
+        input: Value,
+        _ctx: &ToolExecutionContext,
+    ) -> crate::llm::tools::Result<ToolResult> {
+        let mut client = self.client.lock().await;
+        match client.call_tool(&self.def.name, input).await {
+            Ok(output) => Ok(ToolResult::success(output)),
+            Err(e) => Ok(ToolResult::error(e.to_string())),
+        }
+    }
+}
+
 #[cfg(test)]
 mod mcp_tool_naming_tests {
     use super::*;
@@ -255,39 +289,5 @@ mod mcp_tool_naming_tests {
             "tool name must match ^[a-zA-Z0-9_-]+$: {name}"
         );
         assert!(name.len() <= 64, "tool name must be <=64 chars: {name}");
-    }
-}
-
-#[async_trait]
-impl Tool for McpTool {
-    fn name(&self) -> &str {
-        &self.namespaced_name
-    }
-
-    fn description(&self) -> &str {
-        self.def.description.as_deref().unwrap_or("MCP tool")
-    }
-
-    fn input_schema(&self) -> Value {
-        self.def
-            .input_schema
-            .clone()
-            .unwrap_or_else(|| serde_json::json!({}))
-    }
-
-    fn capabilities(&self) -> Vec<ToolCapability> {
-        vec![] // MCP tools declare no built-in capabilities
-    }
-
-    async fn execute(
-        &self,
-        input: Value,
-        _ctx: &ToolExecutionContext,
-    ) -> crate::llm::tools::Result<ToolResult> {
-        let mut client = self.client.lock().await;
-        match client.call_tool(&self.def.name, input).await {
-            Ok(output) => Ok(ToolResult::success(output)),
-            Err(e) => Ok(ToolResult::error(e.to_string())),
-        }
     }
 }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -862,9 +862,12 @@ pub enum PlanModeState {
 impl PlanModeState {
     /// Returns true if the tool requires user approval in this state.
     pub fn tool_needs_approval(&self, tool_name: &str, _threshold: u8) -> bool {
-        let is_high_risk = matches!(tool_name, "bash" | "write_file" | "edit_file" | "code_exec");
         match self {
-            PlanModeState::AutoExecuting { .. } => is_high_risk,
+            // `is_high_risk_tool` is the single source of truth for this
+            // classification - duplicating its list here previously let the
+            // two drift (a tool added to one list silently stayed missing
+            // from the other).
+            PlanModeState::AutoExecuting { .. } => Self::is_high_risk_tool(tool_name),
             PlanModeState::Executing { .. } => true,
             _ => false,
         }
@@ -932,7 +935,10 @@ impl PlanModeState {
 
     /// Classify a tool call as high-risk for auto-run threshold checks.
     pub fn is_high_risk_tool(tool_name: &str) -> bool {
-        matches!(tool_name, "bash" | "write_file" | "edit_file" | "code_exec")
+        matches!(
+            tool_name,
+            "bash" | "write_file" | "edit_file" | "apply_patch" | "code_exec"
+        )
     }
 }
 

--- a/tests/plan_autorun_test.rs
+++ b/tests/plan_autorun_test.rs
@@ -89,7 +89,7 @@ fn high_risk_tools_pause_auto_execution() {
         mode: AutoRunMode::AutoPlan,
     };
 
-    for high_risk_tool in &["bash", "write_file", "edit_file", "code_exec"] {
+    for high_risk_tool in &["bash", "write_file", "edit_file", "apply_patch", "code_exec"] {
         assert!(
             PlanModeState::is_high_risk_tool(high_risk_tool),
             "{} must be classified high-risk",

--- a/tests/plan_autorun_test.rs
+++ b/tests/plan_autorun_test.rs
@@ -89,7 +89,13 @@ fn high_risk_tools_pause_auto_execution() {
         mode: AutoRunMode::AutoPlan,
     };
 
-    for high_risk_tool in &["bash", "write_file", "edit_file", "apply_patch", "code_exec"] {
+    for high_risk_tool in &[
+        "bash",
+        "write_file",
+        "edit_file",
+        "apply_patch",
+        "code_exec",
+    ] {
         assert!(
             PlanModeState::is_high_risk_tool(high_risk_tool),
             "{} must be classified high-risk",


### PR DESCRIPTION
A tool call cut off mid-argument by max_tokens (finish_reason "length")
left a dangling, truncated <tool_call> fragment visible in the displayed
text instead of being cleaned up. Malformed JSON inside a well-formed
<tool_call> pair was also silently dropped with no logging, making it
undiagnosable. Earlier valid tool calls in the same response still parse
correctly in both cases.