### PR TITLE
Add model deletion to the TUI's Model Download dialog

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2681,11 +2681,10 @@ mod tests {
         assert!(app
             .model_download_installed
             .contains(&"qwen2.5-coder:7b".to_string()));
-        assert!(app
-            .messages
-            .iter()
-            .any(|m| m.content.contains("Failed to delete 'qwen2.5-coder:7b'")
-                && m.content.contains("model is in use")));
+        assert!(app.messages.iter().any(|m| m
+            .content
+            .contains("Failed to delete 'qwen2.5-coder:7b'")
+            && m.content.contains("model is in use")));
     }
 
     /// Up recalls the last submitted message into the input without resending

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -141,6 +141,12 @@ pub struct App {
     pub model_download_status: Option<String>,
     pub model_download_fraction: Option<f64>,
     model_download_task: Option<tokio::task::JoinHandle<()>>,
+    /// Installed model awaiting delete confirmation ('Y'/Enter confirms,
+    /// 'N'/Esc cancels back to the suggestion list).
+    pub model_download_confirm_delete: Option<String>,
+    /// Installed model currently being deleted, if any.
+    pub model_download_deleting: Option<String>,
+    model_download_delete_task: Option<tokio::task::JoinHandle<()>>,
     ollama_host: String,
 
     // Provider Switch dialog state (Ctrl+W, native Ollama provider)
@@ -212,6 +218,9 @@ impl App {
             model_download_status: None,
             model_download_fraction: None,
             model_download_task: None,
+            model_download_confirm_delete: None,
+            model_download_deleting: None,
+            model_download_delete_task: None,
             ollama_host: "http://localhost:11434".to_string(),
             provider_switch_models: Vec::new(),
             provider_switch_selected: 0,
@@ -630,6 +639,36 @@ impl App {
                     let models = super::ollama_download::fetch_installed_models(host).await;
                     let _ = sender.send(TuiEvent::OllamaModelsListed(models));
                 });
+            }
+            TuiEvent::OllamaDeleteFinished { model, error } => {
+                self.model_download_deleting = None;
+                self.model_download_delete_task = None;
+
+                let content = match &error {
+                    None => format!("🗑️ Deleted '{}'.", model),
+                    Some(e) => format!("❌ Failed to delete '{}': {}", model, e),
+                };
+                let notification = DisplayMessage {
+                    id: Uuid::new_v4(),
+                    role: "system".to_string(),
+                    content,
+                    thinking_text: None,
+                    thinking_expanded: false,
+                    timestamp: chrono::Utc::now(),
+                    token_count: None,
+                    cost: None,
+                    provider_name: None,
+                    perf_metrics: None,
+                    tokens_per_second: None,
+                };
+                self.messages.push(notification);
+
+                if error.is_none() {
+                    self.model_download_installed.retain(|m| m != &model);
+                    self.refresh_model_download_suggestions();
+                }
+
+                self.switch_mode(AppMode::Chat).await?;
             }
         }
         Ok(())
@@ -2011,6 +2050,8 @@ impl App {
         self.model_download_running = false;
         self.model_download_status = None;
         self.model_download_fraction = None;
+        self.model_download_confirm_delete = None;
+        self.model_download_deleting = None;
         self.refresh_model_download_suggestions();
 
         let host = self.ollama_host.clone();
@@ -2049,25 +2090,60 @@ impl App {
         self.model_download_task = Some(handle);
     }
 
+    /// Start deleting `model` in the background. No-op if a pull or delete
+    /// is already running (only one operation at a time from this dialog).
+    async fn start_model_delete(&mut self, model: String) {
+        if self.model_download_running || self.model_download_deleting.is_some() {
+            return;
+        }
+
+        self.model_download_deleting = Some(model.clone());
+
+        let host = self.ollama_host.clone();
+        let sender = self.event_sender();
+        let handle = super::ollama_download::spawn_delete(host, model, sender).await;
+        self.model_download_delete_task = Some(handle);
+    }
+
     /// Handle keys in the Model Download dialog.
     async fn handle_model_download_key(&mut self, event: crossterm::event::KeyEvent) -> Result<()> {
         use super::events::keys;
         use crossterm::event::KeyCode;
 
+        // Confirming a delete: only Y/Enter confirms, N/Esc cancels back to
+        // the suggestion list (without closing the whole dialog).
+        if let Some(model) = self.model_download_confirm_delete.clone() {
+            match event.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                    self.model_download_confirm_delete = None;
+                    self.start_model_delete(model).await;
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                    self.model_download_confirm_delete = None;
+                }
+                _ => {}
+            }
+            return Ok(());
+        }
+
         if keys::is_cancel(&event) {
-            // Cancel an in-flight pull (if any) and close the dialog.
+            // Cancel an in-flight pull/delete (if any) and close the dialog.
             if let Some(handle) = self.model_download_task.take() {
                 handle.abort();
             }
+            if let Some(handle) = self.model_download_delete_task.take() {
+                handle.abort();
+            }
             self.model_download_running = false;
+            self.model_download_deleting = None;
             self.model_download_status = None;
             self.model_download_fraction = None;
             self.switch_mode(AppMode::Chat).await?;
             return Ok(());
         }
 
-        // While a pull is running, only Esc (handled above) does anything.
-        if self.model_download_running {
+        // While a pull or delete is running, only Esc (handled above) does anything.
+        if self.model_download_running || self.model_download_deleting.is_some() {
             return Ok(());
         }
 
@@ -2086,6 +2162,17 @@ impl App {
             {
                 self.model_download_input = suggestion.clone();
                 self.refresh_model_download_suggestions();
+            }
+        } else if event.code == KeyCode::Delete {
+            // Ask for confirmation before deleting the highlighted model -
+            // only installed models can be deleted.
+            if let Some(name) = self
+                .model_download_suggestions
+                .get(self.model_download_selected)
+            {
+                if self.model_download_installed.iter().any(|m| m == name) {
+                    self.model_download_confirm_delete = Some(name.clone());
+                }
             }
         } else if keys::is_enter(&event) {
             let model = self.model_download_input.trim().to_string();
@@ -2458,6 +2545,147 @@ mod tests {
             .iter()
             .any(|m| m.content.contains("Failed to pull 'bogus-model'")
                 && m.content.contains("model not found")));
+    }
+
+    /// Delete only asks for confirmation when the highlighted suggestion is
+    /// actually installed - curated-but-not-pulled entries can't be deleted.
+    #[tokio::test]
+    async fn delete_key_ignored_for_uninstalled_suggestion() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        // Freshly opened dialog has no installed models yet.
+        assert!(app.model_download_installed.is_empty());
+
+        app.handle_model_download_key(key(KeyCode::Delete))
+            .await
+            .unwrap();
+
+        assert!(app.model_download_confirm_delete.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_key_on_installed_model_asks_for_confirmation() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        app.handle_event(TuiEvent::OllamaModelsListed(vec![
+            "qwen2.5-coder:7b".to_string()
+        ]))
+        .await
+        .unwrap();
+        let idx = app
+            .model_download_suggestions
+            .iter()
+            .position(|s| s == "qwen2.5-coder:7b")
+            .expect("installed model should be in suggestions");
+        app.model_download_selected = idx;
+
+        app.handle_model_download_key(key(KeyCode::Delete))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            app.model_download_confirm_delete,
+            Some("qwen2.5-coder:7b".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_delete_n_cancels_back_to_list() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        app.model_download_confirm_delete = Some("qwen2.5-coder:7b".to_string());
+
+        app.handle_model_download_key(key(KeyCode::Char('n')))
+            .await
+            .unwrap();
+
+        assert!(app.model_download_confirm_delete.is_none());
+        assert!(app.model_download_deleting.is_none());
+        assert_eq!(app.mode, AppMode::ModelDownload);
+    }
+
+    #[tokio::test]
+    async fn confirm_delete_esc_cancels_back_to_list_without_closing_dialog() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        app.model_download_confirm_delete = Some("qwen2.5-coder:7b".to_string());
+
+        app.handle_model_download_key(key(KeyCode::Esc))
+            .await
+            .unwrap();
+
+        assert!(app.model_download_confirm_delete.is_none());
+        assert_eq!(
+            app.mode,
+            AppMode::ModelDownload,
+            "Esc during confirmation should not close the whole dialog"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_delete_y_starts_delete() {
+        let mut app = test_app().await;
+        app.open_model_download().await.unwrap();
+        app.model_download_confirm_delete = Some("qwen2.5-coder:7b".to_string());
+
+        app.handle_model_download_key(key(KeyCode::Char('y')))
+            .await
+            .unwrap();
+
+        assert!(app.model_download_confirm_delete.is_none());
+        assert_eq!(
+            app.model_download_deleting,
+            Some("qwen2.5-coder:7b".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_ollama_delete_finished_success_removes_from_installed_and_posts_message() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ModelDownload;
+        app.model_download_installed = vec!["qwen2.5-coder:7b".to_string()];
+        app.model_download_deleting = Some("qwen2.5-coder:7b".to_string());
+
+        app.handle_event(TuiEvent::OllamaDeleteFinished {
+            model: "qwen2.5-coder:7b".to_string(),
+            error: None,
+        })
+        .await
+        .unwrap();
+
+        assert!(app.model_download_deleting.is_none());
+        assert_eq!(app.mode, AppMode::Chat);
+        assert!(!app
+            .model_download_installed
+            .contains(&"qwen2.5-coder:7b".to_string()));
+        assert!(app
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Deleted 'qwen2.5-coder:7b'")));
+    }
+
+    #[tokio::test]
+    async fn handle_ollama_delete_finished_failure_keeps_installed_and_posts_error() {
+        let mut app = test_app().await;
+        app.model_download_installed = vec!["qwen2.5-coder:7b".to_string()];
+        app.model_download_deleting = Some("qwen2.5-coder:7b".to_string());
+
+        app.handle_event(TuiEvent::OllamaDeleteFinished {
+            model: "qwen2.5-coder:7b".to_string(),
+            error: Some("model is in use".to_string()),
+        })
+        .await
+        .unwrap();
+
+        assert!(app.model_download_deleting.is_none());
+        assert!(app
+            .model_download_installed
+            .contains(&"qwen2.5-coder:7b".to_string()));
+        assert!(app
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Failed to delete 'qwen2.5-coder:7b'")
+                && m.content.contains("model is in use")));
     }
 
     /// Up recalls the last submitted message into the input without resending

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -70,6 +70,12 @@ pub enum TuiEvent {
         error: Option<String>,
     },
 
+    /// An Ollama model delete finished (`error` is `None` on success).
+    OllamaDeleteFinished {
+        model: String,
+        error: Option<String>,
+    },
+
     /// Locally-installed Ollama models were (re)loaded for the Provider
     /// Switch dialog's model list.
     ProviderSwitchModelsListed(Vec<String>),

--- a/src/tui/ollama_download.rs
+++ b/src/tui/ollama_download.rs
@@ -167,6 +167,45 @@ pub async fn spawn_pull(
     })
 }
 
+/// Start deleting `model` in the background, forwarding the result through
+/// `event_sender`. Returns the `JoinHandle` so the caller can `.abort()` it
+/// (e.g. on Esc), mirroring `spawn_pull` - though a delete is a single
+/// request/response rather than a stream, so there's no progress to forward.
+#[cfg(feature = "ollama")]
+pub async fn spawn_delete(
+    host: String,
+    model: String,
+    event_sender: UnboundedSender<TuiEvent>,
+) -> JoinHandle<()> {
+    use crate::llm::provider::ollama_models;
+
+    tokio::spawn(async move {
+        let result = ollama_models::delete_model(&host, &model).await;
+        let _ = event_sender.send(TuiEvent::OllamaDeleteFinished {
+            model,
+            error: result.err().map(|e| e.to_string()),
+        });
+    })
+}
+
+#[cfg(not(feature = "ollama"))]
+pub async fn spawn_delete(
+    _host: String,
+    model: String,
+    event_sender: UnboundedSender<TuiEvent>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let _ = event_sender.send(TuiEvent::OllamaDeleteFinished {
+            model,
+            error: Some(
+                "This build of crustly was compiled without the 'ollama' feature. \
+                 Rebuild with `--features ollama` (or `all-llm`)."
+                    .to_string(),
+            ),
+        });
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1900,9 +1900,7 @@ fn render_model_download_confirm_delete(f: &mut Frame, model: &str, area: Rect) 
     let lines = vec![
         Line::from(vec![Span::styled(
             format!("🗑️ Delete '{}'?", model),
-            Style::default()
-                .fg(Color::Red)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         )]),
         Line::from(""),
         Line::from(Span::styled(
@@ -1933,9 +1931,7 @@ fn render_model_download_confirm_delete(f: &mut Frame, model: &str, area: Rect) 
                 .border_style(Style::default().fg(Color::Red))
                 .title(Span::styled(
                     " Confirm Delete ",
-                    Style::default()
-                        .fg(Color::Red)
-                        .add_modifier(Modifier::BOLD),
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 )),
         )
         .wrap(Wrap { trim: false });

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1715,6 +1715,14 @@ fn render_provider_switch(f: &mut Frame, app: &App, area: Rect) {
 /// name input + suggestions list, or a live progress bar while a pull is
 /// in flight.
 fn render_model_download(f: &mut Frame, app: &App, area: Rect) {
+    if let Some(model) = &app.model_download_confirm_delete {
+        render_model_download_confirm_delete(f, model, area);
+        return;
+    }
+    if let Some(model) = &app.model_download_deleting {
+        render_model_download_deleting(f, model, area);
+        return;
+    }
     if app.model_download_running {
         render_model_download_progress(f, app, area);
         return;
@@ -1798,6 +1806,11 @@ fn render_model_download(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled(" Pull  ", Style::default().fg(Color::White)),
         Span::styled(
+            "[Del]",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Delete installed  ", Style::default().fg(Color::White)),
+        Span::styled(
             "[Esc]",
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         ),
@@ -1871,6 +1884,81 @@ fn render_model_download_progress(f: &mut Frame, app: &App, area: Rect) {
                 .border_style(Style::default().fg(Color::Yellow))
                 .title(Span::styled(
                     " Downloading… ",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )),
+        )
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(widget, area);
+}
+
+/// Render the confirmation step before deleting a locally-installed model
+/// (Del in the suggestion list).
+fn render_model_download_confirm_delete(f: &mut Frame, model: &str, area: Rect) {
+    let lines = vec![
+        Line::from(vec![Span::styled(
+            format!("🗑️ Delete '{}'?", model),
+            Style::default()
+                .fg(Color::Red)
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  This removes the model from disk. You can re-pull it later.",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "[Y/Enter]",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" Confirm delete  ", Style::default().fg(Color::White)),
+            Span::styled(
+                "[N/Esc]",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" Cancel", Style::default().fg(Color::White)),
+        ]),
+    ];
+
+    let widget = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Red))
+                .title(Span::styled(
+                    " Confirm Delete ",
+                    Style::default()
+                        .fg(Color::Red)
+                        .add_modifier(Modifier::BOLD),
+                )),
+        )
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(widget, area);
+}
+
+/// Render the brief in-flight state while a delete request is running.
+fn render_model_download_deleting(f: &mut Frame, model: &str, area: Rect) {
+    let lines = vec![Line::from(vec![Span::styled(
+        format!("🗑️ Deleting '{}'…", model),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    )])];
+
+    let widget = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow))
+                .title(Span::styled(
+                    " Deleting… ",
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
@@ -2172,6 +2260,27 @@ mod tests {
         assert!(screen.contains("Downloading 'qwen2.5-coder:7b'"));
         assert!(screen.contains("pulling abc123"));
         assert!(screen.contains("50%"));
+    }
+
+    #[tokio::test]
+    async fn model_download_confirm_delete_shows_prompt() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ModelDownload;
+        app.model_download_confirm_delete = Some("qwen2.5-coder:7b".to_string());
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("Delete 'qwen2.5-coder:7b'?"));
+        assert!(screen.contains("Confirm delete"));
+    }
+
+    #[tokio::test]
+    async fn model_download_deleting_shows_status() {
+        let mut app = test_app().await;
+        app.mode = AppMode::ModelDownload;
+        app.model_download_deleting = Some("qwen2.5-coder:7b".to_string());
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("Deleting 'qwen2.5-coder:7b'"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Delete now removes locally-installed Ollama models without leaving
Crustly. Press Del on a highlighted, installed suggestion in the
Model Download dialog (Ctrl+D) to ask for confirmation, then Y/Enter
to delete or N/Esc to back out. Deletion runs through the existing
ollama_models::delete_model backend (previously only reachable via
`crustly ollama rm`) and reports success/failure as a chat message.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D6m37iXkVs8G7aCZ81Ps5P