### PR TITLE
Fix codecov-action input error in coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,4 +141,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          file: ./cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
codecov/codecov-action@v7 renamed the file input to files and now
requires a token. Update the coverage job to use the correct input
name and pass CODECOV_TOKEN, and enable verbose output plus
fail_ci_if_error so upload issues surface instead of silently
producing an incomplete report.