### PR TITLE
Add Qwen3-Coder-Next and Qwen3.6-27B to the Qwen provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ For the forward-looking plan, see [ROADMAP.md](ROADMAP.md).
 
 ---
 
+### Unreleased
+
+#### Qwen3-Coder-Next & Qwen3.6-27B Support
+Added `qwen3-coder-next` and `qwen3.6-27b` to the Qwen provider's known model list with their real 256K context window (previously fell back to a conservative 32K default, triggering premature context compaction). The provider also now auto-selects the OpenAI tool parser when `default_model` contains `coder-next`, matching Qwen3-Coder-Next's documented vLLM/SGLang serving recipe (`--tool-call-parser qwen3_coder`), which returns structured `tool_calls` rather than Hermes `<tool_call>` tags. See [QWEN_INTEGRATION.md](docs/guides/QWEN_INTEGRATION.md) for the updated serving instructions.
+
+---
+
 ### v0.5.0 — Gemini Provider & Claude Code / Qwen Compatibility
 
 #### Native Google Gemini Provider

--- a/README.md
+++ b/README.md
@@ -21,32 +21,32 @@
 
 ## Table of Contents
 
-- [📸 Screenshots](#screenshots)
-- [🎯 Main Coding Features](#main-coding-features)
-- [✨ What's New](#whats-new)
-- [🔒 Interactive Approval System](#interactive-approval-system)
-- [⚠️ Important Disclaimers](#important-disclaimers)
-- [🌐 Supported AI Providers](#supported-ai-providers)
-- [🧩 Reference Coding Models & Hardware Requirements](#reference-coding-models--hardware-requirements)
-- [🚀 Quick Start](#quick-start)
-- [📋 A Note on Claude Max and GitHub Copilot](#a-note-on-claude-max-and-github-copilot)
-- [🏠 Running Crustly with Local LLMs](#running-crustly-with-local-llms)
-- [💡 Best Practices for Using Crustly](#best-practices-for-using-crustly)
-- [👨‍💻 Why Crustly for Coding?](#why-crustly-for-coding)
-- [📋 Plan Mode — Structured Task Planning](#plan-mode-structured-task-planning)
-- [🧪 Manual Testing Guide](#manual-testing-guide)
-- [📊 Performance](#performance)
-- [🏗️ Architecture](#architecture)
-- [📁 Project Structure](#project-structure)
-- [🔍 Debug and Logging](#debug-and-logging)
-- [🛠️ Development](#development)
-- [📖 Documentation](#documentation)
-- [🤝 Contributing](#contributing)
-- [🐛 Known Issues & Platform-Specific Notes](#known-issues-platform-specific-notes)
-- [📄 License](#license)
-- [🙏 Acknowledgments](#acknowledgments)
-- [📞 Support](#support)
-- [📈 Status](#status)
+- [📸 Screenshots](#-screenshots)
+- [🎯 Main Coding Features](#-main-coding-features)
+- [✨ What's New](#-whats-new)
+- [🔒 Interactive Approval System](#-interactive-approval-system)
+- [⚠️ Important Disclaimers](#️-important-disclaimers)
+- [🌐 Supported AI Providers](#-supported-ai-providers)
+- [🧩 Reference Coding Models & Hardware Requirements](#-reference-coding-models--hardware-requirements)
+- [🚀 Quick Start](#-quick-start)
+- [📋 A Note on Claude Max and GitHub Copilot](#-a-note-on-claude-max-and-github-copilot)
+- [🏠 Running Crustly with Local LLMs](#-running-crustly-with-local-llms)
+- [💡 Best Practices for Using Crustly](#-best-practices-for-using-crustly)
+- [👨‍💻 Why Crustly for Coding?](#-why-crustly-for-coding)
+- [📋 Plan Mode — Structured Task Planning](#-plan-mode--structured-task-planning)
+- [🧪 Manual Testing Guide](#-manual-testing-guide)
+- [📊 Performance](#-performance)
+- [🏗️ Architecture](#️-architecture)
+- [📁 Project Structure](#-project-structure)
+- [🔍 Debug and Logging](#-debug-and-logging)
+- [🛠️ Development](#️-development)
+- [📖 Documentation](#-documentation)
+- [🤝 Contributing](#-contributing)
+- [🐛 Known Issues & Platform-Specific Notes](#-known-issues--platform-specific-notes)
+- [📄 License](#-license)
+- [🙏 Acknowledgments](#-acknowledgments)
+- [📞 Support](#-support)
+- [📈 Status](#-status)
 
 ---
 
@@ -962,7 +962,7 @@ See [LICENSE.md](LICENSE.md) for details.
 
 ## 📈 Status
 
-Crustly is under active development — see the **[✨ What's New](#whats-new)**
+Crustly is under active development — see the **[✨ What's New](#-whats-new)**
 section above and **[CHANGELOG.md](CHANGELOG.md)** for the current feature
 set, and **[ROADMAP.md](ROADMAP.md)** for what's shipped vs. planned. The
 Sprint 0-12 development log from the pre-1.0 bring-up phase is archived at

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [🔒 Interactive Approval System](#interactive-approval-system)
 - [⚠️ Important Disclaimers](#important-disclaimers)
 - [🌐 Supported AI Providers](#supported-ai-providers)
+- [🧩 Reference Coding Models & Hardware Requirements](#reference-coding-models--hardware-requirements)
 - [🚀 Quick Start](#quick-start)
 - [📋 A Note on Claude Max and GitHub Copilot](#a-note-on-claude-max-and-github-copilot)
 - [🏠 Running Crustly with Local LLMs](#running-crustly-with-local-llms)
@@ -419,6 +420,59 @@ cargo run
 ```
 
 See [LM_STUDIO_GUIDE.md](docs/guides/LM_STUDIO_GUIDE.md) for complete setup instructions.
+
+---
+
+## 🧩 Reference Coding Models & Hardware Requirements
+
+Three models cover the three roles a coding agent needs — writing code, planning/reasoning, and reviewing/documenting — and are Crustly's current reference points for each:
+
+| Model | Role | Params | Context (Crustly) | Provider | Serving |
+|---|---|---|---|---|---|
+| **[Qwen3-Coder-Next](https://huggingface.co/Qwen/Qwen3-Coder-Next)** ⭐ | Primary coding agent | 80B MoE (~3B active/token) | 256K | `providers.qwen` (local) | vLLM / SGLang |
+| **Qwen3.6-27B** | Reasoning & planning | 27B dense | 256K (open-weight); cloud releases may support up to 1M | `providers.qwen` (local or DashScope) | vLLM / SGLang / DashScope |
+| **Gemma 4 26B** (`gemma-4-26b-a4b-it`) | Architecture, docs, review | 25.2B MoE (~3.8B active/token) | 128K via Gemini API; up to 256K on the Ollama-hosted GGUF | `providers.gemini` (free) or native Ollama | Gemini API or Ollama |
+
+All three are wired up in Crustly's provider layer today: `qwen3-coder-next` and `qwen3.6-27b` are registered in the Qwen provider with their real 256K context window, and the provider auto-selects the OpenAI tool-call parser for Qwen3-Coder-Next to match its documented vLLM/SGLang serving recipe. Gemma 4 26B is served through the Gemini provider free of charge, or locally via `ollama pull gemma4:26b`. See [QWEN_INTEGRATION.md](docs/guides/QWEN_INTEGRATION.md) for Qwen setup/config and [LM_STUDIO_GUIDE.md](docs/guides/LM_STUDIO_GUIDE.md#gemma-4-google) for the Gemma 4 hardware breakdown.
+
+### Hardware requirements
+
+> Figures below are estimated from published parameter counts using standard quantization overhead (~0.55–0.6 bytes/param at Q4/INT4, 2 bytes/param at BF16/FP16) — the same method used elsewhere in this README and in [LM_STUDIO_GUIDE.md](docs/guides/LM_STUDIO_GUIDE.md). Check each model's card for vendor-confirmed numbers before provisioning production hardware.
+
+#### Qwen3-Coder-Next (80B MoE, ~3B active/token)
+
+Designed for datacenter/workstation vLLM or SGLang serving rather than a single consumer GPU — the full expert set must be resident for production-grade throughput.
+
+| Deployment | VRAM | System RAM | Notes |
+|---|---|---|---|
+| **BF16/FP16 (vLLM/SGLang default)** | ~160 GB | 32 GB+ | Needs multi-GPU, e.g. 2× A100/H100 80GB, or split across 4× 48GB workstation GPUs with tensor parallelism |
+| **AWQ/GPTQ INT4 (vLLM quantized)** | ~45–50 GB | 32 GB+ | Fits a single 80GB A100/H100, or 2× 24GB consumer GPUs (e.g. RTX 4090) with tensor parallelism |
+| Disk | ~45 GB (INT4) – ~160 GB (BF16 safetensors) | — | — |
+
+```bash
+vllm serve Qwen/Qwen3-Coder-Next \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder
+```
+
+No local GPU? Use DashScope cloud instead (`api_key` + `region` under `[providers.qwen]` — see [QWEN_INTEGRATION.md](docs/guides/QWEN_INTEGRATION.md)) once Qwen3-Coder-Next is available there.
+
+#### Qwen3.6-27B (27B dense)
+
+Comparable footprint to other 27B-class dense models already in this README (Gemma-3-27B-IT, Qwen2.5-Coder-32B).
+
+| Deployment | VRAM | System RAM | Notes |
+|---|---|---|---|
+| **Q4_K_M (GGUF via Ollama/LM Studio)** | ~20 GB | 40 GB | Best speed/quality balance for local use |
+| **BF16/FP16 (vLLM/SGLang)** | ~54 GB | 32 GB+ | Fits a single 80GB A100/H100 |
+| Cloud (DashScope) | none | none | Recommended default for the reasoning/planning tier if you don't have a spare GPU |
+
+#### Gemma 4 26B (25.2B MoE, ~3.8B active/token)
+
+| Deployment | VRAM | System RAM | Notes |
+|---|---|---|---|
+| **Gemini API** (`providers.gemini`) | none | none | Free of charge, 128K context, no GPU or Ollama required — recommended default |
+| **Ollama** (`ollama pull gemma4:26b`, Q4_K_M) | ~12 GB | 32 GB | Up to 256K context locally; see the exact config snippet in [LM_STUDIO_GUIDE.md](docs/guides/LM_STUDIO_GUIDE.md#gemma-4-google) |
 
 ---
 

--- a/docs/guides/QWEN_INTEGRATION.md
+++ b/docs/guides/QWEN_INTEGRATION.md
@@ -172,6 +172,10 @@ thinking_budget = 5000  # Optional: limit thinking tokens
 
 ## Supported Models
 
+### Qwen3-Coder-Next & Qwen3.6
+- `qwen3-coder-next` - Agentic coding MoE (80B total / ~3B active, 256K context). Auto-selects the OpenAI tool parser (see [Local Deployment with vLLM](#local-deployment-with-vllm)) since its official serving recipe returns structured `tool_calls`, not Hermes tags.
+- `qwen3.6-27b` - Reasoning + coding (256K context locally; cloud releases may support up to 1M)
+
 ### Qwen3 Series
 - `qwen3-235b-a22b` - Flagship MoE model (131K context)
 - `qwen3-32b` - High performance (131K context)
@@ -221,6 +225,32 @@ default_model = "Qwen/Qwen3-8B"
 tool_parser = "hermes"
 enable_thinking = true
 ```
+
+### Qwen3-Coder-Next (vLLM / SGLang)
+
+Qwen3-Coder-Next's official serving recipe uses the dedicated `qwen3_coder`
+tool-call parser, which returns tool calls via the structured OpenAI
+`tool_calls` field rather than Hermes `<tool_call>` tags:
+
+```bash
+vllm serve Qwen/Qwen3-Coder-Next \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --port 8000
+```
+
+Crustly detects `coder-next` in `default_model` and automatically switches
+the OpenAI tool parser on for you, so no `tool_parser` setting is required:
+
+```toml
+[providers.qwen]
+enabled = true
+base_url = "http://localhost:8000/v1/chat/completions"
+default_model = "qwen3-coder-next"
+```
+
+Set `tool_parser` explicitly (e.g. `"hermes"`) only if you're running a
+different tool-call parser than the recipe above.
 
 ## Local Deployment with LM Studio
 

--- a/src/llm/provider/factory.rs
+++ b/src/llm/provider/factory.rs
@@ -816,7 +816,10 @@ mod tests {
             repetition_penalty: None,
         };
 
-        let provider = configure_qwen(QwenProvider::local(config.base_url.clone().unwrap()), &config);
+        let provider = configure_qwen(
+            QwenProvider::local(config.base_url.clone().unwrap()),
+            &config,
+        );
 
         assert_eq!(provider.tool_parser(), ToolCallParser::OpenAI);
     }
@@ -839,7 +842,10 @@ mod tests {
             repetition_penalty: None,
         };
 
-        let provider = configure_qwen(QwenProvider::local(config.base_url.clone().unwrap()), &config);
+        let provider = configure_qwen(
+            QwenProvider::local(config.base_url.clone().unwrap()),
+            &config,
+        );
 
         assert_eq!(provider.tool_parser(), ToolCallParser::NativeQwen);
     }
@@ -862,7 +868,10 @@ mod tests {
             repetition_penalty: None,
         };
 
-        let provider = configure_qwen(QwenProvider::local(config.base_url.clone().unwrap()), &config);
+        let provider = configure_qwen(
+            QwenProvider::local(config.base_url.clone().unwrap()),
+            &config,
+        );
 
         assert_eq!(provider.tool_parser(), ToolCallParser::Hermes);
     }

--- a/src/llm/provider/factory.rs
+++ b/src/llm/provider/factory.rs
@@ -290,6 +290,19 @@ fn configure_qwen(mut provider: QwenProvider, config: &QwenProviderConfig) -> Qw
         if tool_parser == ToolCallParser::NativeQwen {
             println!("🔧 Using native Qwen function calling (✿FUNCTION✿ markers)\n");
         }
+    } else if config
+        .default_model
+        .as_deref()
+        .is_some_and(|m| m.to_lowercase().contains("coder-next"))
+    {
+        // Qwen3-Coder-Next's recommended vLLM/SGLang serving recipe
+        // (`--tool-call-parser qwen3_coder --enable-auto-tool-choice`)
+        // returns tool calls via the structured OpenAI `tool_calls` field,
+        // not the Hermes `<tool_call>` text tags that `QwenProvider::local`
+        // otherwise defaults to for local deployments - so an explicit
+        // override is needed here to match that server behavior.
+        provider = provider.with_tool_parser(ToolCallParser::OpenAI);
+        tracing::info!("Auto-selected OpenAI tool parser for Qwen3-Coder-Next");
     }
 
     // Set thinking mode
@@ -780,6 +793,78 @@ mod tests {
         assert!(result.is_ok());
         let provider = result.unwrap();
         assert_eq!(provider.name(), "qwen");
+    }
+
+    /// Qwen3-Coder-Next's documented vLLM/SGLang serving recipe
+    /// (`--tool-call-parser qwen3_coder --enable-auto-tool-choice`) emits
+    /// tool calls via the structured OpenAI `tool_calls` field, so
+    /// `configure_qwen` must not leave it on `QwenProvider::local`'s Hermes
+    /// default when no explicit `tool_parser` is configured.
+    #[test]
+    fn configure_qwen_auto_selects_openai_parser_for_coder_next() {
+        let config = QwenProviderConfig {
+            enabled: true,
+            api_key: None,
+            base_url: Some("http://localhost:8000/v1".to_string()),
+            default_model: Some("qwen3-coder-next".to_string()),
+            tool_parser: None,
+            enable_thinking: false,
+            thinking_budget: None,
+            region: None,
+            top_p: None,
+            top_k: None,
+            repetition_penalty: None,
+        };
+
+        let provider = configure_qwen(QwenProvider::local(config.base_url.clone().unwrap()), &config);
+
+        assert_eq!(provider.tool_parser(), ToolCallParser::OpenAI);
+    }
+
+    /// An explicit `tool_parser` config always wins over the Coder-Next
+    /// auto-selection - a user who deliberately picked Hermes should get it.
+    #[test]
+    fn configure_qwen_explicit_tool_parser_overrides_coder_next_auto_selection() {
+        let config = QwenProviderConfig {
+            enabled: true,
+            api_key: None,
+            base_url: Some("http://localhost:8000/v1".to_string()),
+            default_model: Some("qwen3-coder-next".to_string()),
+            tool_parser: Some("native".to_string()),
+            enable_thinking: false,
+            thinking_budget: None,
+            region: None,
+            top_p: None,
+            top_k: None,
+            repetition_penalty: None,
+        };
+
+        let provider = configure_qwen(QwenProvider::local(config.base_url.clone().unwrap()), &config);
+
+        assert_eq!(provider.tool_parser(), ToolCallParser::NativeQwen);
+    }
+
+    /// Other local Qwen3 models must keep the existing Hermes default -
+    /// the auto-selection is scoped to Coder-Next specifically.
+    #[test]
+    fn configure_qwen_keeps_hermes_default_for_other_models() {
+        let config = QwenProviderConfig {
+            enabled: true,
+            api_key: None,
+            base_url: Some("http://localhost:8000/v1".to_string()),
+            default_model: Some("qwen3-8b".to_string()),
+            tool_parser: None,
+            enable_thinking: false,
+            thinking_budget: None,
+            region: None,
+            top_p: None,
+            top_k: None,
+            repetition_penalty: None,
+        };
+
+        let provider = configure_qwen(QwenProvider::local(config.base_url.clone().unwrap()), &config);
+
+        assert_eq!(provider.tool_parser(), ToolCallParser::Hermes);
     }
 
     #[test]

--- a/src/llm/provider/qwen.rs
+++ b/src/llm/provider/qwen.rs
@@ -6,6 +6,8 @@
 //! - Local deployment (vLLM, LM Studio) and DashScope cloud API
 //!
 //! ## Supported Models
+//! - qwen3-coder-next (Qwen3-Coder-Next MoE, 80B/~3B active, 256K context)
+//! - qwen3.6-27b (Qwen3.6 reasoning + coding, 256K context)
 //! - qwen3-235b-a22b (Qwen3 MoE flagship)
 //! - qwen3-32b (Qwen3 32B)
 //! - qwen3-14b (Qwen3 14B)
@@ -136,6 +138,13 @@ impl QwenProvider {
     pub fn with_tool_parser(mut self, parser: ToolCallParser) -> Self {
         self.tool_parser = parser;
         self
+    }
+
+    /// Current tool-call parsing mode, for tests in other modules (e.g.
+    /// `factory::configure_qwen`'s auto-selection logic).
+    #[cfg(test)]
+    pub(crate) fn tool_parser(&self) -> ToolCallParser {
+        self.tool_parser
     }
 
     /// Override sampling parameters sent with every request. Any field left
@@ -1464,6 +1473,9 @@ impl Provider for QwenProvider {
 
     fn supported_models(&self) -> Vec<String> {
         vec![
+            // Qwen3-Coder-Next and Qwen3.6 (256K context)
+            "qwen3-coder-next".to_string(),
+            "qwen3.6-27b".to_string(),
             // Qwen3 models
             "qwen3-235b-a22b".to_string(),
             "qwen3-32b".to_string(),
@@ -1495,6 +1507,9 @@ impl Provider for QwenProvider {
 
     fn context_window(&self, model: &str) -> Option<u32> {
         match model {
+            // Qwen3-Coder-Next and Qwen3.6 (256K native context)
+            "qwen3-coder-next" => Some(262_144),
+            "qwen3.6-27b" => Some(262_144),
             // Qwen3 models
             "qwen3-235b-a22b" => Some(131_072),
             "qwen3-32b" => Some(131_072),
@@ -2168,6 +2183,8 @@ Here's my analysis of the code."#;
         assert!(models.contains(&"qwen3-8b".to_string()));
         assert!(models.contains(&"qwen2.5-coder-14b-instruct".to_string()));
         assert!(models.contains(&"qwen-max".to_string()));
+        assert!(models.contains(&"qwen3-coder-next".to_string()));
+        assert!(models.contains(&"qwen3.6-27b".to_string()));
     }
 
     #[test]
@@ -2175,6 +2192,8 @@ Here's my analysis of the code."#;
         let provider = QwenProvider::dashscope_intl("test-key".to_string());
         assert_eq!(provider.context_window("qwen3-8b"), Some(131_072));
         assert_eq!(provider.context_window("qwen-max"), Some(32_768));
+        assert_eq!(provider.context_window("qwen3-coder-next"), Some(262_144));
+        assert_eq!(provider.context_window("qwen3.6-27b"), Some(262_144));
     }
 
     #[test]


### PR DESCRIPTION
Both models were only reachable through the generic local-deployment
fallback, which left two gaps: context_window() defaulted to a
conservative 32K instead of their real 256K (triggering premature
context compaction), and the local provider's Hermes tool-parser
default didn't match Qwen3-Coder-Next's documented vLLM/SGLang serving
recipe (--tool-call-parser qwen3_coder), which returns structured
tool_calls instead of Hermes tags.

Registers both models with their real context window, and
auto-selects the OpenAI tool parser when default_model contains
"coder-next" unless the user has set tool_parser explicitly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SUkefgLzR226iMtzPjFzL