### PR TITLE
fix: update markdown renderer for pulldown-cmark 0.13 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,15 +4752,22 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.6"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.13.0",
  "getopts",
  "memchr",
+ "pulldown-cmark-escape",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ urlencoding = "2.1"
 # Syntax & Parsing
 syntect = { version = "5.2", default-features = false, features = ["default-fancy"] }
 tree-sitter = "0.20"
-pulldown-cmark = "0.9"
+pulldown-cmark = "0.13"
 
 # LSP
 tower-lsp = "0.20"

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -2,7 +2,7 @@
 //!
 //! Converts markdown text to styled Ratatui widgets.
 
-use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag};
+use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag, TagEnd};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -82,10 +82,10 @@ impl MarkdownRenderer {
 
     fn handle_start_tag(&mut self, tag: Tag) {
         match tag {
-            Tag::Heading(level, ..) => self.heading_level = level as u32,
+            Tag::Heading { level, .. } => self.heading_level = level as u32,
             Tag::CodeBlock(kind) => self.start_code_block(kind),
             Tag::List(_) => self.list_level += 1,
-            Tag::BlockQuote => self.flush_current_line(),
+            Tag::BlockQuote(_) => self.flush_current_line(),
             _ => {}
         }
     }
@@ -156,14 +156,14 @@ impl MarkdownRenderer {
         self.lines.push(Line::from("")); // Add spacing after paragraph
     }
 
-    fn handle_end_tag(&mut self, tag: Tag) {
+    fn handle_end_tag(&mut self, tag: TagEnd) {
         match tag {
-            Tag::Heading(..) => self.end_heading(),
-            Tag::CodeBlock(_) => self.end_code_block(),
-            Tag::List(_) => self.end_list(),
-            Tag::Paragraph => self.end_paragraph(),
-            Tag::Item => self.flush_current_line(),
-            Tag::BlockQuote => self.lines.push(Line::from("")), // Add spacing after blockquote
+            TagEnd::Heading(_) => self.end_heading(),
+            TagEnd::CodeBlock => self.end_code_block(),
+            TagEnd::List(_) => self.end_list(),
+            TagEnd::Paragraph => self.end_paragraph(),
+            TagEnd::Item => self.flush_current_line(),
+            TagEnd::BlockQuote(_) => self.lines.push(Line::from("")), // Add spacing after blockquote
             _ => {}
         }
     }
@@ -247,7 +247,7 @@ pub fn last_code_block(markdown: &str) -> Option<String> {
                 in_code_block = true;
                 current.clear();
             }
-            Event::End(Tag::CodeBlock(_)) => {
+            Event::End(TagEnd::CodeBlock) => {
                 in_code_block = false;
                 last = Some(std::mem::take(&mut current));
             }


### PR DESCRIPTION
Bumps pulldown-cmark from 0.9.6 to 0.13.4 (dependabot PR #44) and
updates src/tui/markdown.rs for the new API:
- Tag::Heading is now a struct variant instead of a tuple variant
- Tag::BlockQuote now carries an Option<BlockQuoteKind>
- Event::End now carries TagEnd instead of Tag