### PR TITLE
Add GGUF management improvement plan informed by llamastash analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,14 @@ env:
   # needs a C/C++ toolchain, already present on GitHub's ubuntu/macos
   # runners (llama-cpp compiles vendored llama.cpp via cmake; see
   # llama-cpp-2-integration-plan.md §3/§4.2). Windows keeps its own
-  # narrower openai,aws-bedrock list below, unrelated to this.
+  # narrower openai,aws-bedrock list below - but that list still exercises
+  # `gguf-management` (local .gguf list/pull/rm, no FFI/cmake) because it's
+  # part of `default`, which every command below includes automatically
+  # (none pass `--no-default-features`). That's the point of
+  # ccguf-managment-imrpoment-plan.md Phase M0: Windows CI could never
+  # exercise the model-management commands before this split (they lived
+  # behind `llama-cpp`, which Windows CI has never enabled, since it has no
+  # `cmake` install step for it), and now it does, with no toolchain cost.
   CI_FEATURES: openai,aws-bedrock,ollama,llama-cpp,llama-cpp-llguidance,profiling
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,6 +4281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7029,6 +7038,8 @@ checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",
+ "memchr",
+ "ntapi",
  "windows 0.57.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,7 @@ dependencies = [
  "shellexpand",
  "sqlx",
  "syntect",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.19",
  "tiktoken-rs",
@@ -5518,7 +5519,7 @@ dependencies = [
  "rustix 0.38.44",
  "self_cell",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -7021,6 +7022,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8279,11 +8291,33 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -8315,6 +8349,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
@@ -8329,6 +8374,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8374,6 +8430,15 @@ dependencies = [
  "regex",
  "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,6 +1914,7 @@ dependencies = [
  "uuid",
  "viuer",
  "which",
+ "windows 0.58.0",
  "zeroize",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,12 @@ sha2 = { version = "0.11", optional = true }
 # Only the `Disks`/`Disk` API is used (`Disks::new_with_refreshed_list()`,
 # `.mount_point()`, `.available_space()`), so default features are dropped
 # to skip process/network/component enumeration this crate doesn't need.
+# "system" added for Phase M11 (hardware_detect.rs) - `System::total_memory()`
+# for the CPU-only/Apple-unified-memory RAM reading is gated behind it (confirmed
+# by reading the vendored crate's Cargo.toml, not assumed).
 sysinfo = { version = "0.33", optional = true, default-features = false, features = [
     "disk",
+    "system",
 ] }
 # Grammar-constrained decoding for tool calls (Phase 4b, `llama-cpp-llguidance`
 # feature only) - builds the JSON-Schema-union grammar and the constrained

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,9 @@ schemars = { version = "1.2", optional = true, features = ["preserve_order"] }
 # enabled. See llama-cpp-2-integration-plan.md.
 llama-cpp-2 = { version = "0.1.153", optional = true, default-features = false }
 # Checksum verification for downloaded .gguf files (llama_cpp_models.rs) -
-# see llama-cpp-2-integration-plan.md §4.11/§8.
+# see llama-cpp-2-integration-plan.md §4.11/§8 and, for why this is gated on
+# `gguf-management` rather than `llama-cpp`, ccguf-managment-imrpoment-plan.md
+# Phase M0.
 sha2 = { version = "0.11", optional = true }
 # Grammar-constrained decoding for tool calls (Phase 4b, `llama-cpp-llguidance`
 # feature only) - builds the JSON-Schema-union grammar and the constrained
@@ -152,16 +154,26 @@ tokio-test = "0.4"
 pprof = { version = "0.15", features = ["flamegraph", "frame-pointer"], optional = true }
 
 [features]
-default = []
+default = ["gguf-management"]
 # Profiling feature enables pprof on Unix only (no-op on Windows)
 profiling = []
 openai = ["async-openai"]
 aws-bedrock = ["aws-sdk-bedrockruntime"]
 ollama = ["dep:ollama-rs", "dep:schemars"]
-# Deliberately NOT part of `all-llm`: unlike every other provider feature,
-# this one compiles native C++ (cmake + a C/C++ toolchain required) - see
-# llama-cpp-2-integration-plan.md §3/§3.4/§4.2.
-llama-cpp = ["dep:llama-cpp-2", "dep:sha2"]
+# Local `.gguf` file management (list/pull/rm - directory scan + plain HTTP,
+# no FFI) - see ccguf-managment-imrpoment-plan.md Phase M0. Unlike
+# `llama-cpp` below, this carries no C/C++ toolchain cost (only `sha2`, a
+# small pure-Rust dependency), so it's part of `default` and `all-llm`:
+# managing `.gguf` files shouldn't require building the in-process inference
+# engine just to list what's on disk.
+gguf-management = ["dep:sha2"]
+# Deliberately NOT part of `all-llm`/`default`: unlike every other provider
+# feature (and unlike `gguf-management` above), this one compiles native
+# C++ (cmake + a C/C++ toolchain required) - see
+# llama-cpp-2-integration-plan.md §3/§3.4/§4.2. Depends on `gguf-management`
+# so `--features llama-cpp` still gets `crustly llama-cpp list/pull/rm`
+# exactly as before this feature was split out.
+llama-cpp = ["dep:llama-cpp-2", "gguf-management"]
 # GPU backends (llama-cpp-2-integration-plan.md §4.1/Phase 8), each layered
 # on top of `llama-cpp` and requiring its own SDK/toolkit at build time -
 # see §4.2. Opt-in individually; none are implied by `llama-cpp` alone
@@ -177,7 +189,7 @@ llama-cpp-mkl = ["llama-cpp", "llama-cpp-2/mkl"]
 # (§4.7), not a replacement for it. Not wired into the default generation
 # path yet - see src/llm/provider/llama_cpp_grammar.rs's module doc.
 llama-cpp-llguidance = ["llama-cpp", "llama-cpp-2/llguidance", "dep:llguidance", "dep:toktrie"]
-all-llm = ["openai", "aws-bedrock", "ollama"]
+all-llm = ["openai", "aws-bedrock", "ollama", "gguf-management"]
 
 [profile.dev]
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,23 @@ tokio-test = "0.4"
 # Profiling (Unix-only - not supported on Windows)
 pprof = { version = "0.15", features = ["flamegraph", "frame-pointer"], optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+# Win32 DXGI adapter enumeration for AMD/Intel GPU detection on Windows
+# (src/llm/provider/hardware_detect.rs, Phase M11) - a native API call, not
+# a subprocess, since no vendor CLI tool is a reliable cross-vendor default
+# on Windows the way nvidia-smi/rocm-smi/system_profiler are on their
+# platforms. `optional = true` + gated via `gguf-management`'s `dep:windows`
+# below (same wiring as `sha2`/`sysinfo`) so a Windows build with zero
+# Cargo features doesn't pay this compile cost either - target-specific
+# dependency tables and Cargo features compose independently, so this has
+# no effect at all on non-Windows targets regardless of which features are
+# enabled.
+windows = { version = "0.58", optional = true, features = [
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Dxgi_Common",
+    "Win32_Foundation",
+] }
+
 [features]
 default = ["gguf-management"]
 # Profiling feature enables pprof on Unix only (no-op on Windows)
@@ -172,13 +189,15 @@ profiling = []
 openai = ["async-openai"]
 aws-bedrock = ["aws-sdk-bedrockruntime"]
 ollama = ["dep:ollama-rs", "dep:schemars"]
-# Local `.gguf` file management (list/pull/rm - directory scan + plain HTTP,
-# no FFI) - see ccguf-managment-imrpoment-plan.md Phase M0. Unlike
-# `llama-cpp` below, this carries no C/C++ toolchain cost (only `sha2`, a
-# small pure-Rust dependency), so it's part of `default` and `all-llm`:
-# managing `.gguf` files shouldn't require building the in-process inference
-# engine just to list what's on disk.
-gguf-management = ["dep:sha2", "dep:sysinfo"]
+# Local `.gguf` file management (list/pull/rm - directory scan + plain HTTP)
+# plus hardware detection - see ccguf-managment-imrpoment-plan.md Phases M0
+# and M11. Unlike `llama-cpp` below, this carries no C/C++ toolchain cost on
+# any platform (`sha2`/`sysinfo` are small pure-Rust deps; `windows` is
+# Microsoft's own metadata-only FFI bindings crate, Windows-only per the
+# target table above, no C compiler needed to build it), so it's part of
+# `default` and `all-llm`: managing `.gguf` files shouldn't require building
+# the in-process inference engine just to list what's on disk.
+gguf-management = ["dep:sha2", "dep:sysinfo", "dep:windows"]
 # Deliberately NOT part of `all-llm`/`default`: unlike every other provider
 # feature (and unlike `gguf-management` above), this one compiles native
 # C++ (cmake + a C/C++ toolchain required) - see

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,14 @@ llama-cpp-2 = { version = "0.1.153", optional = true, default-features = false }
 # `gguf-management` rather than `llama-cpp`, ccguf-managment-imrpoment-plan.md
 # Phase M0.
 sha2 = { version = "0.11", optional = true }
+# Cross-platform free-disk-space query for the download precheck
+# (llama_cpp_models.rs, Phase M6) - no stable stdlib API exists for this.
+# Only the `Disks`/`Disk` API is used (`Disks::new_with_refreshed_list()`,
+# `.mount_point()`, `.available_space()`), so default features are dropped
+# to skip process/network/component enumeration this crate doesn't need.
+sysinfo = { version = "0.33", optional = true, default-features = false, features = [
+    "disk",
+] }
 # Grammar-constrained decoding for tool calls (Phase 4b, `llama-cpp-llguidance`
 # feature only) - builds the JSON-Schema-union grammar and the constrained
 # sampler in src/llm/provider/llama_cpp_grammar.rs. Neither is re-exported
@@ -166,7 +174,7 @@ ollama = ["dep:ollama-rs", "dep:schemars"]
 # small pure-Rust dependency), so it's part of `default` and `all-llm`:
 # managing `.gguf` files shouldn't require building the in-process inference
 # engine just to list what's on disk.
-gguf-management = ["dep:sha2"]
+gguf-management = ["dep:sha2", "dep:sysinfo"]
 # Deliberately NOT part of `all-llm`/`default`: unlike every other provider
 # feature (and unlike `gguf-management` above), this one compiles native
 # C++ (cmake + a C/C++ toolchain required) - see

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,19 +168,27 @@ tasks and acceptance criteria per item.
   header-parsed value as of M1)
 
 **Hardware-aware local model selection (DP6 — new since the plan's Update 3):**
-- [ ] **Hardware detection & display** — best-effort GPU vendor/VRAM + system RAM probe
-  (`nvidia-smi`/`rocm-smi`/DXGI/`system_profiler`/`vulkaninfo`, subprocess-based, no SDK linkage),
-  surfaced in `doctor` and the TUI host-info panel; display/advisory only, never auto-mutates
-  `providers.llama_cpp` config
-- [ ] **Local hardware-fit filtering** — `Fits`/`Tight`/`Won't fit` labels and a `crustly llama-cpp
-  list --best-fit` sort over models already on disk, using the memory estimate above against
-  detected hardware; explicitly not a HuggingFace catalog search
+- [x] **Hardware detection & display** — best-effort GPU vendor/VRAM + system RAM probe
+  (`nvidia-smi`/`rocm-smi`/`system_profiler`/`vulkaninfo`, subprocess-based, no SDK linkage;
+  each spawn/parse split so the parse half is unit-tested against captured sample output),
+  surfaced in `doctor` and a new host-info row on the Ctrl+G dialog (fetched once per TUI
+  session, cached process-wide in a `OnceLock`); display/advisory only, never auto-mutates
+  `providers.llama_cpp` config. **Scope note**: the Windows AMD/Intel DXGI path is a
+  documented stub returning `None` (falls through to CPU-only), not a real Win32 FFI binding
+  — this development environment has no Windows target to build/verify it against; degrades
+  cleanly per this item's own design, and NVIDIA-on-Windows (a subprocess call) is unaffected
+- [x] **Local hardware-fit filtering** — `Fits`/`Tight`/`Won't fit` labels (plus the context
+  length the estimate used, shown alongside) and a `crustly llama-cpp list --best-fit` sort
+  over models already on disk, using the memory estimate above against detected hardware;
+  same labels shown as a per-row tag in the Ctrl+G dialog. `doctor` gained a finding naming
+  the largest already-downloaded model the detected hardware can hold. Explicitly not a
+  HuggingFace catalog search
 
 **Diagnostics (DP5, lowest priority — cheap once the above exists):**
 - [x] **`crustly llama-cpp doctor`** — structured diagnostics (build feature/GPU backend, `models_dir`
-  existence/writability, disk space, `extra_model_paths`/`scan_ollama_models` sanity), always exits
-  0 regardless of findings. Detected-hardware line deferred with M11/M12 below — this command
-  surfaces that data once it exists, not a reason to duplicate detection logic here
+  existence/writability, disk space, `extra_model_paths`/`scan_ollama_models` sanity, and now
+  the detected-hardware + largest-fitting-model lines from the two items above), always exits
+  0 regardless of findings
 
 **Deferred — tracked in Backlog below, not this milestone:** catalog-based, benchmark-ranked
 `recommend` for models not yet downloaded (needs an external CI-maintained benchmark dataset;
@@ -283,6 +291,7 @@ are done; the rest are tracked here as they get picked up:
 | `crustly run` pipelines | Chain multiple prompts with conditional logic in a YAML file |
 | Catalog-based, benchmark-ranked GGUF recommend | Rank models *not yet downloaded* against a benchmark dataset (llamastash's `recommend`, minus the VRAM-fit-only subset already covered by v0.5.3's hardware-aware local selection). Needs an external, CI-refreshed benchmark pipeline — deferred until a concrete need shows up; see `ccguf-managment-imrpoment-plan.md` Phase M10 |
 | Fix `crustly ollama rm`'s arg-parsing bug | `OllamaCommands::Rm`'s positional field is named `model`, identical to the top-level `global = true` `--model` flag's ident — clap silently routes the value into the wrong field (confirmed against the real binary while fixing the identical bug in `LlamaCppCommands::Rm` during v0.5.3 M7, which renamed its own field to `name`). Same one-line fix, deliberately left untouched here since it's Ollama's CLI, not `llama-cpp`'s — outside that phase's scope |
+| Real Windows AMD/Intel GPU detection (DXGI) | `hardware_detect::detect_windows_dxgi` (v0.5.3 M11) is a stub returning `None` — this project's development environment has no Windows target to build/verify a real `windows`/`windows-sys` DXGI FFI binding against. Falls through to the CPU-only/system-RAM path cleanly (not a regression, no dependency added), but a real Windows dev machine could implement `IDXGIFactory1::EnumAdapters1` as originally scoped in `ccguf-managment-imrpoment-plan.md` Phase M11 |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,9 +116,14 @@ analysis), not by phase number — highest-value/most-blocking first. Six execut
 tasks and acceptance criteria per item.
 
 **Foundation — unblocks everything else below (DP1):**
-- [ ] **Decouple GGUF file management from the `llama-cpp` build feature** — `list`/`pull`/`rm`
-  today require the full cmake/C++ toolchain even though they do no FFI; new `gguf-management`
-  feature fixes this and folds into `all-llm`
+- [x] **Decouple GGUF file management from the `llama-cpp` build feature** — `list`/`pull`/`rm`
+  no longer require the cmake/C++ toolchain; new `gguf-management` feature carries just the
+  management code (plus `sha2`), joins both `default` and `all-llm`, and `llama-cpp` depends
+  on it so nothing regressed. Also decoupled the TUI Ctrl+G dialog's list/download/delete and
+  the Model Info panel's quantization hint, which the source plan hadn't originally scoped in
+  but turned out to need the same fix. Verified: zero `llama-cpp-2`/`-sys-2` in the dependency
+  tree under `--features gguf-management`; 834/834 tests pass there, 851/851 under
+  `--features llama-cpp`, 883/883 under `all-llm` — no regressions
 - [ ] **Pure-Rust GGUF header metadata parser** — real architecture/parameter-count/quantization/
   context-length/chat-template-presence, replacing today's filename-only quantization guess;
   hardened against malformed/truncated/adversarial files (never panics/OOMs on a crafted header)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,10 +133,20 @@ tasks and acceptance criteria per item.
   than a panic or partial/corrupt result. 13 new tests, 847/847 total under `gguf-management`
 
 **Core management (DP2–DP4):**
-- [ ] **Memory/VRAM footprint estimate** — "~4.9 GB at this context length" in `list`/TUI, advisory only
-- [ ] **Multi-source discovery** — Ollama (via its manifests, not raw blob scanning), HuggingFace/LM
-  Studio caches, extra configured paths — beyond today's single-directory scan
-- [ ] **Deduplication** — symlink collapsing, split-GGUF (`-00001-of-00005.gguf`) unification
+- [x] **Memory/VRAM footprint estimate** (`gguf_metadata::estimate_memory_bytes`) — weights + KV-cache
+  term when the header has enough attention geometry, weights-only (explicitly labeled) otherwise;
+  shown in `crustly llama-cpp list` as `"~4.9 GB"`/`"~4.9 GB (weights only)"`, advisory only
+- [x] **Multi-source discovery** — `providers.llama_cpp.extra_model_paths` (extra scanned
+  directories) and `scan_ollama_models` (reads Ollama's manifest tree —
+  `<dir>/manifests/{host}/{namespace}/{model}/{tag}` — verified against Ollama's own source rather
+  than assumed, resolving each manifest's model-weights layer to its blob and a real `name:tag`
+  display name, not a raw blob-store scan). HuggingFace/LM Studio well-known-cache auto-scan
+  explicitly deferred (both need a properly bounded recursive walker a flat scan can't provide —
+  see `ccguf-managment-imrpoment-plan.md` M3's scope note)
+- [x] **Deduplication** — canonical-path collapsing (symlinks, and two Ollama manifest tags sharing
+  one blob — names combine rather than one being dropped) and split-GGUF
+  (`-00001-of-00005.gguf`) unification with summed size, handling a partial/incomplete group
+  honestly
 - [ ] **`mmproj` pairing** — vision/audio projector files shown attached to their base model
 - [ ] **Download hardening** — disk-space precheck, `--revision` pinning, resumable downloads
 - [ ] **Agent-facing `--json` CLI contract** — stable schema + documented exit codes on `crustly

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 **Current Version:** 0.5.2 — July 2026
 **Author:** Jeremy JEANNE
 
-**Related strategy docs:** [`differentiation-strategy-vs-opencode.md`](./differentiation-strategy-vs-opencode.md) (competitive positioning — depth over breadth), [`docs/guides/SECURITY_MODEL.md`](./docs/guides/SECURITY_MODEL.md) (permission engine, compared to OpenCode's), [`llm-file-gguf-support.md`](./llm-file-gguf-support.md) (direct GGUF loading evaluation, conditional Go/No-Go)
+**Related strategy docs:** [`differentiation-strategy-vs-opencode.md`](./differentiation-strategy-vs-opencode.md) (competitive positioning — depth over breadth), [`docs/guides/SECURITY_MODEL.md`](./docs/guides/SECURITY_MODEL.md) (permission engine, compared to OpenCode's), [`llm-file-gguf-support.md`](./llm-file-gguf-support.md) (direct GGUF loading evaluation, conditional Go/No-Go), [`ccguf-managment-imrpoment-plan.md`](./ccguf-managment-imrpoment-plan.md) (GGUF model-management improvement plan, informed by a `llamastash` feature analysis — full design/rationale for the v0.5.3 milestone below)
 
 ---
 
@@ -101,6 +101,57 @@ whoever has a model and terminal to try it against.
 
 ## Upcoming Milestones
 
+### v0.5.3 — GGUF Model Management
+**Target:** Q3 2026
+
+**Full design/rationale:** [`ccguf-managment-imrpoment-plan.md`](./ccguf-managment-imrpoment-plan.md)
+— informed by a feature analysis of [`llamastash`](https://github.com/llamastash/llamastash),
+scoped to what's portable without adopting its daemon/launcher/proxy architecture (Crustly
+already runs inference in-process, see the "Unreleased" entry above). Follows the same
+point-release pattern as v0.4.2 (Native Ollama Integration) and v0.5.2 (Local-Model
+Reliability): focused follow-up hardening on a subsystem that just shipped, ahead of v0.6's
+unrelated stability/DX work. Items below are ordered by the plan's own priority (§4 gap
+analysis), not by phase number — highest-value/most-blocking first. Six execution milestones
+(DP1–DP6, ~29 dev-days total) map onto the groupings below; see the plan's §8 for file-level
+tasks and acceptance criteria per item.
+
+**Foundation — unblocks everything else below (DP1):**
+- [ ] **Decouple GGUF file management from the `llama-cpp` build feature** — `list`/`pull`/`rm`
+  today require the full cmake/C++ toolchain even though they do no FFI; new `gguf-management`
+  feature fixes this and folds into `all-llm`
+- [ ] **Pure-Rust GGUF header metadata parser** — real architecture/parameter-count/quantization/
+  context-length/chat-template-presence, replacing today's filename-only quantization guess;
+  hardened against malformed/truncated/adversarial files (never panics/OOMs on a crafted header)
+
+**Core management (DP2–DP4):**
+- [ ] **Memory/VRAM footprint estimate** — "~4.9 GB at this context length" in `list`/TUI, advisory only
+- [ ] **Multi-source discovery** — Ollama (via its manifests, not raw blob scanning), HuggingFace/LM
+  Studio caches, extra configured paths — beyond today's single-directory scan
+- [ ] **Deduplication** — symlink collapsing, split-GGUF (`-00001-of-00005.gguf`) unification
+- [ ] **`mmproj` pairing** — vision/audio projector files shown attached to their base model
+- [ ] **Download hardening** — disk-space precheck, `--revision` pinning, resumable downloads
+- [ ] **Agent-facing `--json` CLI contract** — stable schema + documented exit codes on `crustly
+  llama-cpp list/pull/rm`, extending Crustly's existing agent-facing positioning (`AGENTS.md`)
+- [ ] **TUI enhancements** — Ctrl+G/Ctrl+O dialogs show real header-parsed metadata instead of the
+  filename guess
+
+**Hardware-aware local model selection (DP6 — new since the plan's Update 3):**
+- [ ] **Hardware detection & display** — best-effort GPU vendor/VRAM + system RAM probe
+  (`nvidia-smi`/`rocm-smi`/DXGI/`system_profiler`/`vulkaninfo`, subprocess-based, no SDK linkage),
+  surfaced in `doctor` and the TUI host-info panel; display/advisory only, never auto-mutates
+  `providers.llama_cpp` config
+- [ ] **Local hardware-fit filtering** — `Fits`/`Tight`/`Won't fit` labels and a `crustly llama-cpp
+  list --best-fit` sort over models already on disk, using the memory estimate above against
+  detected hardware; explicitly not a HuggingFace catalog search
+
+**Diagnostics (DP5, lowest priority — cheap once the above exists):**
+- [ ] **`crustly llama-cpp doctor`** — structured diagnostics (build feature, `models_dir`
+  writability, disk space, detected hardware), always exits 0
+
+**Deferred — tracked in Backlog below, not this milestone:** catalog-based, benchmark-ranked
+`recommend` for models not yet downloaded (needs an external CI-maintained benchmark dataset;
+disproportionate maintenance burden for now — see the plan's §3 item 5 and Phase M10).
+
 ### v0.6 — Stability & Developer Experience
 **Target:** Q4 2026
 
@@ -196,6 +247,7 @@ are done; the rest are tracked here as they get picked up:
 | Telemetry (opt-in) | Anonymous usage stats; cost analytics charts in TUI |
 | Azure OpenAI provider | Azure-specific auth and endpoint routing |
 | `crustly run` pipelines | Chain multiple prompts with conditional logic in a YAML file |
+| Catalog-based, benchmark-ranked GGUF recommend | Rank models *not yet downloaded* against a benchmark dataset (llamastash's `recommend`, minus the VRAM-fit-only subset already covered by v0.5.3's hardware-aware local selection). Needs an external, CI-refreshed benchmark pipeline — deferred until a concrete need shows up; see `ccguf-managment-imrpoment-plan.md` Phase M10 |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -173,10 +173,13 @@ tasks and acceptance criteria per item.
   each spawn/parse split so the parse half is unit-tested against captured sample output),
   surfaced in `doctor` and a new host-info row on the Ctrl+G dialog (fetched once per TUI
   session, cached process-wide in a `OnceLock`); display/advisory only, never auto-mutates
-  `providers.llama_cpp` config. **Scope note**: the Windows AMD/Intel DXGI path is a
-  documented stub returning `None` (falls through to CPU-only), not a real Win32 FFI binding
-  — this development environment has no Windows target to build/verify it against; degrades
-  cleanly per this item's own design, and NVIDIA-on-Windows (a subprocess call) is unaffected
+  `providers.llama_cpp` config, including a real Windows AMD/Intel GPU probe via the Win32
+  DXGI API (`windows` crate, Windows-only target dependency) — cross-compile verified
+  (`cargo check`/`build --target x86_64-pc-windows-gnu`, producing a real linked PE32+
+  binary) since no Windows machine is available in this development environment to run it
+  against actual hardware/drivers; degrades cleanly to CPU-only if that's ever wrong. Its two
+  pure logic pieces (PCI vendor ID → vendor, UTF-16 description trimming) are unit-tested on
+  Linux directly. NVIDIA-on-Windows goes through the ordinary `nvidia-smi` subprocess path
 - [x] **Local hardware-fit filtering** — `Fits`/`Tight`/`Won't fit` labels (plus the context
   length the estimate used, shown alongside) and a `crustly llama-cpp list --best-fit` sort
   over models already on disk, using the memory estimate above against detected hardware;
@@ -291,7 +294,7 @@ are done; the rest are tracked here as they get picked up:
 | `crustly run` pipelines | Chain multiple prompts with conditional logic in a YAML file |
 | Catalog-based, benchmark-ranked GGUF recommend | Rank models *not yet downloaded* against a benchmark dataset (llamastash's `recommend`, minus the VRAM-fit-only subset already covered by v0.5.3's hardware-aware local selection). Needs an external, CI-refreshed benchmark pipeline — deferred until a concrete need shows up; see `ccguf-managment-imrpoment-plan.md` Phase M10 |
 | Fix `crustly ollama rm`'s arg-parsing bug | `OllamaCommands::Rm`'s positional field is named `model`, identical to the top-level `global = true` `--model` flag's ident — clap silently routes the value into the wrong field (confirmed against the real binary while fixing the identical bug in `LlamaCppCommands::Rm` during v0.5.3 M7, which renamed its own field to `name`). Same one-line fix, deliberately left untouched here since it's Ollama's CLI, not `llama-cpp`'s — outside that phase's scope |
-| Real Windows AMD/Intel GPU detection (DXGI) | `hardware_detect::detect_windows_dxgi` (v0.5.3 M11) is a stub returning `None` — this project's development environment has no Windows target to build/verify a real `windows`/`windows-sys` DXGI FFI binding against. Falls through to the CPU-only/system-RAM path cleanly (not a regression, no dependency added), but a real Windows dev machine could implement `IDXGIFactory1::EnumAdapters1` as originally scoped in `ccguf-managment-imrpoment-plan.md` Phase M11 |
+| Runtime-verify Windows AMD/Intel GPU detection (DXGI) on real hardware | `hardware_detect::detect_windows_dxgi` (v0.5.3 M11) is implemented against the real Win32 DXGI API and cross-compile verified (`cargo check`/`build --target x86_64-pc-windows-gnu`, produces a real linked Windows binary), but has never run against actual Windows hardware/drivers — this project's development environment has no Windows machine. If it misbehaves on a real machine (wrong adapter picked, vendor ID mismatch, description string garbled), that's the first thing to check; the two pure logic pieces are unit-tested but the live `CreateDXGIFactory1`/`EnumAdapters1`/`GetDesc1` call chain itself isn't |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -147,8 +147,15 @@ tasks and acceptance criteria per item.
   one blob — names combine rather than one being dropped) and split-GGUF
   (`-00001-of-00005.gguf`) unification with summed size, handling a partial/incomplete group
   honestly
-- [ ] **`mmproj` pairing** — vision/audio projector files shown attached to their base model
-- [ ] **Download hardening** — disk-space precheck, `--revision` pinning, resumable downloads
+- [x] **`mmproj` pairing** — vision/audio projector files (detected via the header's
+  `clip.has_vision_encoder`/`clip.has_audio_encoder`, verified against llama.cpp's own source;
+  filename fallback only when the header can't be read) shown attached to their base model
+  (`"model.gguf (+ mmproj)"`) via a conservative exact-core-name match within one directory —
+  ambiguous or cross-directory candidates are left standalone (`"[mmproj]"`) rather than guessed
+- [x] **Download hardening** — disk-space precheck (new `sysinfo` dependency — the one new Cargo
+  dependency across M0–M6, no stable stdlib API exists for free-space queries), `@revision`
+  pinning on the `hf:org/repo/file.gguf@revision` shorthand, and `Range`-header resume (checksum
+  verification correctly covers the whole file across a resume, not just the newly-streamed part)
 - [ ] **Agent-facing `--json` CLI contract** — stable schema + documented exit codes on `crustly
   llama-cpp list/pull/rm`, extending Crustly's existing agent-facing positioning (`AGENTS.md`)
 - [ ] **TUI enhancements** — Ctrl+G/Ctrl+O dialogs show real header-parsed metadata instead of the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,10 +156,16 @@ tasks and acceptance criteria per item.
   dependency across M0–M6, no stable stdlib API exists for free-space queries), `@revision`
   pinning on the `hf:org/repo/file.gguf@revision` shorthand, and `Range`-header resume (checksum
   verification correctly covers the whole file across a resume, not just the newly-streamed part)
-- [ ] **Agent-facing `--json` CLI contract** — stable schema + documented exit codes on `crustly
-  llama-cpp list/pull/rm`, extending Crustly's existing agent-facing positioning (`AGENTS.md`)
-- [ ] **TUI enhancements** — Ctrl+G/Ctrl+O dialogs show real header-parsed metadata instead of the
-  filename guess
+- [x] **Agent-facing `--json` CLI contract** — `crustly llama-cpp list --json` (versioned
+  `schema_version`, dedicated DTO decoupled from the internal `LocalGgufModel`) and documented exit
+  codes (10 no such file, 11 disk space, 12 checksum, 13 network, 14 feature not compiled in) on
+  `list`/`pull`/`rm`, scoped to `llama-cpp` subcommands only — reuses Crustly's own existing error
+  *messages* as the taxonomy rather than inventing new numeric meanings
+- [x] **TUI enhancements** — Ctrl+G dialog shows `display_name`/architecture/parameter-count/native
+  context/memory-estimate/mmproj pairing (previously showed the raw filename even for
+  Ollama-sourced/merged entries — fixed as part of this pass); Ctrl+O panel adds native
+  context-length and chat-template-present rows (its quantization row already used the
+  header-parsed value as of M1)
 
 **Hardware-aware local model selection (DP6 — new since the plan's Update 3):**
 - [ ] **Hardware detection & display** — best-effort GPU vendor/VRAM + system RAM probe

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,9 +124,13 @@ tasks and acceptance criteria per item.
   but turned out to need the same fix. Verified: zero `llama-cpp-2`/`-sys-2` in the dependency
   tree under `--features gguf-management`; 834/834 tests pass there, 851/851 under
   `--features llama-cpp`, 883/883 under `all-llm` — no regressions
-- [ ] **Pure-Rust GGUF header metadata parser** — real architecture/parameter-count/quantization/
-  context-length/chat-template-presence, replacing today's filename-only quantization guess;
-  hardened against malformed/truncated/adversarial files (never panics/OOMs on a crafted header)
+- [x] **Pure-Rust GGUF header metadata parser** (`src/llm/provider/gguf_metadata.rs`, zero new
+  dependencies) — real architecture/parameter-count/quantization (layered: precise
+  `general.file_type` → coarser tensor-type mode → filename guess as last resort)/context-length/
+  chat-template-presence, wired into `LocalGgufModel` and its TUI mirror. Hardened: every declared
+  string/array length validated against a cap before any allocation, a 256 MiB cumulative budget
+  backstops the per-value caps, any structural problem returns `None` for the whole file rather
+  than a panic or partial/corrupt result. 13 new tests, 847/847 total under `gguf-management`
 
 **Core management (DP2–DP4):**
 - [ ] **Memory/VRAM footprint estimate** — "~4.9 GB at this context length" in `list`/TUI, advisory only

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -177,8 +177,10 @@ tasks and acceptance criteria per item.
   detected hardware; explicitly not a HuggingFace catalog search
 
 **Diagnostics (DP5, lowest priority — cheap once the above exists):**
-- [ ] **`crustly llama-cpp doctor`** — structured diagnostics (build feature, `models_dir`
-  writability, disk space, detected hardware), always exits 0
+- [x] **`crustly llama-cpp doctor`** — structured diagnostics (build feature/GPU backend, `models_dir`
+  existence/writability, disk space, `extra_model_paths`/`scan_ollama_models` sanity), always exits
+  0 regardless of findings. Detected-hardware line deferred with M11/M12 below — this command
+  surfaces that data once it exists, not a reason to duplicate detection logic here
 
 **Deferred — tracked in Backlog below, not this milestone:** catalog-based, benchmark-ranked
 `recommend` for models not yet downloaded (needs an external CI-maintained benchmark dataset;
@@ -280,6 +282,7 @@ are done; the rest are tracked here as they get picked up:
 | Azure OpenAI provider | Azure-specific auth and endpoint routing |
 | `crustly run` pipelines | Chain multiple prompts with conditional logic in a YAML file |
 | Catalog-based, benchmark-ranked GGUF recommend | Rank models *not yet downloaded* against a benchmark dataset (llamastash's `recommend`, minus the VRAM-fit-only subset already covered by v0.5.3's hardware-aware local selection). Needs an external, CI-refreshed benchmark pipeline — deferred until a concrete need shows up; see `ccguf-managment-imrpoment-plan.md` Phase M10 |
+| Fix `crustly ollama rm`'s arg-parsing bug | `OllamaCommands::Rm`'s positional field is named `model`, identical to the top-level `global = true` `--model` flag's ident — clap silently routes the value into the wrong field (confirmed against the real binary while fixing the identical bug in `LlamaCppCommands::Rm` during v0.5.3 M7, which renamed its own field to `name`). Same one-line fix, deliberately left untouched here since it's Ollama's CLI, not `llama-cpp`'s — outside that phase's scope |
 
 ---
 

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -726,7 +726,48 @@ replicating that maintenance burden isn't justified by this plan's scope.
 see M12 below. If this phase is ever picked back up, it's specifically about
 suggesting *new* models to download, not about ranking ones already on disk.
 
-### Phase M11 — Hardware detection & display
+### Phase M11 — Hardware detection & display ✅ Done
+
+Implemented largely as planned, with one deliberate scope reduction disclosed
+up front rather than discovered mid-implementation: **the Windows AMD/Intel
+DXGI path is a documented stub returning `None`**, not a real Win32 FFI
+binding. This development environment is Linux-only with no Windows target to
+build or test against; writing `unsafe` COM interface calls with zero ability
+to verify they even compile is worse than being explicit about the gap - it
+falls through cleanly to the CPU-only/system-RAM path, which is this phase's
+own designed-in degrade-cleanly outcome, not a crash. NVIDIA-on-Windows is
+unaffected (`nvidia-smi` is a portable subprocess call). No new
+`windows`/`windows-sys` dependency was added as a result - if a future pass
+picks this up on a real Windows dev machine, add it then.
+
+Every other detection path shipped as designed: `src/llm/provider/hardware_detect.rs`
+(new, `gguf-management`-gated) with `detect_nvidia`/`detect_amd_rocm`/
+`detect_apple_display`/`detect_vulkan_fallback`, each split into a subprocess-spawn
+half and an independently-unit-tested pure parse half (`parse_nvidia_smi_csv`,
+`parse_rocm_smi_json`, `parse_system_profiler_json`, `parse_vulkaninfo_summary`) -
+23 new tests, all against captured real-shaped sample output, no live GPU needed.
+`run_with_timeout` hand-rolls the subprocess timeout via a poll loop (`try_wait` +
+`kill` on deadline) rather than a new crate, per the plan's own dependency table.
+System RAM comes from `sysinfo::System::total_memory()` - required adding the
+crate's `"system"` feature (`Cargo.toml`), confirmed by reading the vendored
+0.33.1 source directly rather than assumed, alongside the `"disk"` feature M6
+already enabled. `detect_hardware()` caches in a `OnceLock` exactly as specified,
+and is only ever called from `doctor`, `list --best-fit` (M12), and the TUI's
+host-info row on the Ctrl+G dialog's first open per session
+(`App::open_llama_cpp_models`, guarded by `llama_cpp_hardware.is_none()`) -
+verified by a dedicated test that a second dialog open does not re-trigger
+detection. Display: `doctor` gained a hardware finding (GPU name+available-VRAM
+or "CPU-only", plus system RAM, always `Ok`); the Ctrl+G dialog gained a
+one-line host-info row ("detecting hardware…" while the background task runs,
+then the summary) via a new `TuiEvent::LlamaCppHardwareDetected` and always-
+compiled `HardwareSummary` struct in `llama_cpp_download.rs`, mirroring the
+existing `LlamaCppModelSummary` feature-decoupling pattern exactly.
+
+End-to-end smoke test against the real binary in this sandbox (which has none
+of `nvidia-smi`/`rocm-smi`/`vulkaninfo` installed) confirmed the CPU-only/
+system-RAM-only degrade path live, not just in unit tests: `crustly llama-cpp
+doctor` reported "no GPU detected (or no supported vendor tool installed) -
+CPU-only; system RAM: ~15.7 GB" with `Ok` status and exit 0.
 
 **Depends on**: nothing functionally (can ship independently of M1-M9), but
 most useful once M2 exists to interpret it against.
@@ -786,7 +827,42 @@ from also becoming a "never slows down the common path" regression.
 each independently testable against captured sample output) plus the
 degradation-path testing the "clean fallback" requirement above demands.
 
-### Phase M12 — Local hardware-fit filtering (the part of `recommend` that doesn't need benchmark data)
+### Phase M12 — Local hardware-fit filtering (the part of `recommend` that doesn't need benchmark data) ✅ Done
+
+Implemented as planned, plus one useful discovery: `LocalGgufModel::estimated_memory_bytes`
+(M2) was **already** computed at `min(native_context_length, 8192)` - the
+exact capped-context rule this phase's spec calls for - so no new memory-
+estimate logic was needed, only the fit comparison itself and a place to
+surface which context length the estimate used
+(`LocalGgufModel::estimated_memory_context_length`, a new field threaded
+through the same `LlamaCppModelJson`/`LlamaCppModelSummary` mirror boundaries
+every prior field addition established).
+
+`src/llm/provider/llama_cpp_models.rs` gained `HardwareFit` (`Fits`/`Tight`/
+`WontFit`/`Unknown`, `Tight` at >85% of budget, a documented default not a
+tuned one), `hardware_fit()`, `sort_by_fit()` (fit category first, largest
+`estimated_memory_bytes` first within a category - the most-capable
+already-fitting model sorts to the top, a reasonable proxy for "best" absent
+benchmark data), and `best_fitting_model()` (doctor's payoff line). `crustly
+llama-cpp list --best-fit` sorts and annotates each row with `Fit: <label>
+(ctx N)`; combined with `--json` it adds `fit`/`estimated_memory_context_length`
+fields to the existing versioned schema (additive, no `schema_version` bump).
+`doctor` gained a `best_fitting_model`-powered finding naming the largest
+already-downloaded model the detected hardware can hold (or a `Warn` when
+none fit) - the exact payoff M9's and M11's own doc comments predicted this
+phase would deliver. The TUI Ctrl+G dialog annotates each row with a
+color-coded `[Fits]`/`[Tight]`/`[Won't fit]` tag (green/yellow/red, or the
+row's own highlight color when selected, to avoid a visually inconsistent
+un-highlighted patch) via a small duplicated threshold function in
+`render.rs` rather than importing the `gguf-management`-gated
+`HardwareFit` type into the TUI's always-compiled render layer.
+
+End-to-end smoke test against the real binary confirmed the full chain live:
+a synthetic 7B Q4_K_M `.gguf` fixture (~5.0 GB estimate at the capped 8192-
+token context) against this sandbox's real (GPU-less) ~15.7 GB system RAM
+budget correctly labeled `Fits`, both in the human table (`Fits (ctx 8192)`)
+and in `--json` output (`"fit": "Fits"`), and surfaced identically through
+`doctor`'s "largest already-downloaded model this hardware can hold" line.
 
 **Depends on**: M1, M2, M11.
 

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -13,6 +13,12 @@ Date: 2026-08-06. Two review passes so far:
   and added an explicit maturity caveat (§1) plus an explicit deferred item
   (MTP speculative-decoding detection, §3) that the first pass omitted
   without saying so.
+- **Update 3** (scope addition, user-requested): promoted local hardware
+  detection/display and hardware-fit model selection out of the "deferred"
+  bucket (M10) into concrete phases (M11/M12), grounded in llamastash's
+  actual detection subsystem (`docs/architecture.md`'s per-vendor subprocess
+  probe chain and VRAM-fit filter, not a re-guess) — see §1's expanded
+  "Hardware awareness" bullet and the new M11/M12 sections in §5.
 Scope: improve how Crustly discovers, inspects, downloads, and manages local
 `.gguf` model files, informed by a feature analysis of
 [`llamastash`](https://github.com/llamastash/llamastash) — a Rust TUI/CLI
@@ -69,9 +75,27 @@ tree, and `config.example.yaml` reference (not a paraphrase of a paraphrase):
   (◉) vs. audio (♪) in the TUI.
 - **Download**: `pull <hf-repo>` with disk-space prechecks, SHA-256
   verification, and `--revision <sha>` pinning for reproducible pulls.
-- **Hardware awareness**: filters/ranks discovered and recommendable models
-  against detected VRAM/RAM; context auto-fit picks the largest context that
-  fits instead of failing at load time.
+- **Hardware awareness**: detection is a per-vendor subprocess probe chain
+  run at startup and on a slow hotplug timer, documented in llamastash's own
+  `docs/architecture.md` — `nvidia-smi --query-gpu=…` (NVIDIA, Linux/Windows),
+  `rocm-smi --showmeminfo vram gtt --json` (AMD, Linux), the Win32 DXGI API
+  (`IDXGIFactory1::EnumAdapters1`, AMD/Intel on Windows — a native API call,
+  not a subprocess), `system_profiler SPDisplaysDataType -json` (Apple
+  Metal/unified memory), and `vulkaninfo --summary` as a cross-vendor
+  fallback that only recovers an adapter name, no VRAM figure; the first
+  probe to return non-empty data wins, and anything that returns nothing
+  falls through to a `CpuOnly` classification rather than erroring. The
+  result feeds three things: (1) a **VRAM-fit hard filter** that prunes any
+  candidate model too large to load before any ranking happens, (2) a TUI
+  host-info pane showing GPU name/VRAM/live utilization where available, and
+  (3) **context auto-fit** — reading the GGUF's own attention geometry
+  (`block_count`, `head_count_kv`, `head_dim`) plus the tensor table's weight
+  bytes and the live free-memory snapshot to solve for the largest context
+  that actually fits, rather than failing at load time or relying on
+  `llama.cpp`'s own `--fit` (which llamastash's docs note misreads unified
+  memory on some AMD iGPUs). Only the VRAM-fit filter and the detection
+  layer itself are relevant to a *management* plan — the composite
+  benchmark-score ranking on top of the filter (§3 item 5) is not.
 - **Agent-facing CLI contract**: stable `--json` output, byte-stable TSV when
   piped, and a documented exit-code table (64–74 per failure class) so a
   calling agent can branch on the exit code instead of parsing text —
@@ -153,11 +177,16 @@ Crustly:
    architectural decision (ADR 0005), not something this plan reopens.
 4. **No second theming/keybinding system.** Any TUI work here extends
    Crustly's existing dialogs and render pipeline, not a parallel UI stack.
-5. **No CI-refreshed community benchmark table.** llamastash's `recommend`
-   ranks against externally-maintained benchmark data; replicating that
-   maintenance burden is disproportionate to the value for Crustly. A
-   lighter, purely local hardware-fit heuristic (Phase M10) covers the
-   useful part without the ongoing-data-pipeline cost.
+5. **No CI-refreshed community benchmark table, and no catalog of models the
+   user doesn't have yet.** llamastash's `recommend` composite-ranks
+   candidates by `benchmark score × tok/s × params × recency` after its
+   VRAM-fit filter; replicating that externally-maintained benchmark
+   pipeline is disproportionate to the value for Crustly. **Narrowed by
+   this plan's Update 3**: the VRAM-fit filter itself needs no benchmark
+   data — it's a local calculation over already-discovered models (Phase
+   M2's memory estimate) against detected hardware (Phase M11) — so that
+   part is no longer deferred; see M12. What stays deferred (Phase M10) is
+   specifically the benchmark-ranked, not-yet-downloaded-model catalog.
 6. **No MTP (speculative-decoding-capable) GGUF detection, for now.** Added
    in this review pass — the first draft omitted this llamastash feature
    without saying why. llamastash flags MTP-capable GGUFs at discovery time
@@ -187,7 +216,9 @@ Crustly:
 | KV-cache memory estimate / context auto-fit | Yes | No | **Medium** |
 | Agent-facing `--json` + documented exit codes | Yes | No | **Medium** (Crustly is itself agent-facing — see AGENTS.md — so this is more relevant to Crustly than a generic nice-to-have) |
 | `doctor`-style diagnostics | Yes | No | **Low** |
-| Hardware-aware recommend | Yes (CI benchmark data) | No | **Low** (deferred, see §3 item 5) |
+| Hardware detection & display (GPU vendor/VRAM, RAM) | Yes (subprocess probe chain) | No | **Medium** — new, see M11 |
+| Local hardware-fit filtering ("will this model I already have fit?") | Yes (VRAM-fit hard filter) | No | **Medium** — new, see M12 |
+| Catalog-based, benchmark-ranked recommend (models not yet downloaded) | Yes (CI benchmark data) | No | **Low** (deferred, see §3 item 5, M10) |
 | MTP/speculative-decoding-capable GGUF detection | Yes (TUI badge) | No | **N/A — explicitly deferred, see §3 item 6** (no consumer without a speculative-decoding engine, which Crustly doesn't have) |
 
 ---
@@ -321,10 +352,20 @@ transformer KV-cache formula, and surface it:
 - In `crustly llama-cpp list` / the TUI info panel, so a user can see
   "~4.9 GB at this context length" before loading.
 - As a warning (not a hard block) when `n_gpu_layers`/`n_ctx` in
-  `LlamaCppProviderConfig` looks likely to exceed detected system RAM —
-  advisory only, since Crustly (correctly, per `llama-cpp-2-integration-plan.md`
-  §4.11) doesn't do hardware detection today and shouldn't overreach here
-  either; this is a same-order-of-magnitude estimate, not a guarantee.
+  `LlamaCppProviderConfig` looks likely to exceed available memory — this is
+  a same-order-of-magnitude estimate, not a guarantee.
+
+At the time this phase was first drafted, "available memory" meant only
+whatever the user's own OS-level tools reported, since
+`llama-cpp-2-integration-plan.md` §4.11 correctly kept Crustly out of the
+hardware-detection business for the *inference engine itself* (no
+auto-guessed `n_gpu_layers`). **Update 3 note**: Phase M11 below adds actual
+hardware detection, but strictly on the management/display side — it never
+feeds back into `LlamaCppProviderConfig` or auto-sets `n_gpu_layers`/`n_ctx`.
+That keeps faith with §4.11's original reasoning (a config knob stays a
+config knob, not a guess) while still answering "what can my hardware
+run" as an advisory question, which is what this update's request is
+actually asking for.
 
 **Effort**: Medium.
 
@@ -468,21 +509,99 @@ Phase 7's corrected-assumptions note).
 A diagnostics subcommand, always exiting 0, reporting (as structured findings,
 not just log lines): whether the binary was built with `llama-cpp`/a GPU
 feature, whether `models_dir` exists and is writable, available disk space,
-and (once M2 lands) a rough "largest model your detected RAM can hold at
-default settings" line. Lower priority than M0–M7 since it's diagnostic
-sugar rather than filling a functional gap, but cheap once the underlying
-data (M1/M2) exists.
+and (once M2 and M11 land) the actually-detected hardware plus a rough
+"largest model your detected RAM/VRAM can hold at default settings" line —
+this is the natural place to surface M11's detection output as text, not a
+reason to duplicate detection logic here. Lower priority than M0–M7 since
+it's diagnostic sugar rather than filling a functional gap, but cheap once
+the underlying data (M1/M2, and later M11) exists.
 
 **Effort**: Small.
 
-### Phase M10 — Hardware-aware `recommend` (deferred)
+### Phase M10 — Catalog-based, benchmark-ranked `recommend` (deferred)
 
 Explicitly **deferred**, not scheduled. llamastash's version depends on an
-externally maintained, CI-refreshed benchmark dataset — replicating that
-maintenance burden isn't justified by this plan's scope. If pursued later,
-scope it down to a purely local heuristic (detected RAM/VRAM vs. M2's memory
-estimate for already-discovered models), not a ranked catalog of models the
-user doesn't have yet.
+externally maintained, CI-refreshed benchmark dataset to rank models the
+user does **not** yet have (`benchmark score × tok/s × params × recency`);
+replicating that maintenance burden isn't justified by this plan's scope.
+**Narrowed by Update 3**: the local, no-benchmark-data half of what
+"hardware-aware recommend" means is no longer part of this deferred item —
+see M12 below. If this phase is ever picked back up, it's specifically about
+suggesting *new* models to download, not about ranking ones already on disk.
+
+### Phase M11 — Hardware detection & display
+
+**Depends on**: nothing functionally (can ship independently of M1-M9), but
+most useful once M2 exists to interpret it against.
+
+**Problem**: Crustly has no notion of what GPU/VRAM/RAM the machine it's
+running on actually has. A user deciding which local `.gguf` file to load,
+or what `n_gpu_layers`/`n_ctx` to set, currently has to know their own
+hardware and do the arithmetic by hand.
+
+**Change**: add a best-effort hardware probe, grounded in llamastash's own
+documented approach (§1) rather than inventing a detection strategy from
+scratch — deliberately **subprocess-based, not SDK-linked**, so this stays
+consistent with M0's whole point (management-side code shouldn't need a
+build-time C/C++ toolchain):
+
+- **NVIDIA** (Linux/Windows): shell out to `nvidia-smi --query-gpu=name,memory.total,memory.used --format=csv,noheader`.
+- **AMD** (Linux): shell out to `rocm-smi --showmeminfo vram gtt --json`.
+- **AMD/Intel** (Windows): the Win32 DXGI API (`IDXGIFactory1::EnumAdapters1`)
+  — a native API call via the `windows`/`windows-sys` crate, not a
+  subprocess; no VRAM live-utilization data available this way, matching
+  llamastash's own documented limitation for this path.
+- **Apple** (macOS): shell out to `system_profiler SPDisplaysDataType -json`
+  for unified-memory total.
+- **Cross-vendor fallback**: shell out to `vulkaninfo --summary` for an
+  adapter name when none of the above resolve anything.
+- **CPU-only**: whatever of the above ran found nothing → report `CpuOnly`,
+  not an error. System RAM total (relevant on the CPU-only and Apple-unified
+  paths) comes from a small, already-common cross-platform crate rather than
+  reimplementing per-OS `/proc/meminfo`/`sysctl`/WMI parsing — see §6.
+- **Degrade cleanly everywhere**: a missing binary, a non-zero exit, a
+  timeout (cap subprocess wait — a hung driver tool must not hang `doctor`
+  or `list`), or unparseable output all fall through to "unknown," the same
+  posture this plan already requires of the GGUF parser (M1) and the
+  filename-based quantization fallback. Detection failure is never fatal to
+  `crustly llama-cpp list`/`doctor`.
+
+**Display**: surface the result in `crustly llama-cpp doctor` (extends M9)
+and a new host-info line/panel in the Ctrl+G TUI dialog (extends M8) — name,
+VRAM total (where available), system RAM total. Read-only and advisory, as
+established in M2's note above: this never writes back into
+`LlamaCppProviderConfig`.
+
+**Effort**: Medium — mostly plumbing (subprocess spawn + parse per vendor,
+each independently testable against captured sample output) plus the
+degradation-path testing the "clean fallback" requirement above demands.
+
+### Phase M12 — Local hardware-fit filtering (the part of `recommend` that doesn't need benchmark data)
+
+**Depends on**: M1, M2, M11.
+
+This is the promoted subset of what was originally deferred as part of
+Phase M10 (see §3 item 5's Update-3 note) — the part llamastash's own VRAM-
+fit hard filter does *before* its benchmark-ranking step, which needs no
+external dataset because it only compares two numbers Crustly can already
+compute locally: M2's per-model memory estimate and M11's detected
+VRAM/RAM.
+
+- Annotate each entry in `crustly llama-cpp list` / the TUI dialog with a
+  fit indicator against the detected hardware at a sensible default context
+  length — e.g. **Fits** (comfortably under budget), **Tight** (fits but
+  leaves little headroom), **Won't fit** (exceeds detected VRAM+RAM) —
+  three states, not a false-precision percentage.
+- `crustly llama-cpp list --best-fit` (or equivalent flag): sort
+  already-discovered local models by fit instead of name/date, so "which of
+  the models I already have should I actually run" has a direct answer
+  without the user doing the arithmetic themselves.
+- Explicitly **not** a HuggingFace catalog search and **not** benchmark-
+  ranked — both stay in deferred Phase M10. This phase only ever ranks
+  models the user has already downloaded.
+
+**Effort**: Small–Medium, once M2/M11 exist — this phase is mostly a
+comparison and a sort, not new detection or parsing logic.
 
 ---
 
@@ -492,13 +611,19 @@ user doesn't have yet.
 |---|---|---|
 | None required for M0 | — | Feature-flag reorganization only |
 | None required for M1 | — | Hand-rolled parser over `std::io`, consistent with keeping the management path toolchain-light (the whole point of M0) |
-| None required for M2–M9 | — | Built on M1's output plus existing `reqwest`/`sha2`/`tokio::fs` already in the dependency tree |
+| None required for M2, M3, M4, M5, M6, M7, M8, M9, M12 | — | Built on M1's output plus existing `reqwest`/`sha2`/`tokio::fs` already in the dependency tree |
+| A small cross-platform system-info crate (e.g. `sysinfo`), optional, `gguf-management`-gated | M11 (system RAM total, CPU-only fallback path) | Reimplementing per-OS `/proc/meminfo`/`sysctl`/WMI parsing by hand is exactly the kind of low-value hand-rolling this plan otherwise avoids doing (contrast with M1's parser, which *is* worth hand-rolling because no lightweight crate does GGUF header parsing specifically). A RAM-total query is commodity functionality a well-maintained pure-Rust crate already solves portably. |
+| `windows`/`windows-sys` (Windows-only, already optional-by-target) | M11 (DXGI adapter enumeration on Windows, AMD/Intel GPUs) | Native Win32 API binding, not a subprocess — matches llamastash's own documented approach for this specific path; no SDK/toolchain install required beyond what any Windows dev machine already has. |
+| None (GPU vendor tools) | M11 (NVIDIA/AMD/Apple/Vulkan detection) | Subprocess calls to already-installed vendor tools (`nvidia-smi`, `rocm-smi`, `system_profiler`, `vulkaninfo`) via `std::process::Command` — no new Cargo dependency, and no dependency on the tool being present (degrades to "unknown" per M11's clean-degradation requirement). |
 
 Deliberately **not** proposing a general-purpose GGUF/tensor crate (e.g. via
 `candle`) for header parsing — that would reintroduce exactly the kind of
 heavy, ML-framework-shaped dependency this plan is trying to keep *out* of
 the management path, for a job (reading a few KB of typed KV pairs) that
-doesn't need one.
+doesn't need one. Likewise, deliberately **not** proposing NVML/ROCm SDK
+bindings for M11 — that would reintroduce the same build-toolchain problem
+M0 exists to remove, for detection that's fully served by subprocess calls
+to tools GPU owners already have installed.
 
 ---
 
@@ -515,18 +640,22 @@ doesn't need one.
 | M6 — Download hardening | M0 | M | Medium |
 | M7 — Agent-facing `--json`/exit codes | M1 | S–M | Medium |
 | M8 — TUI enhancements | M1, M2, M4, M5 | M | Medium |
-| M9 — `doctor` diagnostics | M0 (M1/M2 for full value) | S | Low |
-| M10 — Hardware-aware recommend | M2 | — | Deferred |
+| M9 — `doctor` diagnostics | M0 (M1/M2/M11 for full value) | S | Low |
+| M10 — Catalog-based, benchmark-ranked recommend | M2, M12 | — | Deferred |
+| M11 — Hardware detection & display | — (M2 to interpret against) | M | Medium |
+| M12 — Local hardware-fit filtering | M1, M2, M11 | S–M | Medium |
 
-Recommended starting sequence: **M0 → M1**, then M2/M3/M6/M7 in any order
-(all independent once M1 lands), M4/M5/M8 last since they consume the others,
-M9 whenever convenient, M10 revisited only if a concrete need for it shows up.
+Recommended starting sequence: **M0 → M1**, then M2/M3/M6/M7/M11 in any order
+(all independent once M1 lands; M11 has no dependency on M1 at all and can
+start even earlier), M4/M5/M8/M12 last since they consume the others, M9
+whenever convenient, M10 revisited only if a concrete need for a
+not-yet-downloaded-model catalog shows up.
 
 ---
 
 ## 8. Development phases (execution roadmap)
 
-§5 defines *what* changes in capability terms (M0–M10); this section groups
+§5 defines *what* changes in capability terms (M0–M12); this section groups
 those into shippable milestones a team can actually schedule against, each
 with concrete files, acceptance criteria, and effort in developer-days
 (one dev-day ≈ focused implementation + tests + review for that scope, not
@@ -592,10 +721,26 @@ there's a stable feature set to describe).
 | | |
 |---|---|
 | Files | New `crustly llama-cpp doctor` subcommand in `src/cli/mod.rs`; `README.md` (`gguf-management`/new config keys); `config.toml.example` (`extra_model_paths`, Ollama-blob opt-in, revision-pinned `hf:` examples); `docs/guides/LLAMA_CPP_GUIDE.md` (management section, following the precedent `llama-cpp-2-integration-plan.md` Phase 10 already set for this same guide) |
-| Tasks | `doctor` checks: build-feature detection (`gguf-management` vs `llama-cpp` vs neither), `models_dir` existence/writability, available disk space, and (using DP3's estimator) a rough max-model-size-for-detected-RAM line; update all three docs to describe the shipped feature set — capability by capability, not aspirationally |
+| Tasks | `doctor` checks: build-feature detection (`gguf-management` vs `llama-cpp` vs neither), `models_dir` existence/writability, available disk space, and — once DP6 lands — the actually-detected hardware plus a "largest model your hardware can hold" line (before DP6, this line is simply omitted rather than guessed); update all three docs to describe the shipped feature set — capability by capability, not aspirationally |
 | Acceptance criteria | `doctor` always exits 0 and produces structured (not free-text-only) findings, matching this plan's own §5 M9 description; docs describe only what has actually shipped by this point, cross-referencing this plan the way `llama-cpp-2-integration-plan.md`'s own Phase 10 cross-references `llm-file-gguf-support.md` rather than restating it |
 | Effort | ~1.5 dev-days (M9) + ~1 dev-day (docs) ≈ **2.5 dev-days** |
 | Exit gate | A new user with no prior context can run `crustly llama-cpp doctor` and the shipped guide section to get from zero to a listed, inspectable local model |
+
+### DP6 — Hardware-aware local recommendations
+**Covers**: M11, M12. **Depends on**: DP1 (M1, for M12's memory-estimate
+input) and DP3 (M2, the estimator itself). Independent of DP2/DP4/DP5 —
+can be built in parallel with any of them once DP1+DP3 land. This milestone
+exists because a user reviewing llamastash directly asked for the "detect my
+hardware and tell me which of my models fit" experience specifically, not
+just the memory-estimate math DP3 already covers in isolation.
+
+| | |
+|---|---|
+| Files | New `src/llm/provider/hardware_detect.rs` (or similar — probe chain + parsing per vendor); `Cargo.toml` (`sysinfo`, `windows`/`windows-sys` on Windows, both `gguf-management`-gated); `src/llm/provider/llama_cpp_models.rs` (fit annotation/sort on `list`); `src/cli/mod.rs` (`--best-fit` flag); `src/tui/llama_cpp_download.rs` and `src/cli/mod.rs`'s `doctor` (host-info display, extending M8/M9) |
+| Tasks | One detection function per vendor path (NVIDIA/AMD/Windows-DXGI/Apple/Vulkan-fallback/CPU-only), each independently unit-testable against captured sample subprocess output (not a live GPU) so CI doesn't need real hardware; a timeout wrapper around every subprocess call; the `CpuOnly`/"unknown" fallback path; the fit-comparison function (M2 estimate vs. M11 detected budget → `Fits`/`Tight`/`Won't fit`); the `--best-fit` sort |
+| Acceptance criteria | Detection degrades to `CpuOnly`/unknown (never panics, never hangs past the timeout) when a vendor tool is absent — tested by pointing the subprocess call at a nonexistent binary path, not by requiring the test runner to lack a GPU; parsing tests use captured real `nvidia-smi`/`rocm-smi`/`system_profiler` sample output (checked into the test fixtures, not generated live); fit-annotation tests cover all three states plus the "detection found nothing, fit is unknown" fourth state (must render as "unknown," never silently as "won't fit," which would be actively misleading) |
+| Effort | ~3 dev-days (M11 — four-plus detection paths, each simple but independently testable) + ~2 dev-days (M12 — comparison, annotation, sort, TUI/CLI wiring) ≈ **5 dev-days** |
+| Exit gate | `crustly llama-cpp doctor` shows real detected GPU/VRAM/RAM on a machine that has `nvidia-smi`/`rocm-smi`/etc. installed, "CPU-only" cleanly on one that doesn't, and `crustly llama-cpp list --best-fit` sorts already-downloaded models with a correct Fits/Tight/Won't-fit label on each |
 
 ### Roadmap summary
 
@@ -606,12 +751,14 @@ there's a stable feature set to describe).
 | DP3 — Intelligence | M2, M4, M5 | DP1, DP2 | 6 dev-days |
 | DP4 — Interfaces | M7, M8 | DP1 (fully: DP1–DP3) | 5.5 dev-days |
 | DP5 — Polish | M9 + docs | DP1–DP4 | 2.5 dev-days |
-| **Total** | M0–M9 (M10 deferred, §5) | | **~24 dev-days** |
+| DP6 — Hardware-aware local recommendations | M11, M12 | DP1, DP3 (parallel to DP2/DP4/DP5) | 5 dev-days |
+| **Total** | M0–M9, M11–M12 (M10 deferred, §5) | | **~29 dev-days** |
 
 These are sequential dependency-order estimates, not a claim that one
-person spends 24 consecutive days on this — DP2/DP3's sub-items (M3/M6,
-and M2/M4/M5 respectively) are each parallelizable across contributors
-once DP1 lands, same as §7's dependency graph already implies.
+person spends 29 consecutive days on this — DP2/DP3's sub-items (M3/M6, and
+M2/M4/M5 respectively) are each parallelizable across contributors once DP1
+lands, and DP6 as a whole is parallelizable against DP2/DP4/DP5 once DP1+DP3
+land, same as §7's dependency graph already implies.
 
 ## 9. Risks
 
@@ -632,6 +779,16 @@ once DP1 lands, same as §7's dependency graph already implies.
   but adds parsing complexity. Acceptable to ship M1 with "unknown" as a
   valid, honest output rather than a guess, same posture as today's
   `quantization_hint_from_filename` returning `None`.
+- **Subprocess-based hardware detection (M11) hanging or misbehaving**: a
+  vendor tool that hangs (a wedged driver, a broken `nvidia-smi`) must not
+  hang `crustly llama-cpp doctor`/`list` — mitigated by the timeout
+  requirement stated as part of M11's own acceptance criteria (DP6), not
+  left implicit. Spawning `$PATH`-resolved binaries is also a mild trust
+  surface (a malicious entry earlier in `$PATH` than the real tool) — no
+  different in kind from any other tool Crustly already shells out to
+  today, but worth the same care: don't elevate privileges around these
+  calls, and treat their output as untrusted text to parse defensively
+  (same posture as M1's GGUF parser), not as trusted structured data.
 - **Scope creep back toward llamastash's full feature set.** §3 and §6 exist
   specifically to keep this plan bounded; any future addition should be
   checked against "does this manage GGUF files Crustly already has/wants,

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -294,7 +294,28 @@ feature, `sha2` re-gated, `all-llm` extended). No logic changes — should be
 a behavior-preserving refactor verifiable by running the existing test
 suite unmodified under the new feature flag.
 
-### Phase M1 — Pure-Rust GGUF header metadata parser
+### Phase M1 — Pure-Rust GGUF header metadata parser ✅ Done
+
+Implemented as planned, with the caching sub-task deferred: the source
+plan bundled an in-memory `(path, size, modified_at)`-keyed cache into
+this phase, motivated by repeated re-parsing "once M3 scans multiple
+directories." M3 hasn't landed yet — today's single-directory scan only
+reads a small, bounded header prefix per file (never the whole model), so
+building cache infrastructure now, before the multi-directory/repeated-
+call scenario that motivates it exists, would be speculative. Revisit
+alongside M3. Everything else landed: the layered quantization result
+(`general.file_type` precise → tensor-type mode coarser → filename guess
+last resort), the hardening requirement (every declared length capped
+before allocation, 256 MiB cumulative budget, structural problems → `None`
+for the whole file), and the `LocalGgufModel`/TUI-mirror field additions.
+`quantization_hint_for_path` (Ctrl+O panel) was upgraded too, matching M0's
+own precedent of picking up directly-justified small scope beyond the
+phase's original file list. Verified: 847/847 tests under
+`--features gguf-management` (13 new, zero new dependencies), 864/864
+under `--features llama-cpp` and 896/896 under `all-llm` confirm no
+regression; an end-to-end smoke test against a synthetic `.gguf` file
+confirmed `crustly llama-cpp list` prints the precise header-parsed
+quantization, not a filename guess, on a build with no FFI compiled in.
 
 **Problem**: no code anywhere in Crustly reads GGUF header key-value
 metadata; quantization is a filename guess and everything else (architecture,

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -669,7 +669,37 @@ existing `#[cfg(feature = "gguf-management")]` split exactly.
 `render_llama_cpp_models` pattern noted in `llama-cpp-2-integration-plan.md`
 Phase 7's corrected-assumptions note).
 
-### Phase M9 — `crustly llama-cpp doctor`
+### Phase M9 — `crustly llama-cpp doctor` ✅ Done
+
+Implemented as planned: build-feature/GPU-backend detection (`cfg!()`-based, no
+cross-feature-gate function calls - `llama_cpp.rs`'s own `gpu_backend_compiled_in()`
+is itself gated behind `feature = "llama-cpp"`, unusable from `gguf-management`-only
+code, so this duplicates the same `cfg!(any(...))` check locally rather than trying
+to share it), `models_dir` existence/writability (a real write-probe file, not just a
+permissions read), disk space (reusing M6's `available_space_at`, now `pub(crate)`),
+and `extra_model_paths`/`scan_ollama_models` sanity. Structured findings
+(`DoctorStatus::{Ok,Warn,Fail}` + message), always exits 0 regardless, exactly as
+specified. Detected-hardware line explicitly deferred, matching DP5's own note in
+§8 - `doctor` surfaces M11's output once that phase lands, not a reason to duplicate
+detection logic here.
+
+**Two things found and fixed while implementing this phase, neither part of its own
+design**:
+1. **A real gap in this whole document's own verification discipline**: M7's new
+   JSON DTOs (`LlamaCppModelJson`/`LlamaCppListJson`) were never gated behind
+   `#[cfg(feature = "gguf-management")]`, breaking the *true* zero-feature build
+   (`cargo build --no-default-features`, no `--features` added back) - a build this
+   plan's own phases had claimed to verify at every step but, it turns out, never
+   actually ran. Every prior "no-feature build" check in this document's phase
+   write-ups was actually `--features gguf-management --no-default-features`, which
+   is `gguf-management` **on** (it's the crate's `default` feature -
+   `default = ["gguf-management"]`, confirmed by reading `Cargo.toml`, not assumed).
+   Fixed by gating the DTOs (and `DoctorStatus`/`DoctorFinding`, found by the same
+   omission) properly; the true zero-feature build is now part of this phase's own
+   verification and should be for any future phase too.
+2. Confirmed (not new) the `ollama rm` arg-collision bug flagged in M7 is real and
+   independent of `llama-cpp`'s own fix - tracked in `ROADMAP.md`'s Backlog, still
+   deliberately unfixed here.
 
 **Depends on**: M0.
 

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -387,7 +387,23 @@ small hand-crafted or truncated real GGUF headers (mirroring the existing
 in tests) — truncated/malformed fixtures double as the hardening tests
 required above.
 
-### Phase M2 — Memory/VRAM footprint estimate & context auto-fit hint
+### Phase M2 — Memory/VRAM footprint estimate & context auto-fit hint ✅ Done
+
+Implemented as planned: `GgufMetadata` gained `block_count`/`attention_head_count`/
+`attention_head_count_kv`/`embedding_length` (extracted the same suffix-matched way
+as `context_length`, kept internal to the parser rather than exposed on
+`LocalGgufModel` directly); `estimate_memory_bytes` returns weights-only when the
+attention geometry is missing, with `includes_kv_cache` saying so explicitly rather
+than under-counting silently. `bits_per_weight` is a documented-approximate lookup
+table covering every quantization label this module's own tables and the filename
+fallback can produce, including the IQ family. Context length used for the estimate
+is `min(header's native context, 8192)`, matching `default_llama_cpp_n_ctx()`. Wired
+into `LocalGgufModel`/`crustly llama-cpp list`, which now prints
+`"~4.9 GB"`/`"~4.9 GB (weights only)"`. "Context auto-fit hint" (feeding this back as
+an `n_gpu_layers`/`n_ctx` warning) was scoped as advisory-only per the plan's own
+Update-3 note — not implemented as a separate warning path this round, since M9/M11
+(doctor, hardware detection) are the more natural place for an "exceeds your hardware"
+warning than the memory-estimate phase itself; revisit there.
 
 **Depends on**: M1.
 
@@ -414,7 +430,29 @@ actually asking for.
 
 **Effort**: Medium.
 
-### Phase M3 — Multi-source discovery
+### Phase M3 — Multi-source discovery ✅ Done (HF/LM Studio auto-scan explicitly deferred)
+
+Implemented `extra_model_paths` and Ollama manifest-based discovery as planned, both
+verified against ground truth before writing code: Ollama's actual manifest storage
+layout (`server/manifest.go`/`server/images.go`, `types/model/name.go` on
+`github.com/ollama/ollama`) confirmed the `{host}/{namespace}/{model}/{tag}` path
+depth (fixed, so a 4-level `read_dir` nest suffices - no general recursive walker
+needed), the `sha256:` → `sha256-` blob-filename mapping, and the
+`application/vnd.ollama.image.model` media type distinguishing the weights layer from
+`.../projector`/`.../template`/etc. `scan_ollama_models` defaults `false` and is gated
+independently of the `ollama` Cargo feature, per the plan's own correction on that
+exact point. `$OLLAMA_MODELS` env var respected (Ollama's own override), falling back
+to `~/.ollama/models`.
+
+**Scope decision made during implementation, not in the original draft**: the
+HuggingFace/LM Studio well-known-cache auto-scan sub-item was deferred rather than
+attempted. Both caches nest `.gguf` files several directories deep (HF via
+content-addressed symlinks under `models--org--repo/snapshots/<hash>/`; LM Studio
+under `<publisher>/<repo>/`) - reusing the flat single-directory scan
+`extra_model_paths` correctly uses would silently find zero files there, which is
+worse than not implementing it (it would look like a working feature that quietly
+never finds anything). Left for a follow-up once a properly bounded/symlink-safe
+recursive walker is designed - same treatment already given to filesystem watching.
 
 **Depends on**: M0.
 
@@ -463,7 +501,19 @@ exists, lower priority than getting the scan itself right.
 
 **Effort**: Medium.
 
-### Phase M4 — Deduplication (symlinks, split GGUFs)
+### Phase M4 — Deduplication (symlinks, split GGUFs) ✅ Done
+
+Implemented as planned: canonical-path dedup (`std::fs::canonicalize`, falling back to
+the raw path on failure) merges symlink duplicates and same-blob Ollama entries alike
+through the same code path, combining `display_name`s (comma-joined) rather than
+dropping one; split-GGUF grouping (`-00001-of-00005.gguf`, equal-width validated) sums
+size across genuinely separate files and handles a partial group (not all parts
+downloaded yet) honestly rather than requiring completeness. Both passes use a
+"richest metadata wins" tiebreak (`architecture.is_some()`) to decide which entry's
+header-derived fields the merged result keeps. `crustly llama-cpp rm` was
+deliberately left unextended - it still only resolves bare names against the primary
+`models_dir`, so it can't accidentally delete an Ollama-managed blob out from under
+Ollama's own manifest bookkeeping (a safety property, not a gap).
 
 **Depends on**: M1, M3.
 

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -1,11 +1,18 @@
 # GGUF Model Management Improvement Plan (informed by `llamastash`)
 
 Status: **Proposal — analysis only, no implementation started.**
-Date: 2026-08-06 (revised same day after a self-review pass — see the
-"Development phases" section for the resulting execution roadmap; the
-review corrected two inaccuracies in the original draft (§5, M3/M4) and
-added the defensive-parsing, caching, and documentation items now folded
-into M0/M1/M3 and the new §8)
+Date: 2026-08-06. Two review passes so far:
+- **Review 1** (self-review against the Crustly codebase): added the
+  "Development phases" execution roadmap (§8) and corrected two
+  inaccuracies in the original draft (§5, M3/M4), plus the
+  defensive-parsing, caching, and documentation items folded into M0/M1/M3.
+- **Review 2** (re-comparison against llamastash's actual README/docs/config
+  reference, not just a summary of it): corrected the Ollama-discovery
+  design in M3/M4 from "scan the blob store and reverse-resolve names" to
+  "read Ollama's manifests directly," added concrete LM Studio scan paths,
+  and added an explicit maturity caveat (§1) plus an explicit deferred item
+  (MTP speculative-decoding detection, §3) that the first pass omitted
+  without saying so.
 Scope: improve how Crustly discovers, inspects, downloads, and manages local
 `.gguf` model files, informed by a feature analysis of
 [`llamastash`](https://github.com/llamastash/llamastash) — a Rust TUI/CLI
@@ -24,28 +31,42 @@ model.
 
 ## 1. What was analyzed
 
-`llamastash` (MIT, "The Software shall be used for Good, not Evil" clause) is
-a terminal-native launcher for local LLMs: a bearer-token-authenticated
-loopback daemon that spawns `llama-server` processes on demand, backed by a
-TUI and a scriptable CLI. Its full scope (multi-model concurrency, port
-allocation, an OpenAI/Ollama/Anthropic-compatible proxy, five TUI themes,
-hardware-aware launch presets) is out of scope for this document — see §6.
-The part analyzed in depth here is its **GGUF discovery and management
-subsystem**, summarized from its README/docs:
+`llamastash` (MIT © Deepu K Sasidharan, "Software for Good only, not for
+military or intelligence use" clause) is a terminal-native launcher for
+local LLMs: a bearer-token-authenticated loopback daemon that spawns
+`llama-server` processes on demand, backed by a TUI and a scriptable CLI.
+Its full scope (multi-model concurrency, port allocation, an
+OpenAI/Ollama/Anthropic-compatible proxy, five TUI themes, hardware-aware
+launch presets, experimental Lemonade/ds4 backends) is out of scope for this
+document — see §3. The part analyzed in depth here is its **GGUF discovery
+and management subsystem**, verified against its actual README, `docs/`
+tree, and `config.example.yaml` reference (not a paraphrase of a paraphrase):
 
-- **Discovery**: auto-scans HuggingFace cache, Ollama's blob store, and LM
-  Studio's cache directory, plus user-configured extra paths; live filesystem
-  watching picks up new files without a restart.
+- **Discovery**: auto-scans three default "buckets" — HuggingFace's cache
+  (`~/.cache/huggingface/hub` on Linux, `~/Library/Caches/huggingface/hub`
+  on macOS), Ollama's model directory (`~/.ollama/models` on both), and LM
+  Studio's cache (`~/.lmstudio/models` and `~/.cache/lm-studio/models` on
+  Linux; `~/Library/Caches/LMStudio/models` and `~/.lmstudio/models` on
+  macOS) — plus user-configured `model_paths`, each bucket independently
+  toggleable via `disable_default_cache_paths`. Live filesystem watching
+  picks up new files without a restart.
 - **Metadata parsing**: reads GGUF header key-value metadata directly —
   architecture, parameter count, quantization level, native context window,
   embedded chat template, and KV-cache-aware memory estimates. Not a
-  filename-convention guess.
+  filename-convention guess. Also flags MTP (multi-token-prediction /
+  speculative-decoding-capable) GGUFs with a dedicated TUI badge — see the
+  explicit non-goal on this in §3, added in this review pass.
 - **Deduplication**: collapses symlinks, unifies split multi-part GGUFs
-  (`-00001-of-00005.gguf` style) into one logical model, and names
-  content-addressed Ollama blobs intelligibly instead of showing raw SHA
-  digests.
+  (`-00001-of-00005.gguf` style) into one logical model, and — for Ollama —
+  reads the **manifest files** under `~/.ollama/models/manifests/` (which map
+  a human-readable name/tag to one or more content-addressed blob hashes in
+  `~/.ollama/models/blobs/`) to show the model's real name instead of a raw
+  SHA digest. This is manifest-first name resolution, not blob-store
+  scanning with after-the-fact guessing — a distinction this plan's first
+  draft got slightly wrong (see the correction in M3/M4 below).
 - **Multimodal pairing**: auto-detects and pairs vision/audio projector
-  (`mmproj`) files with their base model.
+  (`mmproj`) files with their base model, with distinct glyphs for vision
+  (◉) vs. audio (♪) in the TUI.
 - **Download**: `pull <hf-repo>` with disk-space prechecks, SHA-256
   verification, and `--revision <sha>` pinning for reproducible pulls.
 - **Hardware awareness**: filters/ranks discovered and recommendable models
@@ -53,10 +74,27 @@ subsystem**, summarized from its README/docs:
   fits instead of failing at load time.
 - **Agent-facing CLI contract**: stable `--json` output, byte-stable TSV when
   piped, and a documented exit-code table (64–74 per failure class) so a
-  calling agent can branch on the exit code instead of parsing text.
+  calling agent can branch on the exit code instead of parsing text —
+  reinforced by a published Agent Skills manifest (`npx skills add
+  llamastash/llamastash`) that explicitly teaches calling agents to prefer
+  `--json` and branch on exit codes rather than parse text output. Directly
+  relevant to Phase M7 below, since Crustly is itself an agent-facing tool
+  (`AGENTS.md`).
 - **Diagnostics**: a `doctor` subcommand that always exits 0 and reports
   typed, actionable problems (missing binary, wrong `llama-server` build,
   unwritable cache dir, etc.).
+
+**Project-maturity caveat**, added in this review pass: llamastash is a
+single-maintainer project (119 stars, 12 forks, 4 open issues at analysis
+time) with an active but still-open roadmap of its own (its `TODO.md`
+lists, among other things, "llama.cpp version pinning to prevent silent
+drift" and NVML-based VRAM attribution as *unfinished* work). That doesn't
+undercut the specific design patterns cited above — the GGUF-format facts
+(header layout, split-file convention, manifest structure) are independent
+of llamastash's own maturity — but it's a reason to treat llamastash as a
+useful *reference design*, not a battle-tested implementation to copy
+uncritically. This plan already reflects that by hand-rolling Crustly's own
+parser (M1) rather than depending on llamastash's code directly.
 
 ---
 
@@ -120,6 +158,16 @@ Crustly:
    maintenance burden is disproportionate to the value for Crustly. A
    lighter, purely local hardware-fit heuristic (Phase M10) covers the
    useful part without the ongoing-data-pipeline cost.
+6. **No MTP (speculative-decoding-capable) GGUF detection, for now.** Added
+   in this review pass — the first draft omitted this llamastash feature
+   without saying why. llamastash flags MTP-capable GGUFs at discovery time
+   because it can *act* on that flag (auto-enabling speculative decoding in
+   its launcher). Crustly's `LlamaCppProvider` has no speculative-decoding
+   implementation at all today, so detecting the flag with nothing to
+   consume it is metadata for its own sake. Revisit this only alongside a
+   future speculative-decoding phase in `llama-cpp-2-integration-plan.md`,
+   not as a standalone management-side addition — at that point it's a
+   small extra field on the M1 parser output, not a new subsystem.
 
 ---
 
@@ -139,7 +187,8 @@ Crustly:
 | KV-cache memory estimate / context auto-fit | Yes | No | **Medium** |
 | Agent-facing `--json` + documented exit codes | Yes | No | **Medium** (Crustly is itself agent-facing — see AGENTS.md — so this is more relevant to Crustly than a generic nice-to-have) |
 | `doctor`-style diagnostics | Yes | No | **Low** |
-| Hardware-aware recommend | Yes (CI benchmark data) | No | **Low** (deferred, see §3.5) |
+| Hardware-aware recommend | Yes (CI benchmark data) | No | **Low** (deferred, see §3 item 5) |
+| MTP/speculative-decoding-capable GGUF detection | Yes (TUI badge) | No | **N/A — explicitly deferred, see §3 item 6** (no consumer without a speculative-decoding engine, which Crustly doesn't have) |
 
 ---
 
@@ -286,22 +335,41 @@ transformer KV-cache formula, and surface it:
 Extend `list_local_models` to scan, in addition to
 `providers.llama_cpp.models_dir`:
 - A new `providers.llama_cpp.extra_model_paths: Vec<PathBuf>` config list.
-- Ollama's local blob store (`~/.ollama/models/blobs`) — read-only awareness
-  so a model already pulled via Ollama shows up for llama.cpp management
-  too, without duplicating storage. **Gate this on an explicit config
-  opt-in and the path's actual presence on disk, not on Crustly's own
-  `ollama` Cargo feature/config** — whether an Ollama *daemon* has left
-  blobs on this machine is unrelated to whether this particular Crustly
-  build was compiled with the `ollama` feature (which only governs talking
-  to an Ollama HTTP server); conflating the two would hide real local
-  files on a build that happens not to include `ollama`, and is the wrong
-  signal even on one that does.
-- Optionally, well-known cache locations (HuggingFace's `~/.cache/huggingface/hub`,
-  LM Studio's model directory) behind an opt-in config flag — auto-scanning
-  directories a user didn't explicitly point Crustly at is a bigger default-
-  behavior change than the rest of this plan, so this sub-item should ship
-  disabled by default with a config toggle, not on by default the way
-  llamastash does it.
+- **Ollama, via its manifests — not its blob store.** Correction from this
+  review's re-read of llamastash's actual behavior: the first draft
+  proposed scanning `~/.ollama/models/blobs` directly and "resolving back"
+  a content-addressed blob to a name afterward. llamastash instead reads
+  `~/.ollama/models/manifests/**` (JSON files mapping a human-readable
+  `name:tag` to the blob hash(es) that make it up) and resolves the name
+  *at discovery time*, which is both simpler and gives a correct name
+  unconditionally rather than a best-effort reverse lookup. Crustly should
+  do the same: walk `~/.ollama/models/manifests/`, parse each manifest,
+  and resolve straight to `~/.ollama/models/blobs/sha256-<hash>` with the
+  manifest's own name attached — no separate "resolve blob to name" step
+  needed later in M4. **Gate this on an explicit config opt-in and the
+  path's actual presence on disk, not on Crustly's own `ollama` Cargo
+  feature/config** — whether an Ollama *daemon* has left models on this
+  machine is unrelated to whether this particular Crustly build was
+  compiled with the `ollama` feature (which only governs talking to an
+  Ollama HTTP server); conflating the two would hide real local files on a
+  build that happens not to include `ollama`, and is the wrong signal even
+  on one that does.
+- Optionally, well-known cache locations behind an opt-in config flag —
+  auto-scanning directories a user didn't explicitly point Crustly at is a
+  bigger default-behavior change than the rest of this plan, so this
+  sub-item should ship disabled by default with a config toggle, not on by
+  default the way llamastash does it. Concrete paths (matching llamastash's
+  own default buckets, confirmed against its README's path table):
+
+  | Bucket | Linux | macOS |
+  |---|---|---|
+  | HuggingFace | `~/.cache/huggingface/hub` | `~/Library/Caches/huggingface/hub` |
+  | LM Studio | `~/.lmstudio/models`, `~/.cache/lm-studio/models` | `~/Library/Caches/LMStudio/models`, `~/.lmstudio/models` |
+
+  (Windows paths intentionally left unresolved here — worth confirming
+  against Crustly's own existing Windows path conventions, e.g.
+  `%APPDATA%`-relative, rather than assuming llamastash's Windows layout
+  transfers unchanged.)
 
 Filesystem watching (llamastash's live-update behavior) is explicitly
 **deferred, not dropped** — it's a nice-to-have once multi-source scanning
@@ -309,7 +377,7 @@ exists, lower priority than getting the scan itself right.
 
 **Effort**: Medium.
 
-### Phase M4 — Deduplication (symlinks, split GGUFs, Ollama blob naming)
+### Phase M4 — Deduplication (symlinks, split GGUFs)
 
 **Depends on**: M1, M3.
 
@@ -319,9 +387,15 @@ exists, lower priority than getting the scan itself right.
   zero-padded to the same width) and unify each group into one logical
   `LocalGgufModel` entry (report the summed size, the base name, first-part
   path as the canonical reference).
-- When a discovered file is an Ollama content-addressed blob (Phase M3),
-  resolve it back to Ollama's manifest name where possible instead of
-  showing a raw digest.
+
+Note: Ollama blob→name resolution is **not** this phase's job anymore —
+per M3's correction above, manifest-based name resolution happens at
+discovery time, so an Ollama-sourced entry already carries its real name by
+the time M4 runs. What M4 still needs to handle for Ollama specifically:
+the same underlying blob can be referenced by more than one manifest (e.g.
+two tags pointing at identical weights) — dedup-key on the blob hash so
+that case collapses to one entry with both names shown, rather than two
+listings of the same file.
 
 **Effort**: Medium.
 
@@ -478,7 +552,7 @@ M3/M6 themselves don't depend on each other and can be built in parallel).
 | | |
 |---|---|
 | Files | `src/config/mod.rs` (`extra_model_paths` on `LlamaCppProviderConfig`, default-off Ollama-blob-store opt-in flag); `src/llm/provider/llama_cpp_models.rs` (multi-path scan, disk-space precheck, `Range`-header resume, `@revision` parsing in the `hf:` shorthand) |
-| Tasks | Extend `list_local_models` to accept multiple directories; add the Ollama blob-store path check gated as corrected in M3 above (config opt-in + on-disk presence, independent of the `ollama` Cargo feature); `HEAD`-request disk-space precheck before `download_model` starts streaming; extend `parse_hf_shorthand` to accept an optional `@revision` suffix; attempt `Range`-header resume when a matching `.part` file already exists, falling back to a full restart on a non-206 response |
+| Tasks | Extend `list_local_models` to accept multiple directories; add Ollama manifest-based discovery per M3's correction (walk `~/.ollama/models/manifests/`, resolve each to its blob(s) and real name, gated on config opt-in + on-disk presence, independent of the `ollama` Cargo feature — not a raw blob-store scan); `HEAD`-request disk-space precheck before `download_model` starts streaming; extend `parse_hf_shorthand` to accept an optional `@revision` suffix; attempt `Range`-header resume when a matching `.part` file already exists, falling back to a full restart on a non-206 response |
 | Acceptance criteria | New unit tests for: multi-directory scan de-duplicating nothing yet (dedup is DP3) but merging listings correctly; disk-space precheck rejecting a download when free space is (mock-)reported below the target size; `@revision` shorthand parsing (valid and malformed cases, mirroring the existing `parse_hf_shorthand_none_for_malformed_shorthand` test shape); resume producing an identical final file to a non-interrupted download in the existing `mock_http_server`-based test harness |
 | Effort | ~2.5 dev-days (M3) + ~2.5 dev-days (M6) ≈ **5 dev-days** |
 | Exit gate | A file interrupted mid-download resumes instead of restarting; a model pulled via `ollama pull` (with the opt-in flag set) appears in `crustly llama-cpp list` without being re-downloaded |
@@ -491,7 +565,7 @@ produces the same model twice).
 | | |
 |---|---|
 | Files | `src/llm/provider/gguf_metadata.rs` (memory estimator); `src/llm/provider/llama_cpp_models.rs` (symlink resolution, split-group unification, mmproj pairing) |
-| Tasks | KV-cache-aware memory estimate function taking parsed architecture/params/quantization + requested `n_ctx`; symlink canonicalization before dedup-keying; `-NNNNN-of-NNNNN.gguf` group detection and merge; mmproj filename/header-hint detection and pairing into the base model's entry |
+| Tasks | KV-cache-aware memory estimate function taking parsed architecture/params/quantization + requested `n_ctx`; symlink canonicalization before dedup-keying; `-NNNNN-of-NNNNN.gguf` group detection and merge; blob-hash dedup for Ollama entries so two manifest tags pointing at identical weights collapse to one listing with both names shown; mmproj filename/header-hint detection and pairing into the base model's entry |
 | Acceptance criteria | Memory estimate within a documented order-of-magnitude tolerance against a couple of known real model/quantization combinations (recorded as a comment, not asserted exactly — hardware/build variance makes exact assertions brittle); a synthetic 3-part split group collapses to one listing entry with the summed size; a synthetic mmproj-pattern file pairs with its base-name match and stands alone (with a clear label, not silently dropped) when no match exists |
 | Effort | ~2 dev-days (M2) + ~2.5 dev-days (M4) + ~1.5 dev-days (M5) ≈ **6 dev-days** |
 | Exit gate | `crustly llama-cpp list` shows one entry per logical model (split parts merged, vision projector paired) with an estimated memory figure |

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -1,7 +1,11 @@
 # GGUF Model Management Improvement Plan (informed by `llamastash`)
 
 Status: **Proposal — analysis only, no implementation started.**
-Date: 2026-08-06
+Date: 2026-08-06 (revised same day after a self-review pass — see the
+"Development phases" section for the resulting execution roadmap; the
+review corrected two inaccuracies in the original draft (§5, M3/M4) and
+added the defensive-parsing, caching, and documentation items now folded
+into M0/M1/M3 and the new §8)
 Scope: improve how Crustly discovers, inspects, downloads, and manages local
 `.gguf` model files, informed by a feature analysis of
 [`llamastash`](https://github.com/llamastash/llamastash) — a Rust TUI/CLI
@@ -152,19 +156,39 @@ no C++ toolchain, but is currently only compiled under `feature = "llama-cpp"`.
 
 **Change**: introduce a lightweight `gguf-management` feature (or fold this
 functionality into the crate's default build — it has no heavy dependencies:
-`reqwest`, `sha2`, filesystem calls, all of which are already used
-elsewhere in the default build) that compiles `llama_cpp_models.rs` and the
-`crustly llama-cpp {list,pull,rm}` CLI subcommand independently of
-`feature = "llama-cpp"`. `LlamaCppProvider` itself (the FFI-backed inference
-path) stays exactly as gated as it is today. This is the one prerequisite
-change every later phase benefits from: it makes "manage my GGUF files" a
-zero-toolchain operation, matching llamastash's actual value proposition,
-without touching the inference feature-gating decision made in
-`llama-cpp-2-integration-plan.md` §3.4.
+`reqwest` is already an unconditional dependency (`Cargo.toml:53`, not
+`optional = true`), and `sha2` only needs to move from `llama-cpp`-gated to
+`gguf-management`-gated) that compiles independently of `feature = "llama-cpp"`:
 
-**Effort**: Small. Mostly moving `#[cfg(...)]` boundaries and updating
-`Cargo.toml` feature declarations; `sha2` becomes an unconditional (or
-`gguf-management`-gated) dependency instead of `llama-cpp`-gated.
+- `src/llm/provider/llama_cpp_models.rs` (currently
+  `#[cfg(feature = "llama-cpp")]` at `src/llm/provider/mod.rs:28-29`).
+- `cmd_llama_cpp`'s **real** body in `src/cli/mod.rs` (currently split into
+  a `#[cfg(feature = "llama-cpp")]` implementation at `src/cli/mod.rs:1250`
+  and a `#[cfg(not(feature = "llama-cpp"))]` "rebuild with..." stub at
+  `:1356` — only the `#[cfg]` target changes, the `Commands::LlamaCpp`/
+  `LlamaCppCommands` enum definitions are already unconditional and need no
+  change).
+
+`LlamaCppProvider` itself (the FFI-backed inference path, `llama_cpp.rs`)
+stays exactly as gated as it is today — this phase touches management code
+only. Because `gguf-management` carries none of the cmake/C++ toolchain cost
+that is the *specific, documented* reason `llama-cpp` is excluded from
+`all-llm` (`Cargo.toml:161-164,180`: "unlike every other provider feature,
+this one compiles native C++"), that reasoning does not apply here — add
+`gguf-management` to `all-llm`, and consider it a candidate for `default`
+outright, subject to confirming `reqwest`+`sha2`'s combined footprint is
+acceptable in a default build.
+
+This is the one prerequisite change every later phase benefits from: it
+makes "manage my GGUF files" a zero-toolchain operation, matching
+llamastash's actual value proposition, without touching the inference
+feature-gating decision made in `llama-cpp-2-integration-plan.md` §3.4.
+
+**Effort**: Small. Moving `#[cfg(...)]` boundaries across the two files
+above and updating `Cargo.toml` feature declarations (new `gguf-management`
+feature, `sha2` re-gated, `all-llm` extended). No logic changes — should be
+a behavior-preserving refactor verifiable by running the existing test
+suite unmodified under the new feature flag.
 
 ### Phase M1 — Pure-Rust GGUF header metadata parser
 
@@ -180,8 +204,34 @@ walk typed KV pairs) rather than pull in a general-purpose GGUF/ML crate.
 This keeps the dependency footprint aligned with Crustly's stated
 "performance, memory efficiency, reduced resource consumption" positioning —
 the same reasoning `llm-file-gguf-support.md` already applied when weighing
-`llama-cpp-2` itself. Read only the header (a few KB), never the tensor data,
-so this stays fast and memory-light even for a 40GB model file.
+`llama-cpp-2` itself. Read only the header and KV/tensor-info section, never
+the tensor data itself, so this stays fast and memory-light even for a
+40GB model file — note this section's actual size varies (typically well
+under a few MB, but large embedded tokenizer vocabularies can push it
+higher), so size it dynamically from the header's own declared counts
+rather than assuming a fixed small constant.
+
+**Hardening requirement, not optional**: this parser runs over files that
+may be corrupted, truncated, or actively adversarial (any `.gguf` a user
+points Crustly at, including ones downloaded from an arbitrary URL via
+Phase M6). It must reject rather than trust declared sizes: cap KV-pair
+count, string length, and array length against sane upper bounds before
+allocating, bail out cleanly on truncation instead of panicking on an
+out-of-bounds read, and never `unwrap()` on attacker-influenced values.
+This is the same class of defense llamastash documents for its own
+downloads ("archive-bomb defenses: entry/size/ratio caps") applied to
+parsing instead of extraction. Malformed input must degrade to "metadata
+unavailable" (same posture as today's `quantization_hint_from_filename`
+returning `None`), never a crash — this is a hard acceptance criterion
+for M1, not a stretch goal.
+
+**Caching**: once Phase M3 scans multiple directories, a `list` call can
+mean re-parsing headers of many large files on every invocation. Cache
+parsed metadata keyed by `(path, size, modified_at)` (already available
+from the existing directory scan, no new stat calls) so an unchanged file
+is never re-parsed — an in-memory cache is enough for M1; a persisted
+cache (e.g. alongside Crustly's existing SQLite database) is worth
+revisiting only if profiling after M3 shows it's needed.
 
 Extract at minimum:
 - `general.architecture`, `general.name`
@@ -193,14 +243,24 @@ Extract at minimum:
 - `*.context_length` (the model's trained/native context window)
 - Whether an embedded chat template (`tokenizer.chat_template`) is present
 
-This becomes the foundation `LocalGgufModel` builds on (replacing the
-filename-only `quantization_hint`), and is what Phases M2/M4/M5/M8 consume.
+This becomes the foundation `LocalGgufModel` builds on (demoting the
+filename-only `quantization_hint` to an explicit fallback, not removing
+it — it stays the answer when a header can't be read), and is what Phases
+M2/M4/M5/M8 consume. Adding fields to `LocalGgufModel` has a known blast
+radius that should be scoped into this phase rather than discovered during
+M8: its two TUI mirrors, `LlamaCppModelSummary` and `LlamaCppModelDetails`
+(`src/tui/llama_cpp_download.rs`), currently copy a subset of its fields
+field-by-field and will need the same fields added; the existing 11
+`llama_cpp_models` unit tests (`quantization_hint_recognizes_common_tags`
+and siblings) must keep passing unmodified since the filename fallback
+path doesn't change behavior, only priority.
 
 **Effort**: Medium. New module (e.g. `src/llm/provider/gguf_metadata.rs`),
 pure functions over `&[u8]`/`Read`, straightforward to unit test against
 small hand-crafted or truncated real GGUF headers (mirroring the existing
 `mock_http_server` pattern of not depending on a real multi-GB model file
-in tests).
+in tests) — truncated/malformed fixtures double as the hardening tests
+required above.
 
 ### Phase M2 — Memory/VRAM footprint estimate & context auto-fit hint
 
@@ -226,10 +286,16 @@ transformer KV-cache formula, and surface it:
 Extend `list_local_models` to scan, in addition to
 `providers.llama_cpp.models_dir`:
 - A new `providers.llama_cpp.extra_model_paths: Vec<PathBuf>` config list.
-- Ollama's local blob store (`~/.ollama/models/blobs`, when the `ollama`
-  feature/config is present) — read-only awareness so a model already
-  pulled via Ollama shows up for llama.cpp management too, without
-  duplicating storage.
+- Ollama's local blob store (`~/.ollama/models/blobs`) — read-only awareness
+  so a model already pulled via Ollama shows up for llama.cpp management
+  too, without duplicating storage. **Gate this on an explicit config
+  opt-in and the path's actual presence on disk, not on Crustly's own
+  `ollama` Cargo feature/config** — whether an Ollama *daemon* has left
+  blobs on this machine is unrelated to whether this particular Crustly
+  build was compiled with the `ollama` feature (which only governs talking
+  to an Ollama HTTP server); conflating the two would hide real local
+  files on a build that happens not to include `ollama`, and is the wrong
+  signal even on one that does.
 - Optionally, well-known cache locations (HuggingFace's `~/.cache/huggingface/hub`,
   LM Studio's model directory) behind an opt-in config flag — auto-scanning
   directories a user didn't explicitly point Crustly at is a bigger default-
@@ -249,9 +315,10 @@ exists, lower priority than getting the scan itself right.
 
 - Resolve symlinks before dedup-keying so the same file reached two ways
   doesn't list twice.
-- Detect the `-00001-of-000NN.gguf` split-file convention and unify each
-  group into one logical `LocalGgufModel` entry (report the summed size,
-  the base name, first-part path as the canonical reference).
+- Detect the `-00001-of-00005.gguf` split-file convention (both numbers
+  zero-padded to the same width) and unify each group into one logical
+  `LocalGgufModel` entry (report the summed size, the base name, first-part
+  path as the canonical reference).
 - When a discovered file is an Ollama content-addressed blob (Phase M3),
   resolve it back to Ollama's manifest name where possible instead of
   showing a raw digest.
@@ -383,8 +450,104 @@ M9 whenever convenient, M10 revisited only if a concrete need for it shows up.
 
 ---
 
-## 8. Risks
+## 8. Development phases (execution roadmap)
 
+§5 defines *what* changes in capability terms (M0–M10); this section groups
+those into shippable milestones a team can actually schedule against, each
+with concrete files, acceptance criteria, and effort in developer-days
+(one dev-day ≈ focused implementation + tests + review for that scope, not
+wall-clock calendar time). Each milestone is independently releasable —
+none blocks shipping the ones before it.
+
+### DP1 — Foundation: unlock management without the build toolchain
+**Covers**: M0, M1. **Depends on**: nothing (first milestone).
+
+| | |
+|---|---|
+| Files | `Cargo.toml` (new `gguf-management` feature, `sha2` re-gate, `all-llm` extension); `src/llm/provider/mod.rs` (`#[cfg]` on `llama_cpp_models`); `src/cli/mod.rs` (`#[cfg]` on `cmd_llama_cpp`, both bodies); new `src/llm/provider/gguf_metadata.rs` |
+| Tasks | Move the two `#[cfg(feature = "llama-cpp")]` boundaries to `gguf-management`; write the GGUF header parser (magic/version validation, typed KV walk, tensor-info walk for parameter-count derivation) with the bounds-checking required in M1; wire real quantization/architecture/param-count/context-length/chat-template-presence into `LocalGgufModel`, demoting the filename guess to fallback; add the in-memory metadata cache keyed by `(path, size, modified_at)`; update `LlamaCppModelSummary`/`LlamaCppModelDetails` (`src/tui/llama_cpp_download.rs`) to carry the new fields |
+| Acceptance criteria | `cargo build --features gguf-management` succeeds with **no C/C++ toolchain present** (the whole point of M0) and links no `llama-cpp-2`/`llama-cpp-sys-2`; `cargo test --features gguf-management` passes, including the 11 pre-existing `llama_cpp_models` tests unmodified plus new parser tests covering a valid minimal header, a truncated file, and at least one adversarial fixture (oversized declared string/array length) that must return an error, not panic or OOM; `cargo build`/`test` with no features and with `--features llama-cpp`/`all-llm` remain green (behavior-preserving refactor + additive fields) |
+| Effort | ~1 dev-day (M0) + ~4 dev-days (M1, parser + hardening + caching + downstream struct updates) ≈ **5 dev-days** |
+| Exit gate | `crustly llama-cpp list` shows real architecture/quantization/context-length for a locally-present `.gguf` file, on a build with no C++ toolchain installed |
+
+### DP2 — Reach and safety: find more files, download them more safely
+**Covers**: M3, M6. **Depends on**: DP1 (M3's dedup-ready listing and M6's
+integrity messaging both assume the richer `LocalGgufModel` from M1;
+M3/M6 themselves don't depend on each other and can be built in parallel).
+
+| | |
+|---|---|
+| Files | `src/config/mod.rs` (`extra_model_paths` on `LlamaCppProviderConfig`, default-off Ollama-blob-store opt-in flag); `src/llm/provider/llama_cpp_models.rs` (multi-path scan, disk-space precheck, `Range`-header resume, `@revision` parsing in the `hf:` shorthand) |
+| Tasks | Extend `list_local_models` to accept multiple directories; add the Ollama blob-store path check gated as corrected in M3 above (config opt-in + on-disk presence, independent of the `ollama` Cargo feature); `HEAD`-request disk-space precheck before `download_model` starts streaming; extend `parse_hf_shorthand` to accept an optional `@revision` suffix; attempt `Range`-header resume when a matching `.part` file already exists, falling back to a full restart on a non-206 response |
+| Acceptance criteria | New unit tests for: multi-directory scan de-duplicating nothing yet (dedup is DP3) but merging listings correctly; disk-space precheck rejecting a download when free space is (mock-)reported below the target size; `@revision` shorthand parsing (valid and malformed cases, mirroring the existing `parse_hf_shorthand_none_for_malformed_shorthand` test shape); resume producing an identical final file to a non-interrupted download in the existing `mock_http_server`-based test harness |
+| Effort | ~2.5 dev-days (M3) + ~2.5 dev-days (M6) ≈ **5 dev-days** |
+| Exit gate | A file interrupted mid-download resumes instead of restarting; a model pulled via `ollama pull` (with the opt-in flag set) appears in `crustly llama-cpp list` without being re-downloaded |
+
+### DP3 — Intelligence: fewer duplicate/confusing entries, useful estimates
+**Covers**: M2, M4, M5. **Depends on**: DP1 (metadata), DP2 (multi-source
+listing is what makes dedup non-trivial — a single-directory scan rarely
+produces the same model twice).
+
+| | |
+|---|---|
+| Files | `src/llm/provider/gguf_metadata.rs` (memory estimator); `src/llm/provider/llama_cpp_models.rs` (symlink resolution, split-group unification, mmproj pairing) |
+| Tasks | KV-cache-aware memory estimate function taking parsed architecture/params/quantization + requested `n_ctx`; symlink canonicalization before dedup-keying; `-NNNNN-of-NNNNN.gguf` group detection and merge; mmproj filename/header-hint detection and pairing into the base model's entry |
+| Acceptance criteria | Memory estimate within a documented order-of-magnitude tolerance against a couple of known real model/quantization combinations (recorded as a comment, not asserted exactly — hardware/build variance makes exact assertions brittle); a synthetic 3-part split group collapses to one listing entry with the summed size; a synthetic mmproj-pattern file pairs with its base-name match and stands alone (with a clear label, not silently dropped) when no match exists |
+| Effort | ~2 dev-days (M2) + ~2.5 dev-days (M4) + ~1.5 dev-days (M5) ≈ **6 dev-days** |
+| Exit gate | `crustly llama-cpp list` shows one entry per logical model (split parts merged, vision projector paired) with an estimated memory figure |
+
+### DP4 — Interfaces: agents and humans both get the new data
+**Covers**: M7, M8. **Depends on**: DP1–DP3 (surfaces their combined output;
+gains progressively more to show as earlier milestones land, but only
+strictly *requires* DP1).
+
+| | |
+|---|---|
+| Files | `src/cli/mod.rs` (`--json` flag on `list`, documented exit codes); new integration test fixture for the JSON schema; `src/tui/llama_cpp_download.rs` and its `render_llama_cpp_models`-family functions (`src/tui/render.rs`) |
+| Tasks | `crustly llama-cpp list --json` with a versioned, documented schema (include a `schema_version` field from the start — cheaper to add now than to retrofit once agents depend on the shape); document and stabilize exit codes for `list`/`pull`/`rm` failure modes; extend the Ctrl+G dialog with the new metadata columns and split/mmproj grouped rows; extend the Ctrl+O info panel with header-parsed quantization/context-length/chat-template indicators |
+| Acceptance criteria | `--json` output round-trips through `serde_json` in a test with a fixed expected shape; a snapshot test per new TUI row/column (following the existing `render` snapshot-test pattern noted in `llama-cpp-2-integration-plan.md` Phase 7); exit codes documented in the CLI's own `--help` text or a docs table, not only in this plan |
+| Effort | ~2.5 dev-days (M7) + ~3 dev-days (M8) ≈ **5.5 dev-days** |
+| Exit gate | An external script can call `crustly llama-cpp list --json`, parse a stable schema, and branch on a documented exit code without reading Crustly's source |
+
+### DP5 — Polish: diagnostics and documentation
+**Covers**: M9, plus documentation/config-example updates that earlier
+milestones intentionally deferred rather than scattering piecemeal.
+**Depends on**: DP1–DP4 (a `doctor` command and docs are most useful once
+there's a stable feature set to describe).
+
+| | |
+|---|---|
+| Files | New `crustly llama-cpp doctor` subcommand in `src/cli/mod.rs`; `README.md` (`gguf-management`/new config keys); `config.toml.example` (`extra_model_paths`, Ollama-blob opt-in, revision-pinned `hf:` examples); `docs/guides/LLAMA_CPP_GUIDE.md` (management section, following the precedent `llama-cpp-2-integration-plan.md` Phase 10 already set for this same guide) |
+| Tasks | `doctor` checks: build-feature detection (`gguf-management` vs `llama-cpp` vs neither), `models_dir` existence/writability, available disk space, and (using DP3's estimator) a rough max-model-size-for-detected-RAM line; update all three docs to describe the shipped feature set — capability by capability, not aspirationally |
+| Acceptance criteria | `doctor` always exits 0 and produces structured (not free-text-only) findings, matching this plan's own §5 M9 description; docs describe only what has actually shipped by this point, cross-referencing this plan the way `llama-cpp-2-integration-plan.md`'s own Phase 10 cross-references `llm-file-gguf-support.md` rather than restating it |
+| Effort | ~1.5 dev-days (M9) + ~1 dev-day (docs) ≈ **2.5 dev-days** |
+| Exit gate | A new user with no prior context can run `crustly llama-cpp doctor` and the shipped guide section to get from zero to a listed, inspectable local model |
+
+### Roadmap summary
+
+| Milestone | Covers | Depends on | Effort | 
+|---|---|---|---|
+| DP1 — Foundation | M0, M1 | — | 5 dev-days |
+| DP2 — Reach & safety | M3, M6 | DP1 | 5 dev-days |
+| DP3 — Intelligence | M2, M4, M5 | DP1, DP2 | 6 dev-days |
+| DP4 — Interfaces | M7, M8 | DP1 (fully: DP1–DP3) | 5.5 dev-days |
+| DP5 — Polish | M9 + docs | DP1–DP4 | 2.5 dev-days |
+| **Total** | M0–M9 (M10 deferred, §5) | | **~24 dev-days** |
+
+These are sequential dependency-order estimates, not a claim that one
+person spends 24 consecutive days on this — DP2/DP3's sub-items (M3/M6,
+and M2/M4/M5 respectively) are each parallelizable across contributors
+once DP1 lands, same as §7's dependency graph already implies.
+
+## 9. Risks
+
+- **Malformed/adversarial GGUF headers** (M1): a hand-rolled binary parser
+  running over files sourced from arbitrary URLs (M6) or arbitrary
+  filesystem locations (M3) is a real attack surface — a crafted header
+  with huge declared lengths could otherwise cause an out-of-memory
+  allocation or an out-of-bounds panic. Mitigated by the bounds-checking
+  and clean-degradation requirement stated as a hard acceptance criterion
+  in M1, not left as a follow-up.
 - **GGUF format drift**: the header format is stable and versioned, but new
   architectures periodically introduce new KV keys. Mitigate by parsing
   defensively (unknown keys are skipped, not errors) — same posture
@@ -402,7 +565,7 @@ M9 whenever convenient, M10 revisited only if a concrete need for it shows up.
 
 ---
 
-## 9. Relationship to existing docs
+## 10. Relationship to existing docs
 
 - `llama-cpp-2-integration-plan.md` — the in-process inference engine this
   plan's management layer feeds model files to. Phase 6 of that plan is the

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -1,0 +1,421 @@
+# GGUF Model Management Improvement Plan (informed by `llamastash`)
+
+Status: **Proposal — analysis only, no implementation started.**
+Date: 2026-08-06
+Scope: improve how Crustly discovers, inspects, downloads, and manages local
+`.gguf` model files, informed by a feature analysis of
+[`llamastash`](https://github.com/llamastash/llamastash) — a Rust TUI/CLI
+purpose-built for local-GGUF lifecycle management around `llama.cpp`.
+
+This document does **not** propose adopting llamastash's daemon/launcher/proxy
+architecture. Crustly already runs inference in-process (`LlamaCppProvider`,
+see `llama-cpp-2-integration-plan.md`) and already has its own TUI, config
+format, and agent-facing CLI. The relevant overlap is narrower: llamastash is
+excellent at the part of the problem Crustly currently does the least well —
+**knowing what `.gguf` files exist, what they are, and managing them safely**
+— and that part is portable without importing llamastash's process-supervision
+model.
+
+---
+
+## 1. What was analyzed
+
+`llamastash` (MIT, "The Software shall be used for Good, not Evil" clause) is
+a terminal-native launcher for local LLMs: a bearer-token-authenticated
+loopback daemon that spawns `llama-server` processes on demand, backed by a
+TUI and a scriptable CLI. Its full scope (multi-model concurrency, port
+allocation, an OpenAI/Ollama/Anthropic-compatible proxy, five TUI themes,
+hardware-aware launch presets) is out of scope for this document — see §6.
+The part analyzed in depth here is its **GGUF discovery and management
+subsystem**, summarized from its README/docs:
+
+- **Discovery**: auto-scans HuggingFace cache, Ollama's blob store, and LM
+  Studio's cache directory, plus user-configured extra paths; live filesystem
+  watching picks up new files without a restart.
+- **Metadata parsing**: reads GGUF header key-value metadata directly —
+  architecture, parameter count, quantization level, native context window,
+  embedded chat template, and KV-cache-aware memory estimates. Not a
+  filename-convention guess.
+- **Deduplication**: collapses symlinks, unifies split multi-part GGUFs
+  (`-00001-of-00005.gguf` style) into one logical model, and names
+  content-addressed Ollama blobs intelligibly instead of showing raw SHA
+  digests.
+- **Multimodal pairing**: auto-detects and pairs vision/audio projector
+  (`mmproj`) files with their base model.
+- **Download**: `pull <hf-repo>` with disk-space prechecks, SHA-256
+  verification, and `--revision <sha>` pinning for reproducible pulls.
+- **Hardware awareness**: filters/ranks discovered and recommendable models
+  against detected VRAM/RAM; context auto-fit picks the largest context that
+  fits instead of failing at load time.
+- **Agent-facing CLI contract**: stable `--json` output, byte-stable TSV when
+  piped, and a documented exit-code table (64–74 per failure class) so a
+  calling agent can branch on the exit code instead of parsing text.
+- **Diagnostics**: a `doctor` subcommand that always exits 0 and reports
+  typed, actionable problems (missing binary, wrong `llama-server` build,
+  unwritable cache dir, etc.).
+
+---
+
+## 2. Current state in Crustly
+
+Crustly already has a working local-inference story, and a much thinner
+management layer around it. Concretely, as of this writing:
+
+| Capability | File | Status |
+|---|---|---|
+| In-process GGUF inference (load + run, streaming, tool calling, grammar constraints, GPU offload, idle-unload) | `src/llm/provider/llama_cpp.rs` | **Done** — see `llama-cpp-2-integration-plan.md`, all 10 phases + 4b landed |
+| List local `.gguf` files | `llama_cpp_models::list_local_models` | Directory scan of **one** configured `models_dir`, non-recursive |
+| Quantization detection | `quantization_hint_from_filename` | **Filename-convention guess only** (`Q4_K_M` substring match) — never reads the GGUF header, so an unconventionally-named file reports "unknown" even though the header has the real answer |
+| Model metadata (architecture, param count, context length, chat template) | — | **None.** Crustly has no GGUF header parser at all; `LlamaCppProvider` only reads what `llama-cpp-2`/`llama.cpp` itself extracts at load time, and doesn't surface it back to management commands |
+| Download | `llama_cpp_models::download_model` | Direct URL or `hf:org/repo/file.gguf` shorthand, streamed to `.part`, SHA-256 verified against HF's published LFS hash when resolvable. **No disk-space precheck, no `--revision` pinning, no resume of an interrupted `.part`** |
+| Delete | `llama_cpp_models::delete_model` | Single-file delete, TUI confirms first |
+| Discovery scope | — | **Single directory only.** No scanning of Ollama's blob store, no HuggingFace/LM Studio cache awareness, no filesystem watching |
+| Deduplication | — | **None.** Split multi-part GGUFs would list as N separate unrelated files; no symlink handling |
+| Multimodal pairing | — | **None.** `mmproj` files (if present) list as ordinary unrecognized `.gguf` entries |
+| CLI contract | `crustly llama-cpp {list,pull,rm}` (`src/cli/mod.rs`) | Human-readable output; no `--json`, no documented exit codes beyond the generic error path |
+| TUI | Ctrl+G dialog (`src/tui/llama_cpp_download.rs`), Ctrl+O info panel | Shows path/size/filename-guessed quantization only — same gaps as the CLI, just rendered |
+| Diagnostics | — | **None.** A misconfigured `models_dir`, missing GPU feature build, or unwritable cache dir surfaces as a plain error at the point of failure, not proactively |
+
+**One structural finding worth flagging on its own**: `llama_cpp_models` (the
+whole file-management module — list/pull/rm, no FFI involved) is compiled
+only under `#[cfg(feature = "llama-cpp")]`
+(`src/llm/provider/mod.rs:28-29`), the same feature that pulls in
+`llama-cpp-2`/`llama-cpp-sys-2` and triggers a `cmake` build of vendored
+`llama.cpp`. That means a user who only wants to **inspect or manage** `.gguf`
+files they downloaded for use with an external Ollama/llama.cpp setup — never
+loading one in-process — is forced through the same C++ toolchain requirement
+as someone doing in-process inference. llamastash's entire value proposition
+is that management doesn't need that. This is the first thing worth fixing
+(Phase M0 below) because every other improvement in this plan builds on top
+of it, and it's currently the biggest usability gap between "I have a
+`.gguf` file" and "Crustly can tell me anything about it."
+
+---
+
+## 3. Explicit non-goals (not porting these)
+
+To keep this plan additive rather than a second product living inside
+Crustly:
+
+1. **No embedded daemon/process-supervisor.** Crustly's `LlamaCppProvider`
+   already loads and serves a model in-process on a dedicated worker thread
+   (`llama-cpp-2-integration-plan.md` §4.4). llamastash's loopback daemon +
+   per-model port allocation solves a different problem (running an
+   *external* `llama-server` you point other tools at) that Crustly doesn't
+   have and shouldn't grow just because llamastash has it.
+2. **No OpenAI/Ollama/Anthropic-compatible HTTP proxy.** Out of scope for a
+   model-management improvement; would duplicate Crustly's own
+   `Provider`/`factory.rs` abstraction for no benefit to Crustly's own users.
+3. **No multi-backend pluggability (Lemonade, ds4, etc.).** Crustly's
+   inference backend is `llama-cpp-2`; that's a separate, already-settled
+   architectural decision (ADR 0005), not something this plan reopens.
+4. **No second theming/keybinding system.** Any TUI work here extends
+   Crustly's existing dialogs and render pipeline, not a parallel UI stack.
+5. **No CI-refreshed community benchmark table.** llamastash's `recommend`
+   ranks against externally-maintained benchmark data; replicating that
+   maintenance burden is disproportionate to the value for Crustly. A
+   lighter, purely local hardware-fit heuristic (Phase M10) covers the
+   useful part without the ongoing-data-pipeline cost.
+
+---
+
+## 4. Gap analysis
+
+| Capability | llamastash | Crustly today | Priority |
+|---|---|---|---|
+| Management usable without heavy build toolchain | Yes (single static binary) | No — gated behind `llama-cpp` (cmake/C++) | **High** |
+| GGUF header metadata (arch, params, ctx, chat template, real quant) | Yes | No (filename guess only) | **High** |
+| Multi-source discovery (Ollama/LM Studio/HF caches + extra paths) | Yes | No (one dir) | **Medium** |
+| Filesystem watch for new files | Yes | No | **Low** |
+| Split-GGUF unification / symlink dedup | Yes | No | **Medium** |
+| mmproj pairing | Yes | No | **Medium** |
+| Disk-space precheck before download | Yes | No | **Medium** |
+| `--revision` pinning | Yes | No (always `resolve/main`) | **Low** |
+| Resumable download | Not clearly documented | No | **Low** |
+| KV-cache memory estimate / context auto-fit | Yes | No | **Medium** |
+| Agent-facing `--json` + documented exit codes | Yes | No | **Medium** (Crustly is itself agent-facing — see AGENTS.md — so this is more relevant to Crustly than a generic nice-to-have) |
+| `doctor`-style diagnostics | Yes | No | **Low** |
+| Hardware-aware recommend | Yes (CI benchmark data) | No | **Low** (deferred, see §3.5) |
+
+---
+
+## 5. Proposed phases
+
+Phases are ordered so each one is independently shippable and earlier phases
+unblock later ones (metadata parsing in particular is a dependency for most
+of what follows). No phase requires the ones after it.
+
+### Phase M0 — Decouple management from the `llama-cpp` build feature
+
+**Problem**: listing/downloading/deleting `.gguf` files does no FFI and needs
+no C++ toolchain, but is currently only compiled under `feature = "llama-cpp"`.
+
+**Change**: introduce a lightweight `gguf-management` feature (or fold this
+functionality into the crate's default build — it has no heavy dependencies:
+`reqwest`, `sha2`, filesystem calls, all of which are already used
+elsewhere in the default build) that compiles `llama_cpp_models.rs` and the
+`crustly llama-cpp {list,pull,rm}` CLI subcommand independently of
+`feature = "llama-cpp"`. `LlamaCppProvider` itself (the FFI-backed inference
+path) stays exactly as gated as it is today. This is the one prerequisite
+change every later phase benefits from: it makes "manage my GGUF files" a
+zero-toolchain operation, matching llamastash's actual value proposition,
+without touching the inference feature-gating decision made in
+`llama-cpp-2-integration-plan.md` §3.4.
+
+**Effort**: Small. Mostly moving `#[cfg(...)]` boundaries and updating
+`Cargo.toml` feature declarations; `sha2` becomes an unconditional (or
+`gguf-management`-gated) dependency instead of `llama-cpp`-gated.
+
+### Phase M1 — Pure-Rust GGUF header metadata parser
+
+**Problem**: no code anywhere in Crustly reads GGUF header key-value
+metadata; quantization is a filename guess and everything else (architecture,
+parameter count, native context length, embedded chat template presence) is
+simply unavailable outside of a loaded `LlamaCppProvider`.
+
+**Change**: add a small, dependency-light GGUF header reader — the GGUF
+format's header (magic, version, tensor count, KV metadata) is documented and
+simple enough to parse directly with `std::io` (read the fixed header, then
+walk typed KV pairs) rather than pull in a general-purpose GGUF/ML crate.
+This keeps the dependency footprint aligned with Crustly's stated
+"performance, memory efficiency, reduced resource consumption" positioning —
+the same reasoning `llm-file-gguf-support.md` already applied when weighing
+`llama-cpp-2` itself. Read only the header (a few KB), never the tensor data,
+so this stays fast and memory-light even for a 40GB model file.
+
+Extract at minimum:
+- `general.architecture`, `general.name`
+- Parameter count (derivable from tensor shapes in the header, or
+  `general.parameter_count` where publishers set it)
+- Real quantization type (`general.file_type` / per-tensor type, not a
+  filename guess — `quantization_hint_from_filename` becomes a documented
+  fallback for files whose header can't be read, not the primary path)
+- `*.context_length` (the model's trained/native context window)
+- Whether an embedded chat template (`tokenizer.chat_template`) is present
+
+This becomes the foundation `LocalGgufModel` builds on (replacing the
+filename-only `quantization_hint`), and is what Phases M2/M4/M5/M8 consume.
+
+**Effort**: Medium. New module (e.g. `src/llm/provider/gguf_metadata.rs`),
+pure functions over `&[u8]`/`Read`, straightforward to unit test against
+small hand-crafted or truncated real GGUF headers (mirroring the existing
+`mock_http_server` pattern of not depending on a real multi-GB model file
+in tests).
+
+### Phase M2 — Memory/VRAM footprint estimate & context auto-fit hint
+
+**Depends on**: M1.
+
+Using parsed architecture/param-count/quantization plus a requested `n_ctx`,
+estimate resident memory (weights + KV cache) with the standard
+transformer KV-cache formula, and surface it:
+- In `crustly llama-cpp list` / the TUI info panel, so a user can see
+  "~4.9 GB at this context length" before loading.
+- As a warning (not a hard block) when `n_gpu_layers`/`n_ctx` in
+  `LlamaCppProviderConfig` looks likely to exceed detected system RAM —
+  advisory only, since Crustly (correctly, per `llama-cpp-2-integration-plan.md`
+  §4.11) doesn't do hardware detection today and shouldn't overreach here
+  either; this is a same-order-of-magnitude estimate, not a guarantee.
+
+**Effort**: Medium.
+
+### Phase M3 — Multi-source discovery
+
+**Depends on**: M0.
+
+Extend `list_local_models` to scan, in addition to
+`providers.llama_cpp.models_dir`:
+- A new `providers.llama_cpp.extra_model_paths: Vec<PathBuf>` config list.
+- Ollama's local blob store (`~/.ollama/models/blobs`, when the `ollama`
+  feature/config is present) — read-only awareness so a model already
+  pulled via Ollama shows up for llama.cpp management too, without
+  duplicating storage.
+- Optionally, well-known cache locations (HuggingFace's `~/.cache/huggingface/hub`,
+  LM Studio's model directory) behind an opt-in config flag — auto-scanning
+  directories a user didn't explicitly point Crustly at is a bigger default-
+  behavior change than the rest of this plan, so this sub-item should ship
+  disabled by default with a config toggle, not on by default the way
+  llamastash does it.
+
+Filesystem watching (llamastash's live-update behavior) is explicitly
+**deferred, not dropped** — it's a nice-to-have once multi-source scanning
+exists, lower priority than getting the scan itself right.
+
+**Effort**: Medium.
+
+### Phase M4 — Deduplication (symlinks, split GGUFs, Ollama blob naming)
+
+**Depends on**: M1, M3.
+
+- Resolve symlinks before dedup-keying so the same file reached two ways
+  doesn't list twice.
+- Detect the `-00001-of-000NN.gguf` split-file convention and unify each
+  group into one logical `LocalGgufModel` entry (report the summed size,
+  the base name, first-part path as the canonical reference).
+- When a discovered file is an Ollama content-addressed blob (Phase M3),
+  resolve it back to Ollama's manifest name where possible instead of
+  showing a raw digest.
+
+**Effort**: Medium.
+
+### Phase M5 — `mmproj` (vision/audio projector) pairing
+
+**Depends on**: M1.
+
+Detect `mmproj`-pattern filenames/header hints and associate them with their
+base text model in listings, so the TUI/CLI show "Qwen2.5-VL-7B (+ vision
+projector)" rather than two unrelated entries. This directly benefits
+Crustly's own multimodal path (`llama-cpp-2-integration-plan.md` §4.9,
+`mtmd` support) once a projector is present locally.
+
+**Effort**: Small–Medium.
+
+### Phase M6 — Download hardening
+
+**Depends on**: M0.
+
+- **Disk-space precheck**: before starting a download, compare
+  `Content-Length` (or a `HEAD` request) against available space on the
+  target filesystem; fail fast with a clear message instead of filling the
+  disk mid-download.
+- **`--revision <sha>` pinning**: extend the `hf:org/repo/file.gguf`
+  shorthand to `hf:org/repo/file.gguf@revision`, resolving against that
+  specific commit instead of always `resolve/main` — reproducible pulls,
+  matching llamastash's rationale.
+- **Resume support**: if a `.part` file already exists for the target
+  filename, attempt a `Range`-header resume instead of restarting from
+  zero; fall back to a full restart if the server doesn't honor `Range`.
+
+**Effort**: Medium.
+
+### Phase M7 — Agent-facing CLI contract
+
+**Depends on**: M1 (for `list --json` to be worth adding).
+
+- `crustly llama-cpp list --json`: stable, documented schema (path, size,
+  architecture, param count, quantization, context length, chat-template
+  presence, estimated memory from M2). Crustly already positions itself as
+  agent-usable (`AGENTS.md`, `crustly run "..."` non-interactive mode) so
+  this is a direct extension of an existing product direction, not a new one.
+- Document exit codes for `list`/`pull`/`rm` (reuse Crustly's existing error
+  taxonomy rather than importing llamastash's numeric ranges verbatim —
+  the point is *documented and stable*, not matching llamastash's specific
+  numbers).
+
+**Effort**: Small–Medium.
+
+### Phase M8 — TUI enhancements
+
+**Depends on**: M1, M2, M4, M5.
+
+- Ctrl+G dialog: add architecture/parameter-count/quantization (real, from
+  header)/estimated-memory columns; show split-GGUF groups and mmproj
+  pairings as single entries with an expandable detail line.
+- Ctrl+O info panel: replace the filename-guessed quantization
+  (`LlamaCppModelDetails`, `src/tui/llama_cpp_download.rs`) with the
+  header-parsed value, and add native context length / chat-template-present
+  indicators.
+
+**Effort**: Medium (rendering/state-machine work, following the existing
+`render_llama_cpp_models` pattern noted in `llama-cpp-2-integration-plan.md`
+Phase 7's corrected-assumptions note).
+
+### Phase M9 — `crustly llama-cpp doctor`
+
+**Depends on**: M0.
+
+A diagnostics subcommand, always exiting 0, reporting (as structured findings,
+not just log lines): whether the binary was built with `llama-cpp`/a GPU
+feature, whether `models_dir` exists and is writable, available disk space,
+and (once M2 lands) a rough "largest model your detected RAM can hold at
+default settings" line. Lower priority than M0–M7 since it's diagnostic
+sugar rather than filling a functional gap, but cheap once the underlying
+data (M1/M2) exists.
+
+**Effort**: Small.
+
+### Phase M10 — Hardware-aware `recommend` (deferred)
+
+Explicitly **deferred**, not scheduled. llamastash's version depends on an
+externally maintained, CI-refreshed benchmark dataset — replicating that
+maintenance burden isn't justified by this plan's scope. If pursued later,
+scope it down to a purely local heuristic (detected RAM/VRAM vs. M2's memory
+estimate for already-discovered models), not a ranked catalog of models the
+user doesn't have yet.
+
+---
+
+## 6. New dependencies
+
+| Dependency | Used by | Why |
+|---|---|---|
+| None required for M0 | — | Feature-flag reorganization only |
+| None required for M1 | — | Hand-rolled parser over `std::io`, consistent with keeping the management path toolchain-light (the whole point of M0) |
+| None required for M2–M9 | — | Built on M1's output plus existing `reqwest`/`sha2`/`tokio::fs` already in the dependency tree |
+
+Deliberately **not** proposing a general-purpose GGUF/tensor crate (e.g. via
+`candle`) for header parsing — that would reintroduce exactly the kind of
+heavy, ML-framework-shaped dependency this plan is trying to keep *out* of
+the management path, for a job (reading a few KB of typed KV pairs) that
+doesn't need one.
+
+---
+
+## 7. Sequencing & effort summary
+
+| Phase | Depends on | Effort | Priority |
+|---|---|---|---|
+| M0 — Decouple from `llama-cpp` feature | — | S | High |
+| M1 — GGUF header metadata parser | M0 | M | High |
+| M2 — Memory/VRAM estimate | M1 | M | Medium |
+| M3 — Multi-source discovery | M0 | M | Medium |
+| M4 — Dedup (symlinks/split/blobs) | M1, M3 | M | Medium |
+| M5 — mmproj pairing | M1 | S–M | Medium |
+| M6 — Download hardening | M0 | M | Medium |
+| M7 — Agent-facing `--json`/exit codes | M1 | S–M | Medium |
+| M8 — TUI enhancements | M1, M2, M4, M5 | M | Medium |
+| M9 — `doctor` diagnostics | M0 (M1/M2 for full value) | S | Low |
+| M10 — Hardware-aware recommend | M2 | — | Deferred |
+
+Recommended starting sequence: **M0 → M1**, then M2/M3/M6/M7 in any order
+(all independent once M1 lands), M4/M5/M8 last since they consume the others,
+M9 whenever convenient, M10 revisited only if a concrete need for it shows up.
+
+---
+
+## 8. Risks
+
+- **GGUF format drift**: the header format is stable and versioned, but new
+  architectures periodically introduce new KV keys. Mitigate by parsing
+  defensively (unknown keys are skipped, not errors) — same posture
+  `llama-cpp-2-integration-plan.md` already takes toward unexpected upstream
+  behavior.
+- **Parameter-count estimation accuracy**: not all publishers set
+  `general.parameter_count`; deriving it from tensor shapes is more reliable
+  but adds parsing complexity. Acceptable to ship M1 with "unknown" as a
+  valid, honest output rather than a guess, same posture as today's
+  `quantization_hint_from_filename` returning `None`.
+- **Scope creep back toward llamastash's full feature set.** §3 and §6 exist
+  specifically to keep this plan bounded; any future addition should be
+  checked against "does this manage GGUF files Crustly already has/wants,
+  or does this reimplement a launcher/daemon/proxy Crustly doesn't need."
+
+---
+
+## 9. Relationship to existing docs
+
+- `llama-cpp-2-integration-plan.md` — the in-process inference engine this
+  plan's management layer feeds model files to. Phase 6 of that plan is the
+  starting point this document extends; nothing here revisits that plan's
+  own (settled) architectural decisions.
+- `llm-file-gguf-support.md` — the original Go/No-Go evaluation for
+  `llama-cpp-2`; this plan reuses its dependency-minimalism reasoning (§6
+  above) rather than re-litigating it.
+- `ollama-rs-integration-plan.md` — precedent for the file/module naming
+  conventions (`LocalModelInfo`/`PullProgress` ↔
+  `LocalGgufModel`/`DownloadProgress`) this plan's new types should keep
+  following.
+
+No ADR is proposed at this stage — the phases above are additive extensions
+of an already-decided architecture (in-process `llama-cpp-2`, file-based
+local model management), not a new architectural decision on their own.

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -238,7 +238,22 @@ Phases are ordered so each one is independently shippable and earlier phases
 unblock later ones (metadata parsing in particular is a dependency for most
 of what follows). No phase requires the ones after it.
 
-### Phase M0 — Decouple management from the `llama-cpp` build feature
+### Phase M0 — Decouple management from the `llama-cpp` build feature ✅ Done
+
+Implemented as planned, with one scope addition found during implementation:
+`src/tui/llama_cpp_download.rs`'s `list_local`/`spawn_download`/`spawn_delete`
+(pure management, called directly from the CLI's own management code) and
+`src/tui/app.rs`'s `quantization_hint_for_path` were gated on `llama-cpp` too
+and would otherwise have stayed silently degraded (empty list / `None` hint)
+under a `gguf-management`-only build even though nothing FFI-related stood in
+the way — moved alongside the two files below. `gguf-management` also joined
+`default` (not just `all-llm`), since the only real marginal cost is `sha2`
+(`reqwest` was already unconditional). Verified: zero `llama-cpp-2`/`-sys-2`
+in the dependency tree under `--features gguf-management`; 834/834 tests pass
+there (including the pre-existing 11 `llama_cpp_models` tests and the moved
+CLI/TUI tests, unmodified in behavior); 851/851 under `--features llama-cpp`
+and 883/883 under `all-llm` confirm no regression; `cargo clippy -D warnings`
+and `cargo fmt --check` both clean on the affected feature combinations.
 
 **Problem**: listing/downloading/deleting `.gguf` files does no FFI and needs
 no C++ toolchain, but is currently only compiled under `feature = "llama-cpp"`.

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -728,17 +728,39 @@ suggesting *new* models to download, not about ranking ones already on disk.
 
 ### Phase M11 — Hardware detection & display ✅ Done
 
-Implemented largely as planned, with one deliberate scope reduction disclosed
-up front rather than discovered mid-implementation: **the Windows AMD/Intel
-DXGI path is a documented stub returning `None`**, not a real Win32 FFI
-binding. This development environment is Linux-only with no Windows target to
-build or test against; writing `unsafe` COM interface calls with zero ability
-to verify they even compile is worse than being explicit about the gap - it
-falls through cleanly to the CPU-only/system-RAM path, which is this phase's
-own designed-in degrade-cleanly outcome, not a crash. NVIDIA-on-Windows is
-unaffected (`nvidia-smi` is a portable subprocess call). No new
-`windows`/`windows-sys` dependency was added as a result - if a future pass
-picks this up on a real Windows dev machine, add it then.
+Implemented as planned, including the Windows AMD/Intel DXGI path -
+**upgraded from a documented stub to a real implementation in a follow-up
+pass**, once it turned out this development environment could install a
+Windows cross-compilation toolchain (`rustup target add x86_64-pc-windows-gnu`
++ `apt-get install gcc-mingw-w64-x86-64`) that hadn't been tried during the
+initial implementation. `detect_windows_dxgi` (`#[cfg(target_os = "windows")]`)
+now calls the real Win32 DXGI API via the official `windows` crate
+(`CreateDXGIFactory1` → `EnumAdapters1` → `GetDesc1`, skipping the software/
+"Microsoft Basic Render Driver" adapter DXGI always reports alongside real
+hardware) - added as a Windows-only target dependency
+(`[target.'cfg(target_os = "windows")'.dependencies]` in `Cargo.toml`),
+`optional = true` and wired into `gguf-management`'s feature list exactly like
+`sha2`/`sysinfo`, so it costs nothing on any non-Windows target or on a
+Windows build with zero Cargo features either.
+
+**What was actually verified, stated precisely rather than overclaimed**: no
+Windows machine exists in this environment to run the DXGI calls against real
+hardware/drivers. What *was* verified: `cargo check --target
+x86_64-pc-windows-gnu --features gguf-management` (confirms the FFI call
+shapes, struct field names/types, and safety comments all type-check against
+the real `windows` 0.58 crate bindings) **and** `cargo build` for the same
+target, which fully linked into a genuine `PE32+ executable (console) x86-64,
+for MS Windows` binary - meaningfully stronger assurance than an unverified
+stub, but still not a runtime test. The two small pieces of real logic
+(`gpu_vendor_from_pci_id`, PCI vendor ID → `GpuVendor`; `trim_dxgi_description`,
+the NUL-padded UTF-16 description buffer → `String`) were deliberately
+extracted as pure, portable functions specifically so they *are* unit-tested
+on this crate's actual host target (Linux), isolating as much of the real
+logic as possible from the one part that genuinely can't be tested here. This
+distinction (compiled+linked vs. run against hardware) is documented in the
+module's own doc comment, not just here, so it stays visible to whoever next
+touches this code. NVIDIA-on-Windows is unaffected either way (`nvidia-smi` is
+a portable subprocess call, tried first, identical to Linux).
 
 Every other detection path shipped as designed: `src/llm/provider/hardware_detect.rs`
 (new, `gguf-management`-gated) with `detect_nvidia`/`detect_amd_rocm`/

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -599,7 +599,30 @@ environment to exercise the reject branch otherwise.
 
 **Effort**: Medium.
 
-### Phase M7 — Agent-facing CLI contract
+### Phase M7 — Agent-facing CLI contract ✅ Done
+
+Implemented as planned: `LlamaCppModelJson`/`LlamaCppListJson` (a dedicated,
+versioned DTO decoupled from `LocalGgufModel`, `schema_version` starting at 1) for
+`crustly llama-cpp list --json`; exit codes scoped only to `llama-cpp` subcommands
+(10 no such file, 11 disk space, 12 checksum, 13 network, 14 feature not compiled
+in, 1 generic - unchanged from every other Crustly command), matched against known
+error-message prefixes in `anyhow::Error::chain()` rather than a new taxonomy,
+exactly as the plan called for. One correction made along the way: `llama_cpp_exit_code`
+must check the whole context chain, not just `.to_string()`'s outermost layer - `Pull`
+wraps every error in `"Failed to download '...'"`, so the specific cause is always a
+layer deeper; the first version of this logic (checking only the outermost message)
+would have silently classified every `Pull` failure as "unrecognized."
+
+**Bug found and fixed along the way, unrelated to this phase's own logic**:
+verifying the `10` (no-such-file) exit code against the real CLI binary surfaced a
+genuine pre-existing clap arg-parsing bug - `LlamaCppCommands::Rm`'s positional field
+was named `model`, identical to the top-level `global = true` `--model` flag's ident,
+which caused clap to route the positional value into the wrong field entirely (`rm
+some-model.gguf` behaved as if `--model some-model.gguf` had been passed, never
+reaching `Rm` at all). Fixed by renaming the field to `name` (also more accurate -
+it's a filename, not "the model"). **`ollama rm` has the identical bug via the same
+root cause and was deliberately left unfixed** - confirmed independently, but
+touching Ollama's CLI is outside this phase's scope; flagged for a future pass.
 
 **Depends on**: M1 (for `list --json` to be worth adding).
 
@@ -615,7 +638,22 @@ environment to exercise the reject branch otherwise.
 
 **Effort**: Small–Medium.
 
-### Phase M8 — TUI enhancements
+### Phase M8 — TUI enhancements ✅ Done
+
+Implemented as planned, plus one baseline fix the plan didn't call out explicitly:
+the Ctrl+G dialog was rendering `model.path.file_name()` directly, never
+`display_name` - meaning an Ollama-sourced entry showed its raw `sha256-<hex>` blob
+filename, and M3/M4/M5's merged split-GGUF/mmproj-paired entries didn't show their
+synthesized names either. Fixed as a prerequisite (new `llama_cpp_model_lines`
+helper, `display_name`-aware, same `" (+ mmproj)"`/`" [mmproj]"` labels as the CLI),
+with an expandable detail line shown on selection (architecture, parameter count via
+a new `format_param_count` helper, native context length, memory estimate, chat-
+template presence) rather than a new keybinding - reuses the dialog's existing
+up/down selection state. Ctrl+O panel: quantization already used the header-parsed
+value as of M1; this phase added `LlamaCppModelDetails.context_length`/
+`has_chat_template` and two new panel rows ("Nat. ctx:", "Chat tmpl:"), computed via
+a new small always-compiled two-variant helper mirroring `quantization_hint_for_path`'s
+existing `#[cfg(feature = "gguf-management")]` split exactly.
 
 **Depends on**: M1, M2, M4, M5.
 

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -19,6 +19,15 @@ Date: 2026-08-06. Two review passes so far:
   actual detection subsystem (`docs/architecture.md`'s per-vendor subprocess
   probe chain and VRAM-fit filter, not a re-guess) — see §1's expanded
   "Hardware awareness" bullet and the new M11/M12 sections in §5.
+- **Review 3** (self-review of Update 3's new material): fixed two
+  underspecified points in M11/M12 that would otherwise have been decided
+  differently by whoever implemented them — when hardware detection
+  actually runs (never as a side effect of a plain `list`; cached
+  per-invocation, not re-probed) and what default context length M12's fit
+  comparison uses (the model's own native length, capped, not an unstated
+  constant). Also folded this plan's priorities into `ROADMAP.md` as the
+  next milestone — see that file for the ordered, ship-ready checklist;
+  this document remains the detailed design/rationale it links back to.
 Scope: improve how Crustly discovers, inspects, downloads, and manages local
 `.gguf` model files, informed by a feature analysis of
 [`llamastash`](https://github.com/llamastash/llamastash) — a Rust TUI/CLI
@@ -539,7 +548,8 @@ running on actually has. A user deciding which local `.gguf` file to load,
 or what `n_gpu_layers`/`n_ctx` to set, currently has to know their own
 hardware and do the arithmetic by hand.
 
-**Change**: add a best-effort hardware probe, grounded in llamastash's own
+**Change**: add a best-effort hardware probe (new
+`src/llm/provider/hardware_detect.rs`), grounded in llamastash's own
 documented approach (§1) rather than inventing a detection strategy from
 scratch — deliberately **subprocess-based, not SDK-linked**, so this stays
 consistent with M0's whole point (management-side code shouldn't need a
@@ -572,6 +582,18 @@ VRAM total (where available), system RAM total. Read-only and advisory, as
 established in M2's note above: this never writes back into
 `LlamaCppProviderConfig`.
 
+**When this runs — added in this review pass, previously unspecified**:
+detection is real subprocess spawning, not free, so it must never be a
+side effect of a plain `crustly llama-cpp list` or of simply opening the
+Ctrl+G dialog. It runs only when explicitly needed: `doctor`, `list
+--best-fit` (M12), and the TUI host-info panel's *first* render per dialog
+session — cached for the lifetime of that CLI invocation / TUI session
+(a static `OnceLock`/`OnceCell` is enough; GPU hotplug mid-session is not a
+case this plan tries to handle, unlike llamastash's persistent-daemon
+hotplug timer, which doesn't have an equivalent in a one-shot CLI/TUI
+process). This keeps the "clean fallback, never fatal" requirement above
+from also becoming a "never slows down the common path" regression.
+
 **Effort**: Medium — mostly plumbing (subprocess spawn + parse per vendor,
 each independently testable against captured sample output) plus the
 degradation-path testing the "clean fallback" requirement above demands.
@@ -587,11 +609,20 @@ external dataset because it only compares two numbers Crustly can already
 compute locally: M2's per-model memory estimate and M11's detected
 VRAM/RAM.
 
-- Annotate each entry in `crustly llama-cpp list` / the TUI dialog with a
-  fit indicator against the detected hardware at a sensible default context
-  length — e.g. **Fits** (comfortably under budget), **Tight** (fits but
-  leaves little headroom), **Won't fit** (exceeds detected VRAM+RAM) —
-  three states, not a false-precision percentage.
+- Annotate each entry in `crustly llama-cpp list --best-fit` / the TUI
+  dialog with a fit indicator against the detected hardware — e.g. **Fits**
+  (comfortably under budget), **Tight** (fits but leaves little headroom),
+  **Won't fit** (exceeds detected VRAM+RAM) — three states, not a
+  false-precision percentage. **Default context length for this
+  comparison, unspecified until this review pass**: use the model's own
+  parsed native context length (M1's `*.context_length`) capped at a fixed
+  ceiling (e.g. 8192) so a model advertising a 1M-token native context
+  doesn't get flagged "Won't fit" against a KV-cache estimate nobody would
+  actually configure by default; fall back to Crustly's existing
+  `default_llama_cpp_n_ctx()` (`src/config/mod.rs`) when a model's native
+  length can't be parsed. Surface the context length actually used for the
+  estimate next to the fit label, not just the label alone — otherwise
+  "Tight" is a number a user can't sanity-check.
 - `crustly llama-cpp list --best-fit` (or equivalent flag): sort
   already-discovered local models by fit instead of name/date, so "which of
   the models I already have should I actually run" has a direct answer
@@ -737,8 +768,8 @@ just the memory-estimate math DP3 already covers in isolation.
 | | |
 |---|---|
 | Files | New `src/llm/provider/hardware_detect.rs` (or similar — probe chain + parsing per vendor); `Cargo.toml` (`sysinfo`, `windows`/`windows-sys` on Windows, both `gguf-management`-gated); `src/llm/provider/llama_cpp_models.rs` (fit annotation/sort on `list`); `src/cli/mod.rs` (`--best-fit` flag); `src/tui/llama_cpp_download.rs` and `src/cli/mod.rs`'s `doctor` (host-info display, extending M8/M9) |
-| Tasks | One detection function per vendor path (NVIDIA/AMD/Windows-DXGI/Apple/Vulkan-fallback/CPU-only), each independently unit-testable against captured sample subprocess output (not a live GPU) so CI doesn't need real hardware; a timeout wrapper around every subprocess call; the `CpuOnly`/"unknown" fallback path; the fit-comparison function (M2 estimate vs. M11 detected budget → `Fits`/`Tight`/`Won't fit`); the `--best-fit` sort |
-| Acceptance criteria | Detection degrades to `CpuOnly`/unknown (never panics, never hangs past the timeout) when a vendor tool is absent — tested by pointing the subprocess call at a nonexistent binary path, not by requiring the test runner to lack a GPU; parsing tests use captured real `nvidia-smi`/`rocm-smi`/`system_profiler` sample output (checked into the test fixtures, not generated live); fit-annotation tests cover all three states plus the "detection found nothing, fit is unknown" fourth state (must render as "unknown," never silently as "won't fit," which would be actively misleading) |
+| Tasks | One detection function per vendor path (NVIDIA/AMD/Windows-DXGI/Apple/Vulkan-fallback/CPU-only), each independently unit-testable against captured sample subprocess output (not a live GPU) so CI doesn't need real hardware; a timeout wrapper around every subprocess call; the `CpuOnly`/"unknown" fallback path; a once-per-invocation cache so detection never re-runs within one CLI call or TUI session; the fit-comparison function (M2 estimate, using the capped native-context-length default, vs. M11 detected budget → `Fits`/`Tight`/`Won't fit`); the `--best-fit` sort |
+| Acceptance criteria | Detection degrades to `CpuOnly`/unknown (never panics, never hangs past the timeout) when a vendor tool is absent — tested by pointing the subprocess call at a nonexistent binary path, not by requiring the test runner to lack a GPU; parsing tests use captured real `nvidia-smi`/`rocm-smi`/`system_profiler` sample output (checked into the test fixtures, not generated live); fit-annotation tests cover all three states plus the "detection found nothing, fit is unknown" fourth state (must render as "unknown," never silently as "won't fit," which would be actively misleading); a plain `crustly llama-cpp list` (no `--best-fit`) spawns zero hardware-probe subprocesses — asserted directly, not just implied by the flag design |
 | Effort | ~3 dev-days (M11 — four-plus detection paths, each simple but independently testable) + ~2 dev-days (M12 — comparison, annotation, sort, TUI/CLI wiring) ≈ **5 dev-days** |
 | Exit gate | `crustly llama-cpp doctor` shows real detected GPU/VRAM/RAM on a machine that has `nvidia-smi`/`rocm-smi`/etc. installed, "CPU-only" cleanly on one that doesn't, and `crustly llama-cpp list --best-fit` sorts already-downloaded models with a correct Fits/Tight/Won't-fit label on each |
 

--- a/ccguf-managment-imrpoment-plan.md
+++ b/ccguf-managment-imrpoment-plan.md
@@ -535,7 +535,21 @@ listings of the same file.
 
 **Effort**: Medium.
 
-### Phase M5 — `mmproj` (vision/audio projector) pairing
+### Phase M5 — `mmproj` (vision/audio projector) pairing ✅ Done
+
+Implemented as planned, grounded in verified ground truth rather than a guess: fetched
+llama.cpp's actual `tools/mtmd/clip-impl.h` before writing any code, which confirmed
+projector detection is the boolean keys `clip.has_vision_encoder`/
+`clip.has_audio_encoder` - **not** `general.architecture == "clip"`, which I'd have
+guessed wrong otherwise. `GgufMetadata` gained both booleans (plus a `DecodedValue::
+Bool` variant the parser needed to actually read them, not just note their presence).
+Pairing (`pair_mmproj_files`) is conservative by design: exact core-name match
+(quant/mmproj-marker-stripped filename stem) within one directory only; zero or
+multiple candidates leaves the projector standing alone rather than guessing. One
+simplification from the plan's own phrasing: `LocalGgufModel` collapsed vision/audio
+into a single `is_mmproj: bool` (not tracked separately once paired), so the CLI's
+display label is the generic `"(+ mmproj)"`/`"[mmproj]"` rather than
+vision-or-audio-specific text - a disclosed simplification, not an oversight.
 
 **Depends on**: M1.
 
@@ -547,7 +561,27 @@ Crustly's own multimodal path (`llama-cpp-2-integration-plan.md` §4.9,
 
 **Effort**: Small–Medium.
 
-### Phase M6 — Download hardening
+### Phase M6 — Download hardening ✅ Done
+
+Implemented all three sub-items. Disk-space precheck required this plan's one new
+Cargo dependency across M0-M6: `sysinfo` (its `Disks`/`Disk` API verified against the
+actual crate source before use, since docs.rs was unreachable from this sandbox) -
+no stable stdlib API exists for cross-platform free-space queries, and this is
+exactly the kind of commodity functionality not worth hand-rolling (unlike the GGUF
+parser itself). Landed at `sysinfo` 0.33.1, not the latest 0.39.x, after discovering
+0.39 requires a newer rustc than this sandbox has installed - a real constraint the
+plan hadn't anticipated, resolved by loosening the version requirement rather than
+assuming latest-is-fine. `@revision` pinning extends the `hf:` shorthand as planned;
+the revision-specific HuggingFace API endpoint stayed unverified against a live
+response (network-blocked sandbox, already known) but degrades safely on a wrong
+guess per the function's existing posture. Resume support via `Range` correctly
+recomputes `total_bytes` from a 206 response's *remaining*-bytes `Content-Length`,
+falls back to a clean fresh start when a server ignores `Range`, and hashes
+already-on-disk bytes incrementally so checksum verification covers the whole file
+across a resume. The disk-space reject-path logic was extracted into a pure
+`check_disk_space` function specifically so it's unit-testable with fabricated
+values - real disk free space can't be deterministically driven low enough in a test
+environment to exercise the reject branch otherwise.
 
 **Depends on**: M0.
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -162,14 +162,21 @@ default_model = "qwen2.5-coder-7b-instruct"
 #   crustly ollama embed nomic-embed-text "some text to embed"
 
 # ========================================
-# llama.cpp (in-process, no external server) - requires building crustly
-# with `--features llama-cpp` (native C++ compilation, see
+# llama.cpp (in-process, no external server) - actually *loading* a model
+# via [providers.llama_cpp] below requires building crustly with
+# `--features llama-cpp` (native C++ compilation, see
 # docs/guides/LLAMA_CPP_GUIDE.md before enabling this). Loads a local
 # .gguf file directly into the crustly process - no Ollama/LM Studio
 # daemon to install or keep running, unlike every other local-inference
 # option above. Trade-off: switching models means unloading and reloading
 # a multi-GB file (seconds to tens of seconds), not the near-instant swap
 # Ollama's server gives you - see llama-cpp-2-integration-plan.md §4.5.
+#
+# The `crustly llama-cpp list|pull|rm` file-management commands documented
+# below are lighter-weight than the above: they need only the
+# `gguf-management` feature (on by `default`, no C++ toolchain required),
+# so they work even in a plain `cargo build` with no [providers.llama_cpp]
+# configured at all - see ccguf-managment-imrpoment-plan.md Phase M0.
 # ========================================
 # [providers.llama_cpp]
 # enabled = true

--- a/docs/guides/LLAMA_CPP_GUIDE.md
+++ b/docs/guides/LLAMA_CPP_GUIDE.md
@@ -159,6 +159,7 @@ agents:
       "has_chat_template": true,
       "estimated_memory_bytes": 5726732288,
       "estimated_memory_includes_kv_cache": true,
+      "estimated_memory_context_length": 8192,
       "is_mmproj": false,
       "mmproj_path": null
     }
@@ -180,6 +181,50 @@ branch on the exit code instead of parsing error text:
 | `12` | Checksum mismatch |
 | `13` | Network/download failure |
 | `14` | This build wasn't compiled with `--features gguf-management` |
+
+#### `--best-fit`: which model already on disk should I actually run?
+
+Crustly can do a best-effort read of this machine's GPU VRAM (via
+`nvidia-smi`/`rocm-smi`/`system_profiler`/`vulkaninfo` — whichever is
+installed) and system RAM, then compare each local model's estimated memory
+footprint against that budget:
+
+```bash
+crustly llama-cpp list --best-fit
+```
+
+Each row is annotated `Fits` (comfortably under budget), `Tight` (fits, but
+with little headroom), or `Won't fit` (exceeds the detected budget), along
+with the context length the estimate used (the model's own native context
+length capped at 8192 tokens, since a model advertising a huge native
+context nobody would actually configure by default shouldn't get flagged
+`Won't fit` against an unrealistic KV-cache estimate). `--best-fit` also
+sorts the list so the most-capable model that still fits comes first.
+Combine with `--json` to get `fit`/`estimated_memory_context_length` fields
+in the machine-readable output instead.
+
+Hardware detection is a real subprocess spawn, so it's only ever triggered
+by `--best-fit`, `crustly llama-cpp doctor`, or the TUI's Local Models
+dialog (Ctrl+G) — never by a plain `crustly llama-cpp list`. It's cached for
+the lifetime of the process (or the TUI session), and degrades cleanly to
+"unknown"/CPU-only when no supported vendor tool is installed — never an
+error. **Windows AMD/Intel GPUs are not yet detected** (no VRAM figure) —
+NVIDIA works on Windows via `nvidia-smi`; see the DXGI note in
+`ROADMAP.md`'s Backlog if you want to pick that up.
+
+#### `crustly llama-cpp doctor`
+
+Diagnoses your local setup — build features, `models_dir`
+existence/writability, free disk space, configured extra sources, detected
+hardware, and (once you have at least one local model) the largest one your
+detected hardware can comfortably hold:
+
+```bash
+crustly llama-cpp doctor
+```
+
+Always exits `0` — this reports structured findings, it doesn't gate on
+them the way `list`/`pull`/`rm` can fail.
 
 ## Configuration
 

--- a/docs/guides/LLAMA_CPP_GUIDE.md
+++ b/docs/guides/LLAMA_CPP_GUIDE.md
@@ -203,14 +203,20 @@ sorts the list so the most-capable model that still fits comes first.
 Combine with `--json` to get `fit`/`estimated_memory_context_length` fields
 in the machine-readable output instead.
 
-Hardware detection is a real subprocess spawn, so it's only ever triggered
-by `--best-fit`, `crustly llama-cpp doctor`, or the TUI's Local Models
-dialog (Ctrl+G) — never by a plain `crustly llama-cpp list`. It's cached for
-the lifetime of the process (or the TUI session), and degrades cleanly to
-"unknown"/CPU-only when no supported vendor tool is installed — never an
-error. **Windows AMD/Intel GPUs are not yet detected** (no VRAM figure) —
-NVIDIA works on Windows via `nvidia-smi`; see the DXGI note in
-`ROADMAP.md`'s Backlog if you want to pick that up.
+Hardware detection is a real subprocess spawn (or, on Windows for AMD/Intel
+GPUs, a native Win32 DXGI call — see below), so it's only ever triggered by
+`--best-fit`, `crustly llama-cpp doctor`, or the TUI's Local Models dialog
+(Ctrl+G) — never by a plain `crustly llama-cpp list`. It's cached for the
+lifetime of the process (or the TUI session), and degrades cleanly to
+"unknown"/CPU-only when nothing can be detected — never an error.
+
+On Windows, NVIDIA GPUs are detected via `nvidia-smi` (identical to Linux);
+AMD/Intel GPUs are detected via the Win32 DXGI API directly (no VRAM
+live-utilization figure that way, only the total). **Note on this specific
+path's testing**: it was built and cross-compile verified from a Linux
+development environment with no Windows machine available — see
+`ROADMAP.md`'s Backlog if you're running on Windows and it doesn't detect
+your AMD/Intel GPU correctly, and please file what you saw.
 
 #### `crustly llama-cpp doctor`
 

--- a/docs/guides/LLAMA_CPP_GUIDE.md
+++ b/docs/guides/LLAMA_CPP_GUIDE.md
@@ -86,6 +86,9 @@ crustly llama-cpp pull https://example.com/path/to/model.gguf
 # Hugging Face shorthand - resolves to
 # https://huggingface.co/<org>/<repo>/resolve/main/<file>
 crustly llama-cpp pull hf:Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/qwen2.5-coder-7b-instruct-q4_k_m.gguf
+
+# Pin a specific revision/commit for reproducible pulls
+crustly llama-cpp pull hf:Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/qwen2.5-coder-7b-instruct-q4_k_m.gguf@abc123
 ```
 
 The `hf:` shorthand also looks up the file's published SHA-256 (Hugging
@@ -97,12 +100,26 @@ against, so it downloads with a warning that no integrity hash is
 available. **Gated/private Hugging Face repos aren't supported** — there's
 no token support in this version.
 
+Before streaming starts, Crustly checks that the destination has enough
+free disk space for the download (plus a safety margin) and fails fast
+with a clear message rather than filling the disk mid-download. If a
+download is interrupted, running `pull` again for the same file resumes
+from where it left off instead of restarting, when the server supports
+`Range` requests (most do; a server that doesn't just restarts cleanly).
+
 Downloaded models land in `providers.llama_cpp.models_dir` (default: a
-platform cache directory, `~/.cache/crustly/models` on Linux).
+platform cache directory, `~/.cache/crustly/models` on Linux). Crustly also
+scans `providers.llama_cpp.extra_model_paths` (extra directories you list
+in config) and, if `providers.llama_cpp.scan_ollama_models = true`, models
+already pulled via `ollama pull` — read directly from Ollama's own manifest
+tree, not duplicated on disk.
 
 ```bash
-# List what's downloaded
+# List what's downloaded (all configured sources merged into one list)
 crustly llama-cpp list
+
+# Same, as machine-readable JSON (stable, versioned schema - see below)
+crustly llama-cpp list --json
 
 # Remove one (asks for confirmation - a self-downloaded multi-GB file is
 # harder to reacquire than an `ollama pull` re-fetch from a registry)
@@ -110,9 +127,59 @@ crustly llama-cpp rm qwen2.5-coder-7b-instruct-q4_k_m.gguf
 ```
 
 There is no `crustly llama-cpp show` (unlike Ollama) — `llama.cpp` has no
-equivalent of Ollama's `/api/show` metadata endpoint. `crustly llama-cpp
-list` shows a best-effort quantization guess parsed from the filename
-convention (e.g. `Q4_K_M`, `Q8_0`) instead.
+equivalent of Ollama's `/api/show` metadata endpoint. Instead, `crustly
+llama-cpp list` reads each file's own GGUF header directly (architecture,
+real quantization, parameter count, native context length, chat-template
+presence, an estimated memory footprint) — a filename-convention guess
+(`Q4_K_M`, `Q8_0`) is only used as a last resort, when the header itself
+can't be read. Split multi-part GGUFs (`model-00001-of-00005.gguf`) and a
+paired vision/audio projector (`mmproj-*.gguf`, matched to its base model
+by filename and shown as `"model.gguf (+ mmproj)"`) are collapsed into one
+listing entry rather than shown as unrelated files.
+
+#### `--json` output and exit codes
+
+`crustly llama-cpp list --json` prints a stable, versioned schema instead
+of the human-readable table — no emoji header, just JSON, for scripts and
+agents:
+
+```json
+{
+  "schema_version": 1,
+  "models": [
+    {
+      "path": "/home/user/.cache/crustly/models/qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+      "display_name": null,
+      "size_bytes": 4692672512,
+      "modified_at": "2026-08-07T13:38:28+00:00",
+      "architecture": "qwen2",
+      "parameter_count": 7615616512,
+      "quantization": "Q4_K_M",
+      "context_length": 32768,
+      "has_chat_template": true,
+      "estimated_memory_bytes": 5726732288,
+      "estimated_memory_includes_kv_cache": true,
+      "is_mmproj": false,
+      "mmproj_path": null
+    }
+  ]
+}
+```
+
+`schema_version` bumps only on a breaking change to this shape; new fields
+may be added without a bump. `list`/`pull`/`rm` also exit with a specific,
+documented code instead of a generic failure, so a calling script/agent can
+branch on the exit code instead of parsing error text:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Any other/unrecognized error |
+| `10` | No such file (`rm` on a name that doesn't resolve) |
+| `11` | Not enough disk space for the download |
+| `12` | Checksum mismatch |
+| `13` | Network/download failure |
+| `14` | This build wasn't compiled with `--features gguf-management` |
 
 ## Configuration
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -825,6 +825,10 @@ async fn cmd_chat(config: &crate::config::Config, _session_id: Option<String>) -
         app.set_ollama_config(ollama_cfg.clone());
     }
     app.set_llama_cpp_models_dir(config.providers.llama_cpp_models_dir());
+    app.set_llama_cpp_discovery_sources(
+        config.providers.llama_cpp_extra_model_paths(),
+        config.providers.llama_cpp_ollama_models_dir(),
+    );
     // Hand the [providers.llama_cpp] section to the TUI for the same reason
     // as ollama_config above: the Ctrl+G model switch needs the same
     // n_gpu_layers/n_ctx/sampling settings as the one built at startup, and
@@ -1255,8 +1259,14 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
 
     match operation {
         LlamaCppCommands::List => {
-            println!("🦙 Models in {}\n", models_dir.display());
-            let models = llama_cpp_models::list_local_models(&models_dir)?;
+            println!("🦙 Local .gguf models\n");
+            let extra_model_paths = config.providers.llama_cpp_extra_model_paths();
+            let ollama_models_dir = config.providers.llama_cpp_ollama_models_dir();
+            let models = llama_cpp_models::list_all_local_models(
+                &models_dir,
+                &extra_model_paths,
+                ollama_models_dir.as_deref(),
+            )?;
 
             if models.is_empty() {
                 println!("  (none) - pull one with: crustly llama-cpp pull <source>");
@@ -1264,14 +1274,26 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
                 for m in models {
                     let size_gb = m.size_bytes as f64 / 1_073_741_824.0;
                     let quant = m.quantization_hint.as_deref().unwrap_or("unknown");
-                    let name = m
-                        .path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().into_owned())
-                        .unwrap_or_default();
+                    let name = m.display_name.clone().unwrap_or_else(|| {
+                        m.path
+                            .file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_default()
+                    });
+                    let memory = match m.estimated_memory_bytes {
+                        Some(bytes) => {
+                            let gb = bytes as f64 / 1_073_741_824.0;
+                            if m.estimated_memory_includes_kv_cache {
+                                format!("~{gb:.1} GB")
+                            } else {
+                                format!("~{gb:.1} GB (weights only)")
+                            }
+                        }
+                        None => "-".to_string(),
+                    };
                     println!(
-                        "  {:<45} {:>7.2} GB   {:<10} {}",
-                        name, size_gb, quant, m.modified_at
+                        "  {:<45} {:>7.2} GB   {:<10} {:<22} {}",
+                        name, size_gb, quant, memory, m.modified_at
                     );
                 }
             }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -279,6 +279,14 @@ pub enum LlamaCppCommands {
         /// table - no emoji header, just the JSON, for scripting/agents.
         #[arg(long)]
         json: bool,
+        /// Sort by fit against this machine's detected GPU VRAM/system RAM
+        /// (best-effort, best-effort-cached per invocation) instead of by
+        /// path, and annotate each entry Fits/Tight/Won't fit. Composable
+        /// with --json (adds `fit`/`estimated_memory_context_length`
+        /// fields). Never used for anything but already-downloaded models -
+        /// this does not search Hugging Face for new ones.
+        #[arg(long)]
+        best_fit: bool,
     },
     /// Download a model: a direct URL, or an `hf:org/repo/file.gguf[@revision]`
     /// shorthand resolved against Hugging Face
@@ -343,8 +351,18 @@ struct LlamaCppModelJson {
     has_chat_template: bool,
     estimated_memory_bytes: Option<u64>,
     estimated_memory_includes_kv_cache: bool,
+    /// The context length `estimated_memory_bytes` was actually computed
+    /// at - see `LocalGgufModel::estimated_memory_context_length`.
+    estimated_memory_context_length: Option<u64>,
     is_mmproj: bool,
     mmproj_path: Option<std::path::PathBuf>,
+    /// Fit against this machine's detected hardware ("Fits"/"Tight"/"Won't
+    /// fit"/"unknown") - Phase M12. Only set (present in the serialized
+    /// JSON) when `--best-fit` was passed; omitted entirely on a plain
+    /// `list --json`, matching that flag's opt-in, detection-costs-a-
+    /// subprocess-spawn framing (`hardware_detect`'s own module doc).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fit: Option<String>,
 }
 
 #[cfg(feature = "gguf-management")]
@@ -362,8 +380,10 @@ impl From<&crate::llm::provider::llama_cpp_models::LocalGgufModel> for LlamaCppM
             has_chat_template: m.has_chat_template,
             estimated_memory_bytes: m.estimated_memory_bytes,
             estimated_memory_includes_kv_cache: m.estimated_memory_includes_kv_cache,
+            estimated_memory_context_length: m.estimated_memory_context_length,
             is_mmproj: m.is_mmproj,
             mmproj_path: m.mmproj_path.clone(),
+            fit: None,
         }
     }
 }
@@ -373,6 +393,23 @@ impl From<&crate::llm::provider::llama_cpp_models::LocalGgufModel> for LlamaCppM
 struct LlamaCppListJson {
     schema_version: u32,
     models: Vec<LlamaCppModelJson>,
+}
+
+/// Human/JSON display label for a `HardwareFit` value - Phase M12. A
+/// standalone function (not a `Display` impl on `HardwareFit` itself,
+/// which lives in `llama_cpp_models.rs` and has no reason to know about
+/// this CLI's specific wording) so `--best-fit`'s human table and its
+/// `--json` `fit` field use one identical wording, not two that could
+/// drift apart.
+#[cfg(feature = "gguf-management")]
+fn hardware_fit_label(fit: crate::llm::provider::llama_cpp_models::HardwareFit) -> &'static str {
+    use crate::llm::provider::llama_cpp_models::HardwareFit;
+    match fit {
+        HardwareFit::Fits => "Fits",
+        HardwareFit::Tight => "Tight",
+        HardwareFit::WontFit => "Won't fit",
+        HardwareFit::Unknown => "unknown",
+    }
 }
 
 /// Maps an error from a `crustly llama-cpp` subcommand to a specific,
@@ -1399,20 +1436,43 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
     let models_dir = config.providers.llama_cpp_models_dir();
 
     match operation {
-        LlamaCppCommands::List { json } => {
+        LlamaCppCommands::List { json, best_fit } => {
             let extra_model_paths = config.providers.llama_cpp_extra_model_paths();
             let ollama_models_dir = config.providers.llama_cpp_ollama_models_dir();
-            let models = llama_cpp_models::list_all_local_models(
+            let mut models = llama_cpp_models::list_all_local_models(
                 &models_dir,
                 &extra_model_paths,
                 ollama_models_dir.as_deref(),
             )?;
 
+            // Detection spawns subprocesses - only paid for when actually
+            // asked for (`hardware_detect`'s own module doc), never as a
+            // side effect of a plain `list`.
+            let budget_bytes = if best_fit {
+                crate::llm::provider::hardware_detect::detect_hardware().budget_bytes()
+            } else {
+                None
+            };
+            if best_fit {
+                llama_cpp_models::sort_by_fit(&mut models, budget_bytes);
+            }
+
             if json {
-                let payload = LlamaCppListJson {
+                let mut payload = LlamaCppListJson {
                     schema_version: LLAMA_CPP_LIST_JSON_SCHEMA_VERSION,
                     models: models.iter().map(LlamaCppModelJson::from).collect(),
                 };
+                if best_fit {
+                    for (m, j) in models.iter().zip(payload.models.iter_mut()) {
+                        j.fit = Some(
+                            hardware_fit_label(llama_cpp_models::hardware_fit(
+                                m.estimated_memory_bytes,
+                                budget_bytes,
+                            ))
+                            .to_string(),
+                        );
+                    }
+                }
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&payload)
@@ -1454,9 +1514,26 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
                         }
                         None => "-".to_string(),
                     };
-                    println!(
+                    print!(
                         "  {:<45} {:>7.2} GB   {:<10} {:<22} {}",
                         name, size_gb, quant, memory, m.modified_at
+                    );
+                    if best_fit {
+                        let fit =
+                            llama_cpp_models::hardware_fit(m.estimated_memory_bytes, budget_bytes);
+                        match m.estimated_memory_context_length {
+                            Some(ctx) => {
+                                print!("   {} (ctx {ctx})", hardware_fit_label(fit))
+                            }
+                            None => print!("   {}", hardware_fit_label(fit)),
+                        }
+                    }
+                    println!();
+                }
+                if best_fit && budget_bytes.is_none() {
+                    println!(
+                        "\n  (hardware detection found no usable GPU/RAM reading on this \
+                         machine - every entry above is \"unknown\")"
                     );
                 }
             }
@@ -1731,6 +1808,80 @@ fn llama_cpp_doctor_findings(
                 ),
             }
         });
+    }
+
+    // Phase M11/M12: surface the detected hardware as text - this is the
+    // natural home for that output (M9's own doc comment already called it
+    // out), not a reason to duplicate detection logic here. Always `Ok` -
+    // "CPU-only, RAM unknown" is a legitimate, non-fatal reading on a
+    // machine/CI image with no vendor tools installed, same as every other
+    // "unknown" this function already reports without failing.
+    let hardware = crate::llm::provider::hardware_detect::detect_hardware();
+    let hardware_message = match &hardware.gpu {
+        Some(gpu) => {
+            let name = gpu.name.as_deref().unwrap_or("unknown GPU");
+            match gpu.vram_available_bytes() {
+                Some(vram) => format!(
+                    "detected GPU: {name} (~{:.1} GB VRAM available)",
+                    vram as f64 / 1_073_741_824.0
+                ),
+                None => format!("detected GPU: {name} (VRAM unknown)"),
+            }
+        }
+        None => "no GPU detected (or no supported vendor tool installed) - CPU-only".to_string(),
+    };
+    let ram_message = match hardware.system_ram_total_bytes {
+        Some(bytes) => format!("system RAM: ~{:.1} GB", bytes as f64 / 1_073_741_824.0),
+        None => "system RAM: unknown".to_string(),
+    };
+    findings.push(DoctorFinding {
+        status: DoctorStatus::Ok,
+        message: format!("{hardware_message}; {ram_message}"),
+    });
+
+    // Best-effort - a models scan failure here (e.g. models_dir genuinely
+    // unreadable, already reported above) just means this bonus finding is
+    // skipped, not that `doctor` itself fails.
+    if let Ok(models) = llama_cpp_models::list_all_local_models(
+        models_dir,
+        &config.providers.llama_cpp_extra_model_paths(),
+        config.providers.llama_cpp_ollama_models_dir().as_deref(),
+    ) {
+        if !models.is_empty() {
+            let budget_bytes = hardware.budget_bytes();
+            findings.push(
+                match llama_cpp_models::best_fitting_model(&models, budget_bytes) {
+                    Some(best) => {
+                        let name = best.display_name.clone().unwrap_or_else(|| {
+                            best.path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().into_owned())
+                                .unwrap_or_default()
+                        });
+                        let gb = best.estimated_memory_bytes.unwrap_or(0) as f64 / 1_073_741_824.0;
+                        DoctorFinding {
+                            status: DoctorStatus::Ok,
+                            message: format!(
+                                "largest already-downloaded model this hardware can hold: \
+                             {name} (~{gb:.1} GB estimated)"
+                            ),
+                        }
+                    }
+                    None if budget_bytes.is_some() => DoctorFinding {
+                        status: DoctorStatus::Warn,
+                        message: "no already-downloaded model comfortably fits this hardware's \
+                              detected budget - consider a smaller quantization"
+                            .to_string(),
+                    },
+                    None => DoctorFinding {
+                        status: DoctorStatus::Warn,
+                        message: "could not determine a hardware budget to compare downloaded \
+                              models against"
+                            .to_string(),
+                    },
+                },
+            );
+        }
     }
 
     findings
@@ -2086,7 +2237,10 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Commands::LlamaCpp {
-                operation: LlamaCppCommands::List { json: false }
+                operation: LlamaCppCommands::List {
+                    json: false,
+                    best_fit: false
+                }
             })
         ));
 
@@ -2094,7 +2248,32 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Commands::LlamaCpp {
-                operation: LlamaCppCommands::List { json: true }
+                operation: LlamaCppCommands::List {
+                    json: true,
+                    best_fit: false
+                }
+            })
+        ));
+
+        let cli = Cli::parse_from(["crustly", "llama-cpp", "list", "--best-fit"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::LlamaCpp {
+                operation: LlamaCppCommands::List {
+                    json: false,
+                    best_fit: true
+                }
+            })
+        ));
+
+        let cli = Cli::parse_from(["crustly", "llama-cpp", "list", "--json", "--best-fit"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::LlamaCpp {
+                operation: LlamaCppCommands::List {
+                    json: true,
+                    best_fit: true
+                }
             })
         ));
 
@@ -2142,8 +2321,10 @@ mod tests {
             has_chat_template: true,
             estimated_memory_bytes: Some(5_200_000_000),
             estimated_memory_includes_kv_cache: true,
+            estimated_memory_context_length: Some(8_192),
             is_mmproj: false,
             mmproj_path: None,
+            fit: None,
         };
         let payload = LlamaCppListJson {
             schema_version: LLAMA_CPP_LIST_JSON_SCHEMA_VERSION,
@@ -2157,6 +2338,11 @@ mod tests {
         assert_eq!(json["models"][0]["has_chat_template"], true);
         assert_eq!(json["models"][0]["is_mmproj"], false);
         assert!(json["models"][0]["mmproj_path"].is_null());
+        assert_eq!(json["models"][0]["estimated_memory_context_length"], 8192);
+        // `fit` is only present when `--best-fit` was passed - omitted
+        // entirely (not even `null`) on a plain `list --json`, per its
+        // `#[serde(skip_serializing_if = "Option::is_none")]`.
+        assert!(!json["models"][0].as_object().unwrap().contains_key("fit"));
     }
 
     #[cfg(feature = "gguf-management")]
@@ -2176,6 +2362,7 @@ mod tests {
             display_name: Some("nice-name".to_string()),
             estimated_memory_bytes: Some(5_000_000_000),
             estimated_memory_includes_kv_cache: true,
+            estimated_memory_context_length: Some(8_192),
             is_mmproj: false,
             mmproj_path: None,
         };
@@ -2183,6 +2370,12 @@ mod tests {
         assert_eq!(json.quantization.as_deref(), Some("Q4_K_M"));
         assert_eq!(json.display_name.as_deref(), Some("nice-name"));
         assert_eq!(json.parameter_count, Some(7_000_000_000));
+        assert_eq!(json.estimated_memory_context_length, Some(8_192));
+        assert_eq!(
+            json.fit, None,
+            "From<&LocalGgufModel> never sets `fit` - only --best-fit's own \
+             handler does, after conversion"
+        );
     }
 
     #[test]
@@ -2303,6 +2496,57 @@ mod tests {
             |f| f.message.contains("gguf-management feature compiled in")
                 && f.status == DoctorStatus::Ok
         ));
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_doctor_findings_always_reports_detected_hardware() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = crate::config::Config::default();
+
+        let findings = llama_cpp_doctor_findings(&config, tmp.path());
+
+        // This sandbox has no nvidia-smi/rocm-smi/vulkaninfo installed, so
+        // this exercises the real "no vendor tool found" degrade-to-
+        // CPU-only path end-to-end, not a mocked one - the same "missing
+        // tool -> unknown, never fatal" contract `hardware_detect`'s own
+        // tests establish in isolation.
+        let hardware_finding = findings
+            .iter()
+            .find(|f| f.message.contains("system RAM"))
+            .expect("must report a hardware finding");
+        assert_eq!(hardware_finding.status, DoctorStatus::Ok);
+        assert!(
+            hardware_finding.message.contains("GPU"),
+            "expected the GPU half of the hardware finding, got: {}",
+            hardware_finding.message
+        );
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_doctor_findings_skips_the_best_fit_finding_when_no_models_present() {
+        let tmp = tempfile::tempdir().expect("tempdir"); // empty - no .gguf files
+        let config = crate::config::Config::default();
+
+        let findings = llama_cpp_doctor_findings(&config, tmp.path());
+
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.message.contains("already-downloaded model")),
+            "no local models means no best-fit bonus finding at all, not a Warn about it"
+        );
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn hardware_fit_label_matches_the_documented_wording() {
+        use crate::llm::provider::llama_cpp_models::HardwareFit;
+        assert_eq!(hardware_fit_label(HardwareFit::Fits), "Fits");
+        assert_eq!(hardware_fit_label(HardwareFit::Tight), "Tight");
+        assert_eq!(hardware_fit_label(HardwareFit::WontFit), "Won't fit");
+        assert_eq!(hardware_fit_label(HardwareFit::Unknown), "unknown");
     }
 
     #[cfg(feature = "gguf-management")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1514,11 +1514,22 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
         LlamaCppCommands::List { json, best_fit } => {
             let extra_model_paths = config.providers.llama_cpp_extra_model_paths();
             let ollama_models_dir = config.providers.llama_cpp_ollama_models_dir();
-            let mut models = llama_cpp_models::list_all_local_models(
-                &models_dir,
-                &extra_model_paths,
-                ollama_models_dir.as_deref(),
-            )?;
+            // `list_all_local_models` is a blocking synchronous scan
+            // (directory reads + a GGUF header parse per file, internally
+            // parallelized across its own OS threads via `std::thread::scope`)
+            // - dispatched through `spawn_blocking` here for the same reason
+            // `tui/llama_cpp_download.rs`'s `list_local` already does: it
+            // must not run directly on a Tokio worker thread.
+            let dir_for_scan = models_dir.clone();
+            let mut models = tokio::task::spawn_blocking(move || {
+                llama_cpp_models::list_all_local_models(
+                    &dir_for_scan,
+                    &extra_model_paths,
+                    ollama_models_dir.as_deref(),
+                )
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("Model scan task panicked: {e}"))??;
 
             // Detection spawns subprocesses - only paid for when actually
             // asked for (`hardware_detect`'s own module doc), never as a
@@ -1690,7 +1701,27 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
 
         LlamaCppCommands::Doctor => {
             println!("🩺 crustly llama-cpp doctor\n");
-            let findings = llama_cpp_doctor_findings(config, &models_dir);
+            // `llama_cpp_doctor_findings` stays a plain sync fn (its own
+            // unit tests call it directly, synchronously) - dispatched
+            // through `spawn_blocking` at this one async call site instead,
+            // for the same reason `List` above is: it scans `models_dir`
+            // via `list_all_local_models`, the same blocking, internally-
+            // multi-threaded call. A panic inside it degrades to a single
+            // `Fail` finding rather than aborting `doctor` entirely,
+            // matching this command's own "always exits 0, reports
+            // findings rather than failing" contract.
+            let config_for_scan = config.clone();
+            let dir_for_scan = models_dir.clone();
+            let findings = tokio::task::spawn_blocking(move || {
+                llama_cpp_doctor_findings(&config_for_scan, &dir_for_scan)
+            })
+            .await
+            .unwrap_or_else(|e| {
+                vec![DoctorFinding {
+                    status: DoctorStatus::Fail,
+                    message: format!("doctor's diagnostic task panicked: {e}"),
+                }]
+            });
             let (mut ok, mut warn, mut fail) = (0, 0, 0);
             for f in &findings {
                 match f.status {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -368,21 +368,43 @@ struct LlamaCppModelJson {
 #[cfg(feature = "gguf-management")]
 impl From<&crate::llm::provider::llama_cpp_models::LocalGgufModel> for LlamaCppModelJson {
     fn from(m: &crate::llm::provider::llama_cpp_models::LocalGgufModel) -> Self {
+        // Destructured with every field named and no `..` rest pattern -
+        // deliberately, as a poor man's exhaustiveness check: a field added
+        // to `LocalGgufModel` fails to compile right here instead of
+        // silently never reaching the `--json` output. See
+        // `llama_cpp_download.rs`'s `list_local` for the identical
+        // safeguard on the TUI's own mirror of this same struct.
+        let crate::llm::provider::llama_cpp_models::LocalGgufModel {
+            path,
+            size_bytes,
+            modified_at,
+            quantization_hint,
+            architecture,
+            parameter_count,
+            context_length,
+            has_chat_template,
+            display_name,
+            estimated_memory_bytes,
+            estimated_memory_includes_kv_cache,
+            estimated_memory_context_length,
+            is_mmproj,
+            mmproj_path,
+        } = m;
         Self {
-            path: m.path.clone(),
-            display_name: m.display_name.clone(),
-            size_bytes: m.size_bytes,
-            modified_at: m.modified_at.clone(),
-            architecture: m.architecture.clone(),
-            parameter_count: m.parameter_count,
-            quantization: m.quantization_hint.clone(),
-            context_length: m.context_length,
-            has_chat_template: m.has_chat_template,
-            estimated_memory_bytes: m.estimated_memory_bytes,
-            estimated_memory_includes_kv_cache: m.estimated_memory_includes_kv_cache,
-            estimated_memory_context_length: m.estimated_memory_context_length,
-            is_mmproj: m.is_mmproj,
-            mmproj_path: m.mmproj_path.clone(),
+            path: path.clone(),
+            display_name: display_name.clone(),
+            size_bytes: *size_bytes,
+            modified_at: modified_at.clone(),
+            architecture: architecture.clone(),
+            parameter_count: *parameter_count,
+            quantization: quantization_hint.clone(),
+            context_length: *context_length,
+            has_chat_template: *has_chat_template,
+            estimated_memory_bytes: *estimated_memory_bytes,
+            estimated_memory_includes_kv_cache: *estimated_memory_includes_kv_cache,
+            estimated_memory_context_length: *estimated_memory_context_length,
+            is_mmproj: *is_mmproj,
+            mmproj_path: mmproj_path.clone(),
             fit: None,
         }
     }
@@ -412,6 +434,44 @@ fn hardware_fit_label(fit: crate::llm::provider::llama_cpp_models::HardwareFit) 
     }
 }
 
+/// Error-message prefixes this file's own `bail!` sites produce, that
+/// `llama_cpp_exit_code` below matches against - declared once and
+/// referenced at both the producing and matching sites for the same
+/// single-source-of-truth reason as `llama_cpp_models`'s
+/// `DISK_SPACE_ERROR_PREFIX`/etc. (see that module's doc comment on those
+/// constants). `FEATURE_NOT_COMPILED_ERROR_PREFIX` is shared by every
+/// provider's "not compiled in" `bail!` (`cmd_ollama`'s included), not just
+/// `llama-cpp`'s - only the latter is reachable through this exit-code
+/// mapping today, but the wording itself is meant to stay identical across
+/// providers.
+const NO_SUCH_FILE_ERROR_PREFIX: &str = "No such file:";
+const FEATURE_NOT_COMPILED_ERROR_PREFIX: &str = "This build of crustly was compiled without";
+
+/// `llama_cpp_exit_code` below is deliberately *not* `#[cfg(feature =
+/// "gguf-management")]`-gated itself - it still has to run (and correctly
+/// return 14) against `cmd_llama_cpp`'s `not(gguf-management)` stub error.
+/// That means its body must compile either way, but
+/// `llama_cpp_models::{DISK_SPACE_ERROR_PREFIX, ...}` only exist when the
+/// module they live in is compiled in (`provider/mod.rs` gates the whole
+/// `mod llama_cpp_models;` declaration on this same feature) - so the
+/// import is gated, with a same-named, same-valued local fallback for the
+/// off build below. That fallback never actually matches anything real:
+/// codes 11-13 can only be produced by `download_model`, which doesn't
+/// exist without this feature either.
+#[cfg(feature = "gguf-management")]
+use crate::llm::provider::llama_cpp_models::{
+    CHECKSUM_MISMATCH_ERROR_PREFIX, DISK_SPACE_ERROR_PREFIX, DOWNLOAD_FAILED_ERROR_PREFIX,
+    DOWNLOAD_START_ERROR_PREFIX,
+};
+#[cfg(not(feature = "gguf-management"))]
+const DISK_SPACE_ERROR_PREFIX: &str = "Not enough disk space";
+#[cfg(not(feature = "gguf-management"))]
+const CHECKSUM_MISMATCH_ERROR_PREFIX: &str = "Checksum mismatch for";
+#[cfg(not(feature = "gguf-management"))]
+const DOWNLOAD_START_ERROR_PREFIX: &str = "Failed to start download from";
+#[cfg(not(feature = "gguf-management"))]
+const DOWNLOAD_FAILED_ERROR_PREFIX: &str = "Download failed for";
+
 /// Maps an error from a `crustly llama-cpp` subcommand to a specific,
 /// documented exit code, by matching known message prefixes anywhere in
 /// the error's context chain (`anyhow::Error::chain()`, not just
@@ -430,21 +490,21 @@ fn hardware_fit_label(fit: crate::llm::provider::llama_cpp_models::HardwareFit) 
 fn llama_cpp_exit_code(err: &anyhow::Error) -> i32 {
     for cause in err.chain() {
         let msg = cause.to_string();
-        if msg.starts_with("No such file:") {
+        if msg.starts_with(NO_SUCH_FILE_ERROR_PREFIX) {
             return 10; // model/file not found
         }
-        if msg.starts_with("Not enough disk space") {
+        if msg.starts_with(DISK_SPACE_ERROR_PREFIX) {
             return 11;
         }
-        if msg.starts_with("Checksum mismatch for") {
+        if msg.starts_with(CHECKSUM_MISMATCH_ERROR_PREFIX) {
             return 12;
         }
-        if msg.starts_with("Failed to start download from")
-            || msg.starts_with("Download failed for")
+        if msg.starts_with(DOWNLOAD_START_ERROR_PREFIX)
+            || msg.starts_with(DOWNLOAD_FAILED_ERROR_PREFIX)
         {
             return 13; // network/HTTP failure
         }
-        if msg.starts_with("This build of crustly was compiled without") {
+        if msg.starts_with(FEATURE_NOT_COMPILED_ERROR_PREFIX) {
             return 14; // feature not compiled in
         }
     }
@@ -518,7 +578,7 @@ pub enum OutputFormat {
 }
 
 /// Main CLI entry point
-pub async fn run() -> Result<()> {
+pub async fn run() -> Result<std::process::ExitCode> {
     let cli = Cli::parse();
 
     // Set up logging level based on debug flag
@@ -548,7 +608,31 @@ pub async fn run() -> Result<()> {
     }
     let config = config;
 
-    match cli.command {
+    // `LlamaCpp` needs a documented, non-1 exit code on failure (10-14 -
+    // see `llama_cpp_exit_code`); every other command keeps Rust's default
+    // `Result<(), E>` `Termination` behavior (print `Error: {e:?}`, exit 1)
+    // completely unchanged below. `LlamaCpp` used to get its custom code via
+    // `std::process::exit()` directly - which terminates the process
+    // immediately, skipping every live destructor, including `main()`'s
+    // `_guard` (a `tracing_appender` `WorkerGuard`) that flushes buffered
+    // debug-mode log lines on drop. Returning a `std::process::ExitCode`
+    // instead (an early `return` here, not a `process::exit` call) lets
+    // `main()`'s async body finish and its locals drop normally before the
+    // process actually exits - the standard, destructor-safe way to produce
+    // a custom exit code, and the only change from before: the printed
+    // message and the exit code itself are identical to what
+    // `std::process::exit` produced.
+    if let Some(Commands::LlamaCpp { operation }) = cli.command {
+        return match cmd_llama_cpp(&config, operation).await {
+            Ok(()) => Ok(std::process::ExitCode::SUCCESS),
+            Err(e) => {
+                eprintln!("Error: {e:?}");
+                Ok(std::process::ExitCode::from(llama_cpp_exit_code(&e) as u8))
+            }
+        };
+    }
+
+    let result: Result<()> = match cli.command {
         None | Some(Commands::Chat { session: _ }) => {
             // Default: Interactive TUI mode
             let session = match &cli.command {
@@ -572,18 +656,9 @@ pub async fn run() -> Result<()> {
             max_iterations,
         }) => cmd_autoplan(&config, goal, max_iterations).await,
         Some(Commands::Ollama { operation }) => cmd_ollama(&config, operation).await,
-        Some(Commands::LlamaCpp { operation }) => match cmd_llama_cpp(&config, operation).await {
-            Ok(()) => Ok(()),
-            Err(e) => {
-                // Matches Rust's default `Termination` output for a `Result`
-                // returned from `main` byte-for-byte (`Error: {:?}`), so a
-                // human watching the terminal sees identical text to every
-                // other Crustly command - only the exit code differs here.
-                eprintln!("Error: {e:?}");
-                std::process::exit(llama_cpp_exit_code(&e));
-            }
-        },
-    }
+        Some(Commands::LlamaCpp { .. }) => unreachable!("handled by the early return above"),
+    };
+    result.map(|()| std::process::ExitCode::SUCCESS)
 }
 
 /// Load configuration from file or defaults
@@ -1411,7 +1486,7 @@ async fn cmd_ollama(config: &crate::config::Config, operation: OllamaCommands) -
 #[cfg(not(feature = "ollama"))]
 async fn cmd_ollama(_config: &crate::config::Config, _operation: OllamaCommands) -> Result<()> {
     anyhow::bail!(
-        "This build of crustly was compiled without the 'ollama' feature. \
+        "{FEATURE_NOT_COMPILED_ERROR_PREFIX} the 'ollama' feature. \
          Rebuild with `--features ollama` (or `all-llm`) to use `crustly ollama`."
     );
 }
@@ -1592,7 +1667,7 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
         LlamaCppCommands::Rm { name } => {
             let path = resolve_llama_cpp_model_path(&models_dir, &name);
             if !path.exists() {
-                anyhow::bail!("No such file: {}", path.display());
+                anyhow::bail!("{NO_SUCH_FILE_ERROR_PREFIX} {}", path.display());
             }
 
             let size_gb = std::fs::metadata(&path)
@@ -1893,7 +1968,7 @@ async fn cmd_llama_cpp(
     _operation: LlamaCppCommands,
 ) -> Result<()> {
     anyhow::bail!(
-        "This build of crustly was compiled without the 'gguf-management' feature. \
+        "{FEATURE_NOT_COMPILED_ERROR_PREFIX} the 'gguf-management' feature. \
          Rebuild with `--features gguf-management` to use `crustly llama-cpp`."
     );
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1237,7 +1237,7 @@ async fn cmd_ollama(_config: &crate::config::Config, _operation: OllamaCommands)
 /// Resolve a user-supplied `model` argument (from `crustly llama-cpp rm`)
 /// to a path: an absolute path or one containing a separator is used as-is,
 /// otherwise it's treated as a filename inside `models_dir`.
-#[cfg(feature = "llama-cpp")]
+#[cfg(feature = "gguf-management")]
 fn resolve_llama_cpp_model_path(models_dir: &std::path::Path, model: &str) -> std::path::PathBuf {
     let candidate = std::path::Path::new(model);
     if candidate.is_absolute() || model.contains(std::path::MAIN_SEPARATOR) {
@@ -1247,7 +1247,7 @@ fn resolve_llama_cpp_model_path(models_dir: &std::path::Path, model: &str) -> st
     }
 }
 
-#[cfg(feature = "llama-cpp")]
+#[cfg(feature = "gguf-management")]
 async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppCommands) -> Result<()> {
     use crate::llm::provider::llama_cpp_models;
 
@@ -1353,14 +1353,14 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
     }
 }
 
-#[cfg(not(feature = "llama-cpp"))]
+#[cfg(not(feature = "gguf-management"))]
 async fn cmd_llama_cpp(
     _config: &crate::config::Config,
     _operation: LlamaCppCommands,
 ) -> Result<()> {
     anyhow::bail!(
-        "This build of crustly was compiled without the 'llama-cpp' feature. \
-         Rebuild with `--features llama-cpp` to use `crustly llama-cpp`."
+        "This build of crustly was compiled without the 'gguf-management' feature. \
+         Rebuild with `--features gguf-management` to use `crustly llama-cpp`."
     );
 }
 
@@ -1716,7 +1716,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "llama-cpp")]
+    #[cfg(feature = "gguf-management")]
     #[test]
     fn resolve_llama_cpp_model_path_treats_bare_names_as_relative_to_models_dir() {
         let dir = std::path::Path::new("/models");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -268,19 +268,138 @@ pub enum OllamaCommands {
 
 #[derive(Subcommand, Debug)]
 pub enum LlamaCppCommands {
-    /// List .gguf files in the configured models directory
-    List,
-    /// Download a model: a direct URL, or an `hf:org/repo/file.gguf`
+    /// List .gguf files in the configured models directory, plus any
+    /// extra_model_paths/scan_ollama_models sources
+    ///
+    /// Exit codes: 0 success, 1 unrecognized error. `--json` output is a
+    /// stable, versioned schema (`schema_version` field) suitable for
+    /// scripting - see docs/guides/LLAMA_CPP_GUIDE.md.
+    List {
+        /// Print a stable, versioned JSON schema instead of a human-readable
+        /// table - no emoji header, just the JSON, for scripting/agents.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Download a model: a direct URL, or an `hf:org/repo/file.gguf[@revision]`
     /// shorthand resolved against Hugging Face
+    ///
+    /// Exit codes: 0 success, 11 not enough disk space, 12 checksum mismatch,
+    /// 13 network/download failure, 14 build missing the 'gguf-management'
+    /// feature, 1 any other error.
     Pull {
-        /// Direct URL or `hf:org/repo/file.gguf` shorthand
+        /// Direct URL or `hf:org/repo/file.gguf[@revision]` shorthand
         source: String,
     },
     /// Delete a local .gguf file by name or path
+    ///
+    /// Exit codes: 0 success, 10 no such file, 14 build missing the
+    /// 'gguf-management' feature, 1 any other error.
     Rm {
-        /// Filename (resolved inside the models directory) or full path
-        model: String,
+        /// Filename (resolved inside the models directory) or full path.
+        /// Named `name`, not `model` - a positional field sharing an ident
+        /// with the top-level `global = true` `--model` flag causes clap
+        /// to route the value into the wrong one (confirmed independently
+        /// of this plan's own changes - `ollama rm` has the identical
+        /// pre-existing bug via the same collision, left unfixed here as
+        /// out of this phase's scope, flagged separately).
+        name: String,
     },
+}
+
+/// `crustly llama-cpp list --json`'s schema version. Bump only on a
+/// breaking change to `LlamaCppModelJson`'s field set/types - additive
+/// fields don't need a bump, per the usual "additive is non-breaking"
+/// convention for a versioned JSON contract.
+const LLAMA_CPP_LIST_JSON_SCHEMA_VERSION: u32 = 1;
+
+/// Stable, versioned wire format for `crustly llama-cpp list --json` -
+/// deliberately a separate type from `LocalGgufModel`
+/// (`src/llm/provider/llama_cpp_models.rs`), not `#[derive(Serialize)]` on
+/// it directly, so the internal struct can keep evolving without silently
+/// breaking this contract. snake_case field names, no `rename_all` needed -
+/// matches the dominant convention for Crustly's own domain types (e.g.
+/// `src/config/mod.rs`); camelCase in this codebase is reserved for structs
+/// mirroring an external API, which this isn't.
+#[derive(Debug, Clone, serde::Serialize)]
+struct LlamaCppModelJson {
+    path: std::path::PathBuf,
+    display_name: Option<String>,
+    size_bytes: u64,
+    modified_at: String,
+    architecture: Option<String>,
+    parameter_count: Option<u64>,
+    quantization: Option<String>,
+    context_length: Option<u64>,
+    has_chat_template: bool,
+    estimated_memory_bytes: Option<u64>,
+    estimated_memory_includes_kv_cache: bool,
+    is_mmproj: bool,
+    mmproj_path: Option<std::path::PathBuf>,
+}
+
+impl From<&crate::llm::provider::llama_cpp_models::LocalGgufModel> for LlamaCppModelJson {
+    fn from(m: &crate::llm::provider::llama_cpp_models::LocalGgufModel) -> Self {
+        Self {
+            path: m.path.clone(),
+            display_name: m.display_name.clone(),
+            size_bytes: m.size_bytes,
+            modified_at: m.modified_at.clone(),
+            architecture: m.architecture.clone(),
+            parameter_count: m.parameter_count,
+            quantization: m.quantization_hint.clone(),
+            context_length: m.context_length,
+            has_chat_template: m.has_chat_template,
+            estimated_memory_bytes: m.estimated_memory_bytes,
+            estimated_memory_includes_kv_cache: m.estimated_memory_includes_kv_cache,
+            is_mmproj: m.is_mmproj,
+            mmproj_path: m.mmproj_path.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct LlamaCppListJson {
+    schema_version: u32,
+    models: Vec<LlamaCppModelJson>,
+}
+
+/// Maps an error from a `crustly llama-cpp` subcommand to a specific,
+/// documented exit code, by matching known message prefixes anywhere in
+/// the error's context chain (`anyhow::Error::chain()`, not just
+/// `.to_string()`'s outermost layer - `Pull`'s errors are wrapped in
+/// `"Failed to download '...'"`, so the more specific cause is a layer
+/// deeper). Reuses Crustly's own existing error *messages* as the taxonomy
+/// (every prefix here is a string this codebase already produces
+/// elsewhere, unchanged by this function) rather than inventing new ones
+/// or importing llamastash's specific numeric meanings - see
+/// `ccguf-managment-imrpoment-plan.md` Phase M7.
+///
+/// An unmatched error falls back to `1`, identical to every other Crustly
+/// command's behavior today - this only adds finer-grained codes on top of
+/// that default for failure messages that already exist, it never changes
+/// what a *new*, unrecognized error does.
+fn llama_cpp_exit_code(err: &anyhow::Error) -> i32 {
+    for cause in err.chain() {
+        let msg = cause.to_string();
+        if msg.starts_with("No such file:") {
+            return 10; // model/file not found
+        }
+        if msg.starts_with("Not enough disk space") {
+            return 11;
+        }
+        if msg.starts_with("Checksum mismatch for") {
+            return 12;
+        }
+        if msg.starts_with("Failed to start download from")
+            || msg.starts_with("Download failed for")
+        {
+            return 13; // network/HTTP failure
+        }
+        if msg.starts_with("This build of crustly was compiled without") {
+            return 14; // feature not compiled in
+        }
+    }
+    1
 }
 
 #[derive(Subcommand, Debug)]
@@ -404,7 +523,17 @@ pub async fn run() -> Result<()> {
             max_iterations,
         }) => cmd_autoplan(&config, goal, max_iterations).await,
         Some(Commands::Ollama { operation }) => cmd_ollama(&config, operation).await,
-        Some(Commands::LlamaCpp { operation }) => cmd_llama_cpp(&config, operation).await,
+        Some(Commands::LlamaCpp { operation }) => match cmd_llama_cpp(&config, operation).await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Matches Rust's default `Termination` output for a `Result`
+                // returned from `main` byte-for-byte (`Error: {:?}`), so a
+                // human watching the terminal sees identical text to every
+                // other Crustly command - only the exit code differs here.
+                eprintln!("Error: {e:?}");
+                std::process::exit(llama_cpp_exit_code(&e));
+            }
+        },
     }
 }
 
@@ -1258,8 +1387,7 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
     let models_dir = config.providers.llama_cpp_models_dir();
 
     match operation {
-        LlamaCppCommands::List => {
-            println!("🦙 Local .gguf models\n");
+        LlamaCppCommands::List { json } => {
             let extra_model_paths = config.providers.llama_cpp_extra_model_paths();
             let ollama_models_dir = config.providers.llama_cpp_ollama_models_dir();
             let models = llama_cpp_models::list_all_local_models(
@@ -1268,6 +1396,20 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
                 ollama_models_dir.as_deref(),
             )?;
 
+            if json {
+                let payload = LlamaCppListJson {
+                    schema_version: LLAMA_CPP_LIST_JSON_SCHEMA_VERSION,
+                    models: models.iter().map(LlamaCppModelJson::from).collect(),
+                };
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&payload)
+                        .context("Failed to serialize model list as JSON")?
+                );
+                return Ok(());
+            }
+
+            println!("🦙 Local .gguf models\n");
             if models.is_empty() {
                 println!("  (none) - pull one with: crustly llama-cpp pull <source>");
             } else {
@@ -1358,8 +1500,8 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
             Ok(())
         }
 
-        LlamaCppCommands::Rm { model } => {
-            let path = resolve_llama_cpp_model_path(&models_dir, &model);
+        LlamaCppCommands::Rm { name } => {
+            let path = resolve_llama_cpp_model_path(&models_dir, &name);
             if !path.exists() {
                 anyhow::bail!("No such file: {}", path.display());
             }
@@ -1734,17 +1876,130 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Commands::LlamaCpp {
-                operation: LlamaCppCommands::List
+                operation: LlamaCppCommands::List { json: false }
+            })
+        ));
+
+        let cli = Cli::parse_from(["crustly", "llama-cpp", "list", "--json"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::LlamaCpp {
+                operation: LlamaCppCommands::List { json: true }
             })
         ));
 
         let cli = Cli::parse_from(["crustly", "llama-cpp", "rm", "model.gguf"]);
         match cli.command {
             Some(Commands::LlamaCpp {
-                operation: LlamaCppCommands::Rm { model },
-            }) => assert_eq!(model, "model.gguf"),
+                operation: LlamaCppCommands::Rm { name },
+            }) => assert_eq!(name, "model.gguf"),
             other => panic!("expected LlamaCpp Rm command, got {other:?}"),
         }
+
+        // Regression test for the actual bug this rename fixed: a bare
+        // positional value must resolve to `Rm.name`, not silently be
+        // captured by the global `--model` flag (which shares its ident
+        // with the *old* field name and confused clap's arg matching -
+        // reproduced independently of this test file, confirmed against
+        // the real built binary before this fix).
+        let cli = Cli::parse_from(["crustly", "llama-cpp", "rm", "some-model.gguf"]);
+        assert!(
+            cli.model.is_none(),
+            "the positional Rm argument must not be captured by the global --model flag"
+        );
+    }
+
+    #[test]
+    fn llama_cpp_list_json_round_trips_with_the_documented_schema() {
+        let model = LlamaCppModelJson {
+            path: std::path::PathBuf::from("/models/a.gguf"),
+            display_name: Some("qwen2.5-coder:7b".to_string()),
+            size_bytes: 4_294_967_296,
+            modified_at: "2026-08-07T13:38:28Z".to_string(),
+            architecture: Some("qwen2".to_string()),
+            parameter_count: Some(7_000_000_000),
+            quantization: Some("Q4_K_M".to_string()),
+            context_length: Some(32768),
+            has_chat_template: true,
+            estimated_memory_bytes: Some(5_200_000_000),
+            estimated_memory_includes_kv_cache: true,
+            is_mmproj: false,
+            mmproj_path: None,
+        };
+        let payload = LlamaCppListJson {
+            schema_version: LLAMA_CPP_LIST_JSON_SCHEMA_VERSION,
+            models: vec![model],
+        };
+
+        let json = serde_json::to_value(&payload).expect("must serialize");
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["models"][0]["display_name"], "qwen2.5-coder:7b");
+        assert_eq!(json["models"][0]["parameter_count"], 7_000_000_000_u64);
+        assert_eq!(json["models"][0]["has_chat_template"], true);
+        assert_eq!(json["models"][0]["is_mmproj"], false);
+        assert!(json["models"][0]["mmproj_path"].is_null());
+    }
+
+    #[test]
+    fn llama_cpp_model_json_from_local_gguf_model_carries_every_field() {
+        use crate::llm::provider::llama_cpp_models::LocalGgufModel;
+
+        let model = LocalGgufModel {
+            path: std::path::PathBuf::from("/models/a.gguf"),
+            size_bytes: 100,
+            modified_at: "now".to_string(),
+            quantization_hint: Some("Q4_K_M".to_string()),
+            architecture: Some("qwen2".to_string()),
+            parameter_count: Some(7_000_000_000),
+            context_length: Some(32768),
+            has_chat_template: true,
+            display_name: Some("nice-name".to_string()),
+            estimated_memory_bytes: Some(5_000_000_000),
+            estimated_memory_includes_kv_cache: true,
+            is_mmproj: false,
+            mmproj_path: None,
+        };
+        let json = LlamaCppModelJson::from(&model);
+        assert_eq!(json.quantization.as_deref(), Some("Q4_K_M"));
+        assert_eq!(json.display_name.as_deref(), Some("nice-name"));
+        assert_eq!(json.parameter_count, Some(7_000_000_000));
+    }
+
+    #[test]
+    fn llama_cpp_exit_code_maps_each_known_message_prefix() {
+        let cases: &[(&str, i32)] = &[
+            ("No such file: /models/x.gguf", 10),
+            ("Not enough disk space to download 'x.gguf': ...", 11),
+            ("Checksum mismatch for x.gguf: ...", 12),
+            ("Failed to start download from https://example.com", 13),
+            ("Download failed for https://example.com", 13),
+            (
+                "This build of crustly was compiled without the 'gguf-management' feature.",
+                14,
+            ),
+        ];
+        for (msg, expected) in cases {
+            let err = anyhow::anyhow!("{msg}");
+            assert_eq!(llama_cpp_exit_code(&err), *expected, "for message: {msg}");
+        }
+    }
+
+    #[test]
+    fn llama_cpp_exit_code_checks_the_whole_chain_not_just_the_outermost_context() {
+        // Mirrors how `Pull` actually wraps its errors: the outermost
+        // context is always "Failed to download '...'", so the specific
+        // cause (checksum mismatch, here) is a layer deeper.
+        let root = anyhow::anyhow!("Checksum mismatch for model.gguf: expected a, got b.");
+        let wrapped: anyhow::Error = Err::<(), _>(root)
+            .context("Failed to download 'model.gguf'")
+            .unwrap_err();
+        assert_eq!(llama_cpp_exit_code(&wrapped), 12);
+    }
+
+    #[test]
+    fn llama_cpp_exit_code_falls_back_to_one_for_an_unrecognized_error() {
+        let err = anyhow::anyhow!("some entirely new failure mode nobody has seen before");
+        assert_eq!(llama_cpp_exit_code(&err), 1);
     }
 
     #[cfg(feature = "gguf-management")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1274,12 +1274,21 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
                 for m in models {
                     let size_gb = m.size_bytes as f64 / 1_073_741_824.0;
                     let quant = m.quantization_hint.as_deref().unwrap_or("unknown");
-                    let name = m.display_name.clone().unwrap_or_else(|| {
+                    let mut name = m.display_name.clone().unwrap_or_else(|| {
                         m.path
                             .file_name()
                             .map(|n| n.to_string_lossy().into_owned())
                             .unwrap_or_default()
                     });
+                    // A paired base model's projector is folded into this
+                    // entry (its own row was removed by `pair_mmproj_files`);
+                    // an unpaired projector keeps its own row, labeled so
+                    // it's not just a mysteriously-named model.
+                    if m.mmproj_path.is_some() {
+                        name.push_str(" (+ mmproj)");
+                    } else if m.is_mmproj {
+                        name.push_str(" [mmproj]");
+                    }
                     let memory = match m.estimated_memory_bytes {
                         Some(bytes) => {
                             let gb = bytes as f64 / 1_073_741_824.0;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -304,12 +304,19 @@ pub enum LlamaCppCommands {
         /// out of this phase's scope, flagged separately).
         name: String,
     },
+    /// Diagnose local .gguf model management setup: build features,
+    /// models directory, disk space, configured extra sources
+    ///
+    /// Always exits 0 - this reports findings as text, it never fails
+    /// the way `list`/`pull`/`rm` can.
+    Doctor,
 }
 
 /// `crustly llama-cpp list --json`'s schema version. Bump only on a
 /// breaking change to `LlamaCppModelJson`'s field set/types - additive
 /// fields don't need a bump, per the usual "additive is non-breaking"
 /// convention for a versioned JSON contract.
+#[cfg(feature = "gguf-management")]
 const LLAMA_CPP_LIST_JSON_SCHEMA_VERSION: u32 = 1;
 
 /// Stable, versioned wire format for `crustly llama-cpp list --json` -
@@ -319,7 +326,10 @@ const LLAMA_CPP_LIST_JSON_SCHEMA_VERSION: u32 = 1;
 /// breaking this contract. snake_case field names, no `rename_all` needed -
 /// matches the dominant convention for Crustly's own domain types (e.g.
 /// `src/config/mod.rs`); camelCase in this codebase is reserved for structs
-/// mirroring an external API, which this isn't.
+/// mirroring an external API, which this isn't. Gated on `gguf-management`
+/// since it references `LocalGgufModel`, which is itself gated - the not-
+/// compiled-in build of `cmd_llama_cpp` never needs this type at all.
+#[cfg(feature = "gguf-management")]
 #[derive(Debug, Clone, serde::Serialize)]
 struct LlamaCppModelJson {
     path: std::path::PathBuf,
@@ -337,6 +347,7 @@ struct LlamaCppModelJson {
     mmproj_path: Option<std::path::PathBuf>,
 }
 
+#[cfg(feature = "gguf-management")]
 impl From<&crate::llm::provider::llama_cpp_models::LocalGgufModel> for LlamaCppModelJson {
     fn from(m: &crate::llm::provider::llama_cpp_models::LocalGgufModel) -> Self {
         Self {
@@ -357,6 +368,7 @@ impl From<&crate::llm::provider::llama_cpp_models::LocalGgufModel> for LlamaCppM
     }
 }
 
+#[cfg(feature = "gguf-management")]
 #[derive(Debug, Clone, serde::Serialize)]
 struct LlamaCppListJson {
     schema_version: u32,
@@ -1523,7 +1535,205 @@ async fn cmd_llama_cpp(config: &crate::config::Config, operation: LlamaCppComman
             println!("✅ Deleted '{}'", path.display());
             Ok(())
         }
+
+        LlamaCppCommands::Doctor => {
+            println!("🩺 crustly llama-cpp doctor\n");
+            let findings = llama_cpp_doctor_findings(config, &models_dir);
+            let (mut ok, mut warn, mut fail) = (0, 0, 0);
+            for f in &findings {
+                match f.status {
+                    DoctorStatus::Ok => ok += 1,
+                    DoctorStatus::Warn => warn += 1,
+                    DoctorStatus::Fail => fail += 1,
+                }
+                println!("  {} {}", f.status.icon(), f.message);
+            }
+            println!("\n{ok} ok, {warn} warning(s), {fail} failure(s)");
+            // Always exits 0 - this reports findings, it doesn't fail like
+            // `list`/`pull`/`rm` can (see the subcommand's own doc comment).
+            Ok(())
+        }
     }
+}
+
+/// A single `crustly llama-cpp doctor` finding's severity - not a hard
+/// pass/fail gate, since `doctor` always exits 0 regardless (structured
+/// findings for a human/agent to read, not a check the process itself
+/// lives or dies by). Gated on `gguf-management`, same as `Doctor`'s real
+/// implementation - the not-compiled-in stub never constructs one.
+#[cfg(feature = "gguf-management")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DoctorStatus {
+    Ok,
+    Warn,
+    Fail,
+}
+
+#[cfg(feature = "gguf-management")]
+impl DoctorStatus {
+    fn icon(self) -> &'static str {
+        match self {
+            Self::Ok => "✅",
+            Self::Warn => "⚠️ ",
+            Self::Fail => "❌",
+        }
+    }
+}
+
+#[cfg(feature = "gguf-management")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoctorFinding {
+    status: DoctorStatus,
+    message: String,
+}
+
+/// Computes `doctor`'s findings - a pure function over `config`/
+/// `models_dir` (plus the filesystem/disk they point at) so the checklist
+/// logic is testable without going through the CLI dispatch machinery.
+/// Every check degrades to a `Warn`, never panics or errors the whole
+/// function, on anything it can't determine - same "honest unknown, not a
+/// crash" posture the rest of this plan's phases already established.
+#[cfg(feature = "gguf-management")]
+fn llama_cpp_doctor_findings(
+    config: &crate::config::Config,
+    models_dir: &std::path::Path,
+) -> Vec<DoctorFinding> {
+    use crate::llm::provider::llama_cpp_models;
+
+    let mut findings = vec![DoctorFinding {
+        status: DoctorStatus::Ok,
+        message: "gguf-management feature compiled in - list/pull/rm/doctor available".to_string(),
+    }];
+
+    if cfg!(feature = "llama-cpp") {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Ok,
+            message: "llama-cpp feature compiled in - in-process inference available".to_string(),
+        });
+        let gpu_backend_compiled_in = cfg!(any(
+            feature = "llama-cpp-cuda",
+            feature = "llama-cpp-metal",
+            feature = "llama-cpp-vulkan",
+            feature = "llama-cpp-rocm",
+            feature = "llama-cpp-opencl",
+            feature = "llama-cpp-mkl",
+        ));
+        findings.push(if gpu_backend_compiled_in {
+            DoctorFinding {
+                status: DoctorStatus::Ok,
+                message: "a GPU backend feature is compiled in".to_string(),
+            }
+        } else {
+            DoctorFinding {
+                status: DoctorStatus::Warn,
+                message: "no GPU backend feature compiled in - n_gpu_layers > 0 in config \
+                          will be a silent no-op (CPU only)"
+                    .to_string(),
+            }
+        });
+    } else {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Warn,
+            message: "llama-cpp feature not compiled in - in-process inference unavailable; \
+                      management (list/pull/rm) still works"
+                .to_string(),
+        });
+    }
+
+    if !models_dir.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Warn,
+            message: format!(
+                "models_dir does not exist yet: {} (created automatically on first `pull`)",
+                models_dir.display()
+            ),
+        });
+    } else if !models_dir.is_dir() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Fail,
+            message: format!(
+                "models_dir exists but is not a directory: {}",
+                models_dir.display()
+            ),
+        });
+    } else {
+        let probe = models_dir.join(".crustly-doctor-write-test");
+        match std::fs::write(&probe, b"x") {
+            Ok(()) => {
+                let _ = std::fs::remove_file(&probe);
+                findings.push(DoctorFinding {
+                    status: DoctorStatus::Ok,
+                    message: format!(
+                        "models_dir exists and is writable: {}",
+                        models_dir.display()
+                    ),
+                });
+            }
+            Err(e) => {
+                findings.push(DoctorFinding {
+                    status: DoctorStatus::Fail,
+                    message: format!(
+                        "models_dir exists but is not writable: {} ({e})",
+                        models_dir.display()
+                    ),
+                });
+            }
+        }
+    }
+
+    findings.push(match llama_cpp_models::available_space_at(models_dir) {
+        Some(bytes) => DoctorFinding {
+            status: DoctorStatus::Ok,
+            message: format!(
+                "~{:.1} GB free at models_dir's filesystem",
+                bytes as f64 / 1_073_741_824.0
+            ),
+        },
+        None => DoctorFinding {
+            status: DoctorStatus::Warn,
+            message: "could not determine free disk space at models_dir".to_string(),
+        },
+    });
+
+    for path in config.providers.llama_cpp_extra_model_paths() {
+        findings.push(if path.exists() {
+            DoctorFinding {
+                status: DoctorStatus::Ok,
+                message: format!("extra_model_paths entry exists: {}", path.display()),
+            }
+        } else {
+            DoctorFinding {
+                status: DoctorStatus::Warn,
+                message: format!(
+                    "extra_model_paths entry does not exist: {} (typo, or not mounted yet?)",
+                    path.display()
+                ),
+            }
+        });
+    }
+
+    if let Some(ollama_dir) = config.providers.llama_cpp_ollama_models_dir() {
+        findings.push(if ollama_dir.join("manifests").exists() {
+            DoctorFinding {
+                status: DoctorStatus::Ok,
+                message: format!(
+                    "scan_ollama_models is on and a manifest tree was found: {}",
+                    ollama_dir.display()
+                ),
+            }
+        } else {
+            DoctorFinding {
+                status: DoctorStatus::Warn,
+                message: format!(
+                    "scan_ollama_models is on but no manifests found at: {} (has Ollama \
+                     pulled anything, or is $OLLAMA_MODELS set correctly?)",
+                    ollama_dir.display()
+                ),
+            }
+        });
+    }
+
+    findings
 }
 
 #[cfg(not(feature = "gguf-management"))]
@@ -1907,8 +2117,17 @@ mod tests {
             cli.model.is_none(),
             "the positional Rm argument must not be captured by the global --model flag"
         );
+
+        let cli = Cli::parse_from(["crustly", "llama-cpp", "doctor"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::LlamaCpp {
+                operation: LlamaCppCommands::Doctor
+            })
+        ));
     }
 
+    #[cfg(feature = "gguf-management")]
     #[test]
     fn llama_cpp_list_json_round_trips_with_the_documented_schema() {
         let model = LlamaCppModelJson {
@@ -1940,6 +2159,7 @@ mod tests {
         assert!(json["models"][0]["mmproj_path"].is_null());
     }
 
+    #[cfg(feature = "gguf-management")]
     #[test]
     fn llama_cpp_model_json_from_local_gguf_model_carries_every_field() {
         use crate::llm::provider::llama_cpp_models::LocalGgufModel;
@@ -2000,6 +2220,89 @@ mod tests {
     fn llama_cpp_exit_code_falls_back_to_one_for_an_unrecognized_error() {
         let err = anyhow::anyhow!("some entirely new failure mode nobody has seen before");
         assert_eq!(llama_cpp_exit_code(&err), 1);
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_doctor_findings_reports_a_writable_models_dir_as_ok() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = crate::config::Config::default();
+
+        let findings = llama_cpp_doctor_findings(&config, tmp.path());
+
+        let models_dir_finding = findings
+            .iter()
+            .find(|f| f.message.contains("models_dir exists and is writable"))
+            .expect("must report the writable models_dir");
+        assert_eq!(models_dir_finding.status, DoctorStatus::Ok);
+        // The write-probe file must not be left behind.
+        assert!(!tmp.path().join(".crustly-doctor-write-test").exists());
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_doctor_findings_warns_on_a_missing_models_dir() {
+        let config = crate::config::Config::default();
+        let missing = std::path::Path::new("/definitely/does/not/exist/crustly-doctor-test");
+
+        let findings = llama_cpp_doctor_findings(&config, missing);
+
+        let finding = findings
+            .iter()
+            .find(|f| f.message.contains("does not exist yet"))
+            .expect("must report the missing models_dir");
+        assert_eq!(finding.status, DoctorStatus::Warn);
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_doctor_findings_reports_extra_model_paths_existence() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = crate::config::Config::default();
+        config.providers.llama_cpp = Some(crate::config::LlamaCppProviderConfig {
+            extra_model_paths: vec![
+                tmp.path().to_path_buf(),
+                std::path::PathBuf::from("/definitely/does/not/exist/crustly-extra"),
+            ],
+            ..Default::default()
+        });
+
+        let findings = llama_cpp_doctor_findings(&config, tmp.path());
+
+        assert!(findings.iter().any(|f| f.status == DoctorStatus::Ok
+            && f.message.contains("extra_model_paths entry exists")));
+        assert!(findings.iter().any(|f| f.status == DoctorStatus::Warn
+            && f.message.contains("extra_model_paths entry does not exist")));
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_doctor_findings_says_nothing_about_ollama_when_not_opted_in() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = crate::config::Config::default(); // scan_ollama_models defaults false
+
+        let findings = llama_cpp_doctor_findings(&config, tmp.path());
+
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.message.contains("scan_ollama_models")),
+            "opting out of Ollama scanning should produce no finding about it at all"
+        );
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_doctor_findings_reports_build_features() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config = crate::config::Config::default();
+
+        let findings = llama_cpp_doctor_findings(&config, tmp.path());
+
+        assert!(findings.iter().any(
+            |f| f.message.contains("gguf-management feature compiled in")
+                && f.status == DoctorStatus::Ok
+        ));
     }
 
     #[cfg(feature = "gguf-management")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -363,6 +363,39 @@ impl ProviderConfigs {
                     .join("models")
             })
     }
+
+    /// `providers.llama_cpp.extra_model_paths`, or empty if unconfigured -
+    /// shared by the CLI and TUI so both scan the same extra directories
+    /// without duplicating the resolution.
+    pub fn llama_cpp_extra_model_paths(&self) -> Vec<std::path::PathBuf> {
+        self.llama_cpp
+            .as_ref()
+            .map(|c| c.extra_model_paths.clone())
+            .unwrap_or_default()
+    }
+
+    /// Ollama's models directory, only when
+    /// `providers.llama_cpp.scan_ollama_models` opted in - `None`
+    /// otherwise, and `None` (not a guess) if `$OLLAMA_MODELS` is unset
+    /// and the home directory can't be resolved either. See
+    /// `LlamaCppProviderConfig::scan_ollama_models`'s doc comment for why
+    /// this is independent of the `ollama` Cargo feature.
+    pub fn llama_cpp_ollama_models_dir(&self) -> Option<std::path::PathBuf> {
+        let opted_in = self
+            .llama_cpp
+            .as_ref()
+            .map(|c| c.scan_ollama_models)
+            .unwrap_or(false);
+        if !opted_in {
+            return None;
+        }
+        if let Ok(dir) = std::env::var("OLLAMA_MODELS") {
+            if !dir.is_empty() {
+                return Some(std::path::PathBuf::from(dir));
+            }
+        }
+        dirs::home_dir().map(|h| h.join(".ollama").join("models"))
+    }
 }
 
 /// Individual provider configuration
@@ -644,6 +677,23 @@ pub struct LlamaCppProviderConfig {
     /// unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub models_dir: Option<std::path::PathBuf>,
+
+    /// Extra directories the `llama-cpp` model-management commands also
+    /// scan for `.gguf` files, beyond `models_dir`. Empty by default -
+    /// see `ccguf-managment-imrpoment-plan.md` Phase M3.
+    #[serde(default)]
+    pub extra_model_paths: Vec<std::path::PathBuf>,
+
+    /// Also discover models Ollama has already pulled, by reading its
+    /// manifest tree (`$OLLAMA_MODELS` or `~/.ollama/models`) rather than
+    /// guessing blob names - not a raw blob-store scan. `false` by
+    /// default: this is an explicit opt-in, independent of whether this
+    /// build was compiled with the `ollama` Cargo feature (that feature
+    /// only governs talking to an Ollama *server*; whether an Ollama
+    /// *daemon* left models on disk is unrelated) - see Phase M3's
+    /// correction in `ccguf-managment-imrpoment-plan.md`.
+    #[serde(default)]
+    pub scan_ollama_models: bool,
 }
 
 impl Default for LlamaCppProviderConfig {
@@ -663,6 +713,8 @@ impl Default for LlamaCppProviderConfig {
             seed: None,
             idle_unload_secs: None,
             models_dir: None,
+            extra_model_paths: Vec::new(),
+            scan_ollama_models: false,
         }
     }
 }

--- a/src/llm/provider/gguf_metadata.rs
+++ b/src/llm/provider/gguf_metadata.rs
@@ -81,6 +81,17 @@ pub struct GgufMetadata {
     /// `<arch>.embedding_length` - divided by `attention_head_count` to
     /// get the per-head dimension.
     pub embedding_length: Option<u64>,
+    /// `clip.has_vision_encoder` - identifies a vision projector (mmproj)
+    /// GGUF file, verified against llama.cpp's own `tools/mtmd/
+    /// clip-impl.h` rather than assumed (not `general.architecture ==
+    /// "clip"`, which doesn't exist as a detection signal in the actual
+    /// source). `false` both when the key is absent and when it's present
+    /// but `false` - both mean "not established as a vision projector."
+    pub is_vision_projector: bool,
+    /// `clip.has_audio_encoder` - the audio-projector equivalent of
+    /// `is_vision_projector`, same source and same `false`-means-both
+    /// semantics.
+    pub is_audio_projector: bool,
 }
 
 /// Read `path`'s GGUF header/metadata. `None` on any structural problem —
@@ -153,6 +164,7 @@ impl ValueType {
 enum DecodedValue {
     Str(String),
     UInt(u64),
+    Bool(bool),
     Other,
 }
 
@@ -246,6 +258,7 @@ impl<R: Read> BoundedReader<R> {
                     ValueType::U64 => {
                         DecodedValue::UInt(u64::from_le_bytes(buf[..8].try_into().ok()?))
                     }
+                    ValueType::Bool => DecodedValue::Bool(buf[0] != 0),
                     _ => DecodedValue::Other,
                 })
             }
@@ -306,6 +319,12 @@ fn parse(reader: &mut BoundedReader<impl Read>) -> Option<GgufMetadata> {
             }
             (k, DecodedValue::UInt(n)) if k.ends_with(".embedding_length") => {
                 metadata.embedding_length = Some(n);
+            }
+            ("clip.has_vision_encoder", DecodedValue::Bool(b)) => {
+                metadata.is_vision_projector = b;
+            }
+            ("clip.has_audio_encoder", DecodedValue::Bool(b)) => {
+                metadata.is_audio_projector = b;
             }
             _ => {}
         }
@@ -530,6 +549,12 @@ mod tests {
         buf.extend_from_slice(&value.to_le_bytes());
     }
 
+    fn push_bool_kv(buf: &mut Vec<u8>, key: &str, value: bool) {
+        push_string(buf, key);
+        buf.extend_from_slice(&7u32.to_le_bytes()); // ValueType::Bool
+        buf.push(value as u8);
+    }
+
     /// Appends one tensor-info entry: name, dims, `ggml_type`, offset.
     fn push_tensor(buf: &mut Vec<u8>, name: &str, dims: &[u64], ggml_type: u32) {
         push_string(buf, name);
@@ -589,6 +614,47 @@ mod tests {
         assert_eq!(metadata.architecture, None);
         assert!(!metadata.has_chat_template);
         assert_eq!(metadata.quantization, None);
+    }
+
+    #[test]
+    fn clip_has_vision_encoder_true_sets_is_vision_projector() {
+        let mut buf = header(0, 1);
+        push_bool_kv(&mut buf, "clip.has_vision_encoder", true);
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert!(metadata.is_vision_projector);
+        assert!(!metadata.is_audio_projector);
+    }
+
+    #[test]
+    fn clip_has_vision_encoder_false_does_not_set_is_vision_projector() {
+        let mut buf = header(0, 1);
+        push_bool_kv(&mut buf, "clip.has_vision_encoder", false);
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert!(!metadata.is_vision_projector);
+    }
+
+    #[test]
+    fn clip_has_audio_encoder_true_sets_is_audio_projector() {
+        let mut buf = header(0, 1);
+        push_bool_kv(&mut buf, "clip.has_audio_encoder", true);
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert!(metadata.is_audio_projector);
+        assert!(!metadata.is_vision_projector);
+    }
+
+    #[test]
+    fn neither_clip_key_present_leaves_both_projector_flags_false() {
+        let buf = header(0, 0);
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert!(!metadata.is_vision_projector);
+        assert!(!metadata.is_audio_projector);
     }
 
     #[test]

--- a/src/llm/provider/gguf_metadata.rs
+++ b/src/llm/provider/gguf_metadata.rs
@@ -362,7 +362,14 @@ fn parse(reader: &mut BoundedReader<impl Read>) -> Option<GgufMetadata> {
     metadata.quantization = file_type.and_then(ftype_to_string).or_else(|| {
         type_counts
             .into_iter()
-            .max_by_key(|(_, count)| *count)
+            // `HashMap`'s iteration order is randomized per-hasher-instance,
+            // so on a genuine tie in tensor count `max_by_key` alone would
+            // pick a different `ggml_type` across otherwise-identical runs.
+            // Breaking ties by the lowest type code makes this deterministic
+            // and reproducible for the same file, at the cost of no
+            // particular semantic meaning to *which* tied type wins - there
+            // is no more-correct tiebreak available from the header alone.
+            .max_by_key(|(ty, count)| (*count, std::cmp::Reverse(*ty)))
             .and_then(|(ty, _)| ggml_type_to_string(ty))
     });
 
@@ -684,6 +691,32 @@ mod tests {
             Some("Q4_K"),
             "the coarser per-tensor mode can't express the _M/_S/_L preset suffix"
         );
+    }
+
+    #[test]
+    fn tensor_type_mode_breaks_a_tensor_count_tie_deterministically() {
+        // Two Q4_K (type 12) and two Q5_K (type 13) tensors - a genuine
+        // tie in count, with no `general.file_type` to disambiguate.
+        let mut buf = header(4, 0);
+        push_tensor(&mut buf, "a", &[4096, 4096], 12); // GGML_TYPE_Q4_K
+        push_tensor(&mut buf, "b", &[4096, 4096], 12);
+        push_tensor(&mut buf, "c", &[4096, 4096], 13); // GGML_TYPE_Q5_K
+        push_tensor(&mut buf, "d", &[4096, 4096], 13);
+
+        let expected = read_gguf_metadata(write_temp_gguf(&buf).path())
+            .expect("must parse")
+            .quantization;
+        // Re-parse the byte-identical file many times: a `HashMap`-order-
+        // dependent tiebreak would occasionally disagree with itself across
+        // process-local hasher instances; a deterministic one never does.
+        for _ in 0..50 {
+            let file = write_temp_gguf(&buf);
+            let metadata = read_gguf_metadata(file.path()).expect("must parse");
+            assert_eq!(
+                metadata.quantization, expected,
+                "tied tensor-type counts must resolve the same way every parse"
+            );
+        }
     }
 
     #[test]

--- a/src/llm/provider/gguf_metadata.rs
+++ b/src/llm/provider/gguf_metadata.rs
@@ -1,0 +1,613 @@
+//! Pure-Rust GGUF header/metadata parser — no FFI, no `llama-cpp-2` dependency.
+//!
+//! Reads only the GGUF header, metadata key-value section, and tensor-info
+//! section of a `.gguf` file — never the (multi-GB) tensor data blob that
+//! follows. See `ccguf-managment-imrpoment-plan.md` Phase M1 for the design
+//! rationale and the public GGUF spec this implements against.
+//!
+//! **Hardening**: every value handed to this parser may come from an
+//! untrusted source (a file downloaded from an arbitrary URL via
+//! `llama_cpp_models::download_model`, or just a corrupted/truncated file).
+//! Every declared length is validated against a cap *before* anything
+//! allocation-shaped is called on it, and any structural problem (bad
+//! magic, unsupported version, truncation, or a cap violation) makes the
+//! whole parse return `None` rather than panicking or returning
+//! partial/corrupt data. A structurally valid file that's simply missing an
+//! optional key is not such a problem — it still returns `Some`, with
+//! `None` in the specific missing fields.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+/// GGUF magic bytes ("GGUF"), compared byte-for-byte rather than as a
+/// little/big-endian `u32` to sidestep any endianness ambiguity entirely.
+const GGUF_MAGIC: [u8; 4] = *b"GGUF";
+
+/// GGUF versions this parser understands. Older files are rare in practice
+/// (llama.cpp has published v3 for a long time); newer major versions, if
+/// they ever appear, are safer to decline than to assume compatibility with.
+const MIN_SUPPORTED_VERSION: u32 = 2;
+const MAX_SUPPORTED_VERSION: u32 = 3;
+
+/// Per-value hardening caps — generous enough for any real GGUF file (a
+/// tokenizer vocabulary array commonly runs to 100-200k entries, for
+/// example) while still bounding worst-case adversarial memory use. See the
+/// module doc comment and `ccguf-managment-imrpoment-plan.md` Phase M1's
+/// "Hardening" section for the reasoning behind each number.
+const MAX_KV_COUNT: u64 = 100_000;
+const MAX_TENSOR_COUNT: u64 = 100_000;
+const MAX_TENSOR_DIMS: u32 = 8;
+const MAX_STRING_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_ARRAY_LEN: u64 = 1_000_000;
+/// Cumulative cap on total bytes read while parsing the KV + tensor-info
+/// sections, independent of the per-value caps above — defense in depth
+/// against many small-but-not-individually-over-cap values adding up.
+const MAX_TOTAL_METADATA_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Parsed GGUF metadata. Every field is best-effort/`Option` — see the
+/// module doc comment for when `read_gguf_metadata` returns `None` for the
+/// whole file versus `Some` with individual fields unset.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GgufMetadata {
+    pub architecture: Option<String>,
+    pub name: Option<String>,
+    /// Total scalar weight count, summed across every tensor's dimensions —
+    /// independent of quantization (which affects storage bytes per
+    /// parameter, not the logical parameter count).
+    pub parameter_count: Option<u64>,
+    /// Best-effort quantization label. Prefers `general.file_type` (precise
+    /// — distinguishes e.g. `Q4_K_S` from `Q4_K_M`) over the tensor-type
+    /// mode (coarser — that distinction doesn't exist at the per-tensor
+    /// level, only in the file-level preset name).
+    pub quantization: Option<String>,
+    pub context_length: Option<u64>,
+    pub has_chat_template: bool,
+}
+
+/// Read `path`'s GGUF header/metadata. `None` on any structural problem —
+/// not a valid GGUF file, truncated, or a value exceeds this parser's
+/// hardening caps — never panics. Only the header/KV/tensor-info sections
+/// are read; the tensor data blob itself (the bulk of the file) is never
+/// touched, so this stays fast and memory-light even for a multi-GB model.
+pub fn read_gguf_metadata(path: &Path) -> Option<GgufMetadata> {
+    let file = File::open(path).ok()?;
+    let mut reader = BoundedReader::new(BufReader::new(file));
+    parse(&mut reader)
+}
+
+/// GGUF metadata value type tags (spec-defined, fixed numbering).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValueType {
+    U8,
+    I8,
+    U16,
+    I16,
+    U32,
+    I32,
+    F32,
+    Bool,
+    String,
+    Array,
+    U64,
+    I64,
+    F64,
+}
+
+impl ValueType {
+    fn from_tag(tag: u32) -> Option<Self> {
+        Some(match tag {
+            0 => Self::U8,
+            1 => Self::I8,
+            2 => Self::U16,
+            3 => Self::I16,
+            4 => Self::U32,
+            5 => Self::I32,
+            6 => Self::F32,
+            7 => Self::Bool,
+            8 => Self::String,
+            9 => Self::Array,
+            10 => Self::U64,
+            11 => Self::I64,
+            12 => Self::F64,
+            _ => return None,
+        })
+    }
+
+    /// Byte width of a scalar of this type. `None` for `String`/`Array`,
+    /// which aren't fixed-width.
+    fn scalar_width(self) -> Option<usize> {
+        Some(match self {
+            Self::U8 | Self::I8 | Self::Bool => 1,
+            Self::U16 | Self::I16 => 2,
+            Self::U32 | Self::I32 | Self::F32 => 4,
+            Self::U64 | Self::I64 | Self::F64 => 8,
+            Self::String | Self::Array => return None,
+        })
+    }
+}
+
+/// A decoded value, retained only for the types this parser actually cares
+/// about (strings, and the unsigned-integer types used by
+/// `general.file_type`/`*.context_length`). Every other type is still fully
+/// consumed from the stream (so subsequent KV pairs stay in sync) but
+/// discarded as `Other`.
+enum DecodedValue {
+    Str(String),
+    UInt(u64),
+    Other,
+}
+
+/// Wraps a `Read` with the cumulative byte-budget enforcement shared by
+/// every read in this module — a read fails once the budget is exhausted,
+/// independent of any individual value's own cap.
+struct BoundedReader<R> {
+    inner: R,
+    remaining_budget: u64,
+}
+
+impl<R: Read> BoundedReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            remaining_budget: MAX_TOTAL_METADATA_BYTES,
+        }
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Option<()> {
+        let len = buf.len() as u64;
+        if len > self.remaining_budget {
+            return None;
+        }
+        self.inner.read_exact(buf).ok()?;
+        self.remaining_budget -= len;
+        Some(())
+    }
+
+    fn read_u32(&mut self) -> Option<u32> {
+        let mut buf = [0u8; 4];
+        self.read_exact(&mut buf)?;
+        Some(u32::from_le_bytes(buf))
+    }
+
+    fn read_u64(&mut self) -> Option<u64> {
+        let mut buf = [0u8; 8];
+        self.read_exact(&mut buf)?;
+        Some(u64::from_le_bytes(buf))
+    }
+
+    /// Reads a length-prefixed GGUF string. The declared length is checked
+    /// against `MAX_STRING_BYTES` *before* the backing buffer is allocated
+    /// — the core hardening invariant of this module: never allocate from
+    /// an unchecked, attacker-influenced length.
+    fn read_string(&mut self) -> Option<String> {
+        let len = self.read_u64()?;
+        if len > MAX_STRING_BYTES {
+            return None;
+        }
+        // Safe to allocate: `len` is now bounded by `MAX_STRING_BYTES` (64
+        // MiB), not the raw declared value.
+        let mut buf = vec![0u8; len as usize];
+        self.read_exact(&mut buf)?;
+        Some(String::from_utf8_lossy(&buf).into_owned())
+    }
+
+    /// Reads one value of `ty`, returning a decoded form for the types this
+    /// parser retains (`String`, `U32`/`U64`) or `Other` for everything
+    /// else. Always fully consumes the value's bytes from the stream
+    /// regardless of whether it's retained, so the next KV pair or tensor
+    /// info starts at the right offset.
+    fn read_value(&mut self, ty: ValueType) -> Option<DecodedValue> {
+        match ty {
+            ValueType::String => Some(DecodedValue::Str(self.read_string()?)),
+            ValueType::Array => {
+                let elem_tag = self.read_u32()?;
+                let elem_ty = ValueType::from_tag(elem_tag)?;
+                let len = self.read_u64()?;
+                if len > MAX_ARRAY_LEN {
+                    return None;
+                }
+                // Arrays aren't retained by this parser (no field needs
+                // array contents today) - each element is still fully
+                // decoded to keep the stream position correct.
+                for _ in 0..len {
+                    self.read_value(elem_ty)?;
+                }
+                Some(DecodedValue::Other)
+            }
+            _ => {
+                let width = ty
+                    .scalar_width()
+                    .expect("non-String/Array type has a scalar width");
+                let mut buf = [0u8; 8];
+                self.read_exact(&mut buf[..width])?;
+                Some(match ty {
+                    ValueType::U32 => {
+                        DecodedValue::UInt(u32::from_le_bytes(buf[..4].try_into().ok()?) as u64)
+                    }
+                    ValueType::U64 => {
+                        DecodedValue::UInt(u64::from_le_bytes(buf[..8].try_into().ok()?))
+                    }
+                    _ => DecodedValue::Other,
+                })
+            }
+        }
+    }
+}
+
+fn parse(reader: &mut BoundedReader<impl Read>) -> Option<GgufMetadata> {
+    let mut magic = [0u8; 4];
+    reader.read_exact(&mut magic)?;
+    if magic != GGUF_MAGIC {
+        return None;
+    }
+
+    let version = reader.read_u32()?;
+    if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&version) {
+        return None;
+    }
+
+    let tensor_count = reader.read_u64()?;
+    if tensor_count > MAX_TENSOR_COUNT {
+        return None;
+    }
+    let kv_count = reader.read_u64()?;
+    if kv_count > MAX_KV_COUNT {
+        return None;
+    }
+
+    let mut metadata = GgufMetadata::default();
+    let mut file_type: Option<u64> = None;
+
+    for _ in 0..kv_count {
+        let key = reader.read_string()?;
+        let value_tag = reader.read_u32()?;
+        let value_ty = ValueType::from_tag(value_tag)?;
+        let value = reader.read_value(value_ty)?;
+
+        match (key.as_str(), value) {
+            ("general.architecture", DecodedValue::Str(s)) => metadata.architecture = Some(s),
+            ("general.name", DecodedValue::Str(s)) => metadata.name = Some(s),
+            ("general.file_type", DecodedValue::UInt(n)) => file_type = Some(n),
+            ("tokenizer.chat_template", _) => metadata.has_chat_template = true,
+            (k, DecodedValue::UInt(n)) if k.ends_with(".context_length") => {
+                metadata.context_length = Some(n);
+            }
+            _ => {}
+        }
+    }
+
+    // Tensor-info section: always parsed (cheap - no tensor *data* is read)
+    // for parameter count and the quantization fallback.
+    let mut param_count: Option<u64> = Some(0);
+    let mut type_counts: HashMap<u32, u32> = HashMap::new();
+
+    for _ in 0..tensor_count {
+        let _name = reader.read_string()?;
+        let n_dims = reader.read_u32()?;
+        if n_dims > MAX_TENSOR_DIMS {
+            return None;
+        }
+
+        let mut tensor_elems: Option<u64> = Some(1);
+        for _ in 0..n_dims {
+            let dim = reader.read_u64()?;
+            tensor_elems = tensor_elems.and_then(|acc| acc.checked_mul(dim));
+        }
+
+        let tensor_type = reader.read_u32()?;
+        let _offset = reader.read_u64()?;
+
+        param_count = match (param_count, tensor_elems) {
+            (Some(total), Some(elems)) => total.checked_add(elems),
+            _ => None,
+        };
+        *type_counts.entry(tensor_type).or_insert(0) += 1;
+    }
+
+    metadata.parameter_count = param_count;
+    metadata.quantization = file_type.and_then(ftype_to_string).or_else(|| {
+        type_counts
+            .into_iter()
+            .max_by_key(|(_, count)| *count)
+            .and_then(|(ty, _)| ggml_type_to_string(ty))
+    });
+
+    Some(metadata)
+}
+
+/// Maps `general.file_type` (the `ggml_ftype`/`llama_ftype` enum — a
+/// file-level "which quantization preset was used" value, distinct from
+/// the per-tensor `ggml_type` enum below) to its human name.
+///
+/// Deliberately incomplete: only entries verified with high confidence
+/// against the public spec are mapped. `ggml_ftype` has grown many `IQ*`/
+/// `TQ*` variants over time whose exact integer codes aren't worth
+/// guessing at — an unmapped code has no entry here and the caller falls
+/// through to the coarser tensor-type-mode inference (or ultimately
+/// "unknown"), never a wrong name. Extend this table when a specific,
+/// verified code is reported missing, not preemptively.
+fn ftype_to_string(code: u64) -> Option<String> {
+    let name = match code {
+        0 => "F32",
+        1 => "F16",
+        2 => "Q4_0",
+        3 => "Q4_1",
+        7 => "Q8_0",
+        8 => "Q5_0",
+        9 => "Q5_1",
+        10 => "Q2_K",
+        11 => "Q3_K_S",
+        12 => "Q3_K_M",
+        13 => "Q3_K_L",
+        14 => "Q4_K_S",
+        15 => "Q4_K_M",
+        16 => "Q5_K_S",
+        17 => "Q5_K_M",
+        18 => "Q6_K",
+        _ => return None,
+    };
+    Some(name.to_string())
+}
+
+/// Maps a per-tensor `ggml_type` code to its human name. Coarser than
+/// `ftype_to_string` above by nature — the K-quant `_S`/`_M`/`_L` preset
+/// suffix is a file-level naming convention (which tensors got which
+/// quantization under a given strategy), not a distinct raw tensor type,
+/// so this table can only express the base family (e.g. `"Q4_K"`, not
+/// `"Q4_K_M"`). Same "verified entries only" policy as `ftype_to_string`.
+fn ggml_type_to_string(code: u32) -> Option<String> {
+    let name = match code {
+        0 => "F32",
+        1 => "F16",
+        2 => "Q4_0",
+        3 => "Q4_1",
+        6 => "Q5_0",
+        7 => "Q5_1",
+        8 => "Q8_0",
+        9 => "Q8_1",
+        10 => "Q2_K",
+        11 => "Q3_K",
+        12 => "Q4_K",
+        13 => "Q5_K",
+        14 => "Q6_K",
+        15 => "Q8_K",
+        _ => return None,
+    };
+    Some(name.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Appends a GGUF length-prefixed string.
+    fn push_string(buf: &mut Vec<u8>, s: &str) {
+        buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+        buf.extend_from_slice(s.as_bytes());
+    }
+
+    /// Appends one `general.architecture`/`general.name`-shaped STRING KV
+    /// pair (`key`, value type tag 8, then the length-prefixed value).
+    fn push_string_kv(buf: &mut Vec<u8>, key: &str, value: &str) {
+        push_string(buf, key);
+        buf.extend_from_slice(&8u32.to_le_bytes()); // ValueType::String
+        push_string(buf, value);
+    }
+
+    /// Appends one U32 KV pair (used for `general.file_type` and
+    /// `*.context_length` in these tests).
+    fn push_u32_kv(buf: &mut Vec<u8>, key: &str, value: u32) {
+        push_string(buf, key);
+        buf.extend_from_slice(&4u32.to_le_bytes()); // ValueType::U32
+        buf.extend_from_slice(&value.to_le_bytes());
+    }
+
+    /// Appends one tensor-info entry: name, dims, `ggml_type`, offset.
+    fn push_tensor(buf: &mut Vec<u8>, name: &str, dims: &[u64], ggml_type: u32) {
+        push_string(buf, name);
+        buf.extend_from_slice(&(dims.len() as u32).to_le_bytes());
+        for d in dims {
+            buf.extend_from_slice(&d.to_le_bytes());
+        }
+        buf.extend_from_slice(&ggml_type.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes()); // offset - unused by this parser
+    }
+
+    fn header(tensor_count: u64, kv_count: u64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version
+        buf.extend_from_slice(&tensor_count.to_le_bytes());
+        buf.extend_from_slice(&kv_count.to_le_bytes());
+        buf
+    }
+
+    fn write_temp_gguf(bytes: &[u8]) -> tempfile::NamedTempFile {
+        use std::io::Write as _;
+        let mut file = tempfile::NamedTempFile::new().expect("create temp file");
+        file.write_all(bytes).expect("write temp file");
+        file
+    }
+
+    #[test]
+    fn parses_architecture_name_context_length_and_chat_template() {
+        let mut buf = header(0, 4);
+        push_string_kv(&mut buf, "general.architecture", "qwen2");
+        push_string_kv(&mut buf, "general.name", "Test Model");
+        push_u32_kv(&mut buf, "qwen2.context_length", 32768);
+        push_string_kv(&mut buf, "tokenizer.chat_template", "{{ messages }}");
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse a well-formed file");
+
+        assert_eq!(metadata.architecture.as_deref(), Some("qwen2"));
+        assert_eq!(metadata.name.as_deref(), Some("Test Model"));
+        assert_eq!(metadata.context_length, Some(32768));
+        assert!(metadata.has_chat_template);
+        assert_eq!(
+            metadata.parameter_count,
+            Some(0),
+            "zero tensors, zero params"
+        );
+    }
+
+    #[test]
+    fn missing_optional_keys_still_parses_successfully() {
+        let buf = header(0, 0);
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path())
+            .expect("a structurally valid file with no KV pairs is not a parse failure");
+
+        assert_eq!(metadata.architecture, None);
+        assert!(!metadata.has_chat_template);
+        assert_eq!(metadata.quantization, None);
+    }
+
+    #[test]
+    fn general_file_type_maps_to_the_precise_quantization_string() {
+        let mut buf = header(0, 1);
+        push_u32_kv(&mut buf, "general.file_type", 15); // MOSTLY_Q4_K_M
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert_eq!(metadata.quantization.as_deref(), Some("Q4_K_M"));
+    }
+
+    #[test]
+    fn tensor_type_mode_is_the_fallback_when_file_type_is_absent() {
+        let mut buf = header(4, 0);
+        // Three Q4_K tensors, one F32 (e.g. a token embedding kept at
+        // higher precision) - Q4_K is the mode.
+        push_tensor(&mut buf, "blk.0.weight", &[4096, 4096], 12); // GGML_TYPE_Q4_K
+        push_tensor(&mut buf, "blk.1.weight", &[4096, 4096], 12);
+        push_tensor(&mut buf, "blk.2.weight", &[4096, 4096], 12);
+        push_tensor(&mut buf, "token_embd.weight", &[4096, 32000], 0); // GGML_TYPE_F32
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert_eq!(
+            metadata.quantization.as_deref(),
+            Some("Q4_K"),
+            "the coarser per-tensor mode can't express the _M/_S/_L preset suffix"
+        );
+    }
+
+    #[test]
+    fn parameter_count_sums_across_tensor_dimensions() {
+        let mut buf = header(2, 0);
+        push_tensor(&mut buf, "a", &[4096, 4096], 0); // 16,777,216
+        push_tensor(&mut buf, "b", &[128, 256, 2], 0); // 65,536
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert_eq!(metadata.parameter_count, Some(4096 * 4096 + 128 * 256 * 2));
+    }
+
+    #[test]
+    fn a_string_array_between_two_kv_pairs_is_skipped_correctly() {
+        let mut buf = header(0, 3);
+        push_string_kv(&mut buf, "general.architecture", "qwen2");
+        // tokenizer.ggml.tokens-shaped STRING array - must be fully (and
+        // correctly) skipped for `general.name` below to still parse.
+        push_string(&mut buf, "tokenizer.ggml.tokens");
+        buf.extend_from_slice(&9u32.to_le_bytes()); // ValueType::Array
+        buf.extend_from_slice(&8u32.to_le_bytes()); // element type: String
+        buf.extend_from_slice(&3u64.to_le_bytes()); // 3 elements
+        push_string(&mut buf, "<s>");
+        push_string(&mut buf, "</s>");
+        push_string(&mut buf, "hello");
+        push_string_kv(&mut buf, "general.name", "After The Array");
+
+        let file = write_temp_gguf(&buf);
+        let metadata = read_gguf_metadata(file.path()).expect("must parse");
+        assert_eq!(metadata.architecture.as_deref(), Some("qwen2"));
+        assert_eq!(metadata.name.as_deref(), Some("After The Array"));
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut buf = b"NOPE".to_vec();
+        buf.extend_from_slice(&3u32.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes());
+
+        let file = write_temp_gguf(&buf);
+        assert!(read_gguf_metadata(file.path()).is_none());
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let mut buf = b"GGUF".to_vec();
+        buf.extend_from_slice(&99u32.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes());
+
+        let file = write_temp_gguf(&buf);
+        assert!(read_gguf_metadata(file.path()).is_none());
+    }
+
+    #[test]
+    fn truncation_at_several_points_returns_none_not_a_panic() {
+        let mut full = header(0, 1);
+        push_string_kv(&mut full, "general.architecture", "qwen2");
+
+        // Cut at every byte offset from 0 up to (but not including) the
+        // full length - none of them should panic, all should report a
+        // clean parse failure.
+        for cut in 0..full.len() {
+            let file = write_temp_gguf(&full[..cut]);
+            assert!(
+                read_gguf_metadata(file.path()).is_none(),
+                "truncation at byte {cut} of {} should fail cleanly",
+                full.len()
+            );
+        }
+    }
+
+    #[test]
+    fn oversized_declared_string_length_is_rejected_before_allocating() {
+        // A KV pair claiming a ~1 TiB string, with no actual bytes behind
+        // it. If the cap were checked *after* attempting to allocate, this
+        // would abort or hang the test process; completing quickly with
+        // `None` is the proof the length was validated first.
+        let mut buf = header(0, 1);
+        push_string(&mut buf, "general.architecture");
+        buf.extend_from_slice(&8u32.to_le_bytes()); // ValueType::String
+        buf.extend_from_slice(&(1u64 << 40).to_le_bytes()); // declared length, no data follows
+
+        let file = write_temp_gguf(&buf);
+        assert!(read_gguf_metadata(file.path()).is_none());
+    }
+
+    #[test]
+    fn oversized_declared_array_length_is_rejected() {
+        let mut buf = header(0, 1);
+        push_string(&mut buf, "tokenizer.ggml.tokens");
+        buf.extend_from_slice(&9u32.to_le_bytes()); // ValueType::Array
+        buf.extend_from_slice(&8u32.to_le_bytes()); // element type: String
+        buf.extend_from_slice(&(MAX_ARRAY_LEN + 1).to_le_bytes()); // over the cap, no elements follow
+
+        let file = write_temp_gguf(&buf);
+        assert!(read_gguf_metadata(file.path()).is_none());
+    }
+
+    #[test]
+    fn oversized_declared_kv_count_is_rejected_before_reading_any_of_them() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend_from_slice(&3u32.to_le_bytes());
+        buf.extend_from_slice(&0u64.to_le_bytes()); // tensor_count
+        buf.extend_from_slice(&(MAX_KV_COUNT + 1).to_le_bytes()); // kv_count - no KV data follows
+
+        let file = write_temp_gguf(&buf);
+        assert!(read_gguf_metadata(file.path()).is_none());
+    }
+
+    #[test]
+    fn nonexistent_file_returns_none() {
+        let path = std::path::Path::new("/definitely/does/not/exist/crustly-gguf-test.gguf");
+        assert!(read_gguf_metadata(path).is_none());
+    }
+}

--- a/src/llm/provider/gguf_metadata.rs
+++ b/src/llm/provider/gguf_metadata.rs
@@ -64,6 +64,23 @@ pub struct GgufMetadata {
     pub quantization: Option<String>,
     pub context_length: Option<u64>,
     pub has_chat_template: bool,
+    /// Number of transformer blocks/layers (`<arch>.block_count`). Used
+    /// only by `estimate_memory_bytes`'s KV-cache term - not otherwise
+    /// user-facing, so `LocalGgufModel` doesn't carry this or the three
+    /// fields below directly, only the derived estimate.
+    pub block_count: Option<u64>,
+    /// `<arch>.attention.head_count` - the plain (non-KV) attention head
+    /// count, used to derive per-head dimension.
+    pub attention_head_count: Option<u64>,
+    /// `<arch>.attention.head_count_kv` - distinct from
+    /// `attention_head_count` on GQA/MQA architectures (fewer KV heads
+    /// than query heads); `None` on architectures that don't set it
+    /// separately, in which case `attention_head_count` is the right
+    /// fallback (no GQA reduction).
+    pub attention_head_count_kv: Option<u64>,
+    /// `<arch>.embedding_length` - divided by `attention_head_count` to
+    /// get the per-head dimension.
+    pub embedding_length: Option<u64>,
 }
 
 /// Read `path`'s GGUF header/metadata. `None` on any structural problem —
@@ -274,6 +291,22 @@ fn parse(reader: &mut BoundedReader<impl Read>) -> Option<GgufMetadata> {
             (k, DecodedValue::UInt(n)) if k.ends_with(".context_length") => {
                 metadata.context_length = Some(n);
             }
+            (k, DecodedValue::UInt(n)) if k.ends_with(".block_count") => {
+                metadata.block_count = Some(n);
+            }
+            // Checked before the plain "...head_count" arm below - a key
+            // ending in "_kv" can never also match the non-"_kv" suffix,
+            // but ordering these explicitly documents that intent rather
+            // than relying on it silently.
+            (k, DecodedValue::UInt(n)) if k.ends_with(".attention.head_count_kv") => {
+                metadata.attention_head_count_kv = Some(n);
+            }
+            (k, DecodedValue::UInt(n)) if k.ends_with(".attention.head_count") => {
+                metadata.attention_head_count = Some(n);
+            }
+            (k, DecodedValue::UInt(n)) if k.ends_with(".embedding_length") => {
+                metadata.embedding_length = Some(n);
+            }
             _ => {}
         }
     }
@@ -376,6 +409,99 @@ fn ggml_type_to_string(code: u32) -> Option<String> {
         _ => return None,
     };
     Some(name.to_string())
+}
+
+/// A resident-memory estimate for loading a model at a given context length.
+/// See `estimate_memory_bytes`'s doc comment for what's included and the
+/// accuracy this is meant to convey (order-of-magnitude, not exact).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MemoryEstimate {
+    pub total_bytes: u64,
+    /// `false` when the header didn't have enough attention geometry
+    /// (`block_count`/`attention.head_count[_kv]`/`embedding_length`) to
+    /// compute the KV-cache term - `total_bytes` then covers weights only,
+    /// and callers should say so rather than presenting it as complete.
+    pub includes_kv_cache: bool,
+}
+
+/// Approximate bits-per-weight for quantization labels this module's own
+/// lookup tables (`ftype_to_string`, `ggml_type_to_string`) and
+/// `quantization_hint_from_filename`'s filename-convention fallback can
+/// produce. These are published, widely-cited community figures from the
+/// llama.cpp/GGUF ecosystem, not exact - real bpw varies slightly by the
+/// specific per-tensor mix within a "mostly X" preset. Good enough for an
+/// order-of-magnitude estimate, which is all `estimate_memory_bytes` claims
+/// to give; `None` for a label this table doesn't cover degrades to "can't
+/// estimate," not a guess.
+fn bits_per_weight(quantization: &str) -> Option<f64> {
+    Some(match quantization {
+        "F32" => 32.0,
+        "F16" | "BF16" => 16.0,
+        "Q8_0" | "Q8_1" | "Q8_K" => 8.5,
+        "Q6_K" => 6.6,
+        "Q5_0" | "Q5_1" => 5.5,
+        "Q5_K" | "Q5_K_S" => 5.5,
+        "Q5_K_M" => 5.7,
+        "Q4_0" | "Q4_1" => 4.5,
+        "Q4_K" | "Q4_K_S" => 4.5,
+        "Q4_K_M" => 4.85,
+        "IQ4_NL" => 4.5,
+        "IQ4_XS" => 4.25,
+        "Q3_K" | "Q3_K_S" => 3.5,
+        "Q3_K_M" => 3.75,
+        "Q3_K_L" => 4.1,
+        "IQ3_M" => 3.66,
+        "IQ3_S" | "IQ3_XXS" => 3.44,
+        "Q2_K" => 2.56,
+        "IQ2_M" => 2.7,
+        "IQ2_S" => 2.5,
+        "IQ2_XS" => 2.31,
+        "IQ2_XXS" => 2.06,
+        _ => return None,
+    })
+}
+
+/// Estimate resident memory (weights + KV cache, when the header has
+/// enough geometry to compute it) for loading `metadata` at
+/// `context_length` tokens. `None` - not a fallback guess - when
+/// `parameter_count`/`quantization` themselves are unavailable, same
+/// "honest unknown" posture as the rest of this module.
+pub fn estimate_memory_bytes(
+    metadata: &GgufMetadata,
+    context_length: u64,
+) -> Option<MemoryEstimate> {
+    let params = metadata.parameter_count?;
+    let bpw = bits_per_weight(metadata.quantization.as_deref()?)?;
+    let weight_bytes = (params as f64 * bpw / 8.0) as u64;
+
+    let kv_bytes = (|| -> Option<u64> {
+        let blocks = metadata.block_count?;
+        let head_count = metadata.attention_head_count?;
+        let heads_kv = metadata.attention_head_count_kv.unwrap_or(head_count);
+        let embedding_length = metadata.embedding_length?;
+        if head_count == 0 {
+            return None;
+        }
+        let head_dim = embedding_length / head_count;
+        // 2 (K and V) * blocks * kv-heads * head_dim * 2 bytes/element
+        // (f16 KV cache) * context_length.
+        2u64.checked_mul(blocks)?
+            .checked_mul(heads_kv)?
+            .checked_mul(head_dim)?
+            .checked_mul(2)?
+            .checked_mul(context_length)
+    })();
+
+    Some(match kv_bytes {
+        Some(kv) => MemoryEstimate {
+            total_bytes: weight_bytes.saturating_add(kv),
+            includes_kv_cache: true,
+        },
+        None => MemoryEstimate {
+            total_bytes: weight_bytes,
+            includes_kv_cache: false,
+        },
+    })
 }
 
 #[cfg(test)]
@@ -609,5 +735,77 @@ mod tests {
     fn nonexistent_file_returns_none() {
         let path = std::path::Path::new("/definitely/does/not/exist/crustly-gguf-test.gguf");
         assert!(read_gguf_metadata(path).is_none());
+    }
+
+    #[test]
+    fn estimate_memory_bytes_is_none_without_parameter_count_or_quantization() {
+        let missing_params = GgufMetadata {
+            quantization: Some("Q4_K_M".to_string()),
+            ..Default::default()
+        };
+        assert!(estimate_memory_bytes(&missing_params, 8192).is_none());
+
+        let missing_quant = GgufMetadata {
+            parameter_count: Some(7_000_000_000),
+            ..Default::default()
+        };
+        assert!(estimate_memory_bytes(&missing_quant, 8192).is_none());
+    }
+
+    #[test]
+    fn estimate_memory_bytes_covers_weights_only_when_geometry_is_missing() {
+        let metadata = GgufMetadata {
+            parameter_count: Some(7_000_000_000),
+            quantization: Some("Q4_K_M".to_string()),
+            ..Default::default()
+        };
+        let estimate = estimate_memory_bytes(&metadata, 8192).expect("must estimate");
+        assert!(!estimate.includes_kv_cache);
+        // ~7B params at ~4.85 bits/weight -> roughly 4.2 GB of weights alone.
+        assert!(estimate.total_bytes > 3_500_000_000 && estimate.total_bytes < 5_000_000_000);
+    }
+
+    #[test]
+    fn estimate_memory_bytes_includes_kv_cache_when_geometry_is_present() {
+        let metadata = GgufMetadata {
+            parameter_count: Some(7_000_000_000),
+            quantization: Some("Q4_K_M".to_string()),
+            block_count: Some(32),
+            attention_head_count: Some(32),
+            attention_head_count_kv: Some(8), // GQA - fewer KV heads than query heads
+            embedding_length: Some(4096),
+            ..Default::default()
+        };
+        let weights_only = estimate_memory_bytes(
+            &GgufMetadata {
+                parameter_count: metadata.parameter_count,
+                quantization: metadata.quantization.clone(),
+                ..Default::default()
+            },
+            8192,
+        )
+        .expect("weights-only estimate");
+        let with_kv = estimate_memory_bytes(&metadata, 8192).expect("must estimate");
+
+        assert!(with_kv.includes_kv_cache);
+        assert!(
+            with_kv.total_bytes > weights_only.total_bytes,
+            "the KV-cache term should add to the weights-only baseline"
+        );
+    }
+
+    #[test]
+    fn estimate_memory_bytes_falls_back_to_head_count_without_gqa_kv_heads() {
+        let metadata = GgufMetadata {
+            parameter_count: Some(1_000_000_000),
+            quantization: Some("F16".to_string()),
+            block_count: Some(16),
+            attention_head_count: Some(16),
+            attention_head_count_kv: None, // no GQA - falls back to attention_head_count
+            embedding_length: Some(2048),
+            ..Default::default()
+        };
+        let estimate = estimate_memory_bytes(&metadata, 4096).expect("must estimate");
+        assert!(estimate.includes_kv_cache);
     }
 }

--- a/src/llm/provider/hardware_detect.rs
+++ b/src/llm/provider/hardware_detect.rs
@@ -155,6 +155,19 @@ fn detect_hardware_uncached() -> HardwareInfo {
 /// Also returns `None` on any spawn failure (binary not found - the common
 /// case in CI/most dev machines, and the primary path this module's own
 /// tests can exercise portably without a real GPU).
+///
+/// A hand-rolled `std::process::Command` + poll loop, not
+/// `tokio::process::Command` + `tokio::time::timeout` (the pattern
+/// `llm/tools/bash.rs`/`llm/tools/powershell.rs` already use for the same
+/// "bound a subprocess's runtime" problem) - a deliberate tradeoff, not an
+/// oversight: this whole module is synchronous by design, so
+/// `detect_hardware`'s result can be cached in a plain `OnceLock` and
+/// called from non-async contexts (the CLI's `doctor`) without needing a
+/// runtime handle threaded through. Every async caller already wraps the
+/// entry point in `spawn_blocking` (see `tui/llama_cpp_download.rs`'s
+/// `detect_hardware_summary`) specifically so this module doesn't have to
+/// be async-native. Revisit only if the sync/`OnceLock` design itself ever
+/// needs to change - not just to deduplicate this one function.
 fn run_with_timeout(cmd: &mut Command) -> Option<Output> {
     let mut child = cmd
         .stdin(Stdio::null())

--- a/src/llm/provider/hardware_detect.rs
+++ b/src/llm/provider/hardware_detect.rs
@@ -1,0 +1,608 @@
+//! Best-effort local hardware detection (GPU vendor/VRAM, system RAM) for
+//! Phase M11 of `ccguf-managment-imrpoment-plan.md` - read-only and
+//! advisory, same posture as the rest of this module's siblings
+//! (`gguf_metadata`, `llama_cpp_models`): a missing tool, a timeout, a
+//! non-zero exit, or unparseable output all degrade to "unknown," never an
+//! error, and this never writes back into `LlamaCppProviderConfig`.
+//!
+//! Deliberately subprocess-based for every vendor path except one (rather
+//! than SDK/FFI bindings) - consistent with Phase M0's whole point that the
+//! management surface shouldn't need a build-time C/C++ toolchain. The one
+//! exception the plan calls for, Windows AMD/Intel via the Win32 DXGI API,
+//! is a native FFI binding, not a subprocess, and this development
+//! environment has no Windows target to build or test it against; writing
+//! `unsafe` COM interface calls with zero ability to verify they even
+//! compile for their own target is worse than being explicit about the
+//! gap. `detect_windows_dxgi` below is a documented stub returning `None`
+//! for this phase - it falls through to the CPU-only/system-RAM path,
+//! which is this module's own designed-in "clean degradation," not a
+//! crash. NVIDIA-on-Windows is unaffected (`nvidia-smi` is a subprocess,
+//! fully portable). See `ccguf-managment-imrpoment-plan.md` Phase M11 for
+//! the full writeup of this scope decision.
+//!
+//! Detection runs at most once per process: [`detect_hardware`] caches its
+//! result in a `OnceLock`. Callers that don't need hardware data (a plain
+//! `crustly llama-cpp list`, or the TUI dialog's steady-state redraws)
+//! must never call this - only `doctor`, `list --best-fit`, and the TUI
+//! host-info panel's first load do.
+
+use std::process::{Command, Output, Stdio};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+/// How long a single vendor-tool subprocess is allowed to run before it's
+/// killed and treated as "unknown" - long enough for a real tool under
+/// normal conditions, short enough not to visibly stall `doctor` or the
+/// TUI's first paint on a hung driver.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// How often [`run_with_timeout`] polls the child for completion.
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// The vendor a detected GPU belongs to. `Other` carries whatever name the
+/// Vulkan cross-vendor fallback reported, when no vendor-specific path
+/// resolved anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GpuVendor {
+    Nvidia,
+    Amd,
+    Apple,
+    Other(String),
+}
+
+/// A detected GPU. Every field beyond `vendor` is `Option` - a source that
+/// reports a name but not memory (e.g. the Vulkan fallback) still produces
+/// a usable, honestly-partial `GpuInfo`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GpuInfo {
+    pub vendor: GpuVendor,
+    pub name: Option<String>,
+    pub vram_total_bytes: Option<u64>,
+    /// Currently-used VRAM, when the source reports it. `nvidia-smi` does
+    /// (`memory.used`); `rocm-smi`/`system_profiler`/`vulkaninfo` generally
+    /// don't - `None` there, and [`GpuInfo::vram_available_bytes`] then
+    /// conservatively falls back to the full total rather than guessing a
+    /// used figure (which would risk under-reporting available memory,
+    /// the wrong direction to be wrong in for a "will this fit" check).
+    pub vram_used_bytes: Option<u64>,
+}
+
+impl GpuInfo {
+    /// `vram_total_bytes - vram_used_bytes` when both are known, else the
+    /// total as-is, else `None`.
+    pub fn vram_available_bytes(&self) -> Option<u64> {
+        match (self.vram_total_bytes, self.vram_used_bytes) {
+            (Some(total), Some(used)) => Some(total.saturating_sub(used)),
+            (Some(total), None) => Some(total),
+            (None, _) => None,
+        }
+    }
+}
+
+/// The machine's detected hardware, as best `detect_hardware` could
+/// determine it. `gpu: None` means no GPU path resolved anything - CPU-only,
+/// not an error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HardwareInfo {
+    pub gpu: Option<GpuInfo>,
+    pub system_ram_total_bytes: Option<u64>,
+}
+
+impl HardwareInfo {
+    /// The single number Phase M12's fit comparison (and `doctor`'s
+    /// summary line) compares a model's estimated memory footprint
+    /// against: available VRAM plus system RAM, reflecting that llama.cpp
+    /// can split a model across both (offloaded layers in VRAM, the rest -
+    /// plus most of the KV cache when not fully offloaded - in system
+    /// RAM). Deliberately coarse, per M12's own "three states, not a
+    /// false-precision percentage" framing - not a model of partial-offload
+    /// performance. `None` only when *nothing* was determined at all (no
+    /// GPU reading and no RAM reading) - every other combination returns a
+    /// best-effort `Some`.
+    pub fn budget_bytes(&self) -> Option<u64> {
+        let vram = self.gpu.as_ref().and_then(GpuInfo::vram_available_bytes);
+        match (vram, self.system_ram_total_bytes) {
+            (None, None) => None,
+            (vram, ram) => Some(vram.unwrap_or(0) + ram.unwrap_or(0)),
+        }
+    }
+}
+
+static HARDWARE_INFO: OnceLock<HardwareInfo> = OnceLock::new();
+
+/// Detects (once per process - see the module doc's "when this runs" rule)
+/// and returns the machine's hardware info. Blocking: spawns subprocesses
+/// and waits on them, so callers on the async runtime must wrap this in
+/// `tokio::task::spawn_blocking` (see `tui/llama_cpp_download.rs`'s
+/// `detect_hardware_summary`).
+pub fn detect_hardware() -> &'static HardwareInfo {
+    HARDWARE_INFO.get_or_init(detect_hardware_uncached)
+}
+
+fn detect_hardware_uncached() -> HardwareInfo {
+    let gpu = detect_nvidia()
+        .or_else(detect_amd_rocm)
+        .or_else(detect_windows_dxgi)
+        .or_else(detect_apple_display)
+        .or_else(detect_vulkan_fallback);
+
+    HardwareInfo {
+        gpu,
+        system_ram_total_bytes: system_ram_total_bytes(),
+    }
+}
+
+/// Runs `cmd`, killing and returning `None` if it doesn't finish within
+/// `PROBE_TIMEOUT` - polls rather than blocking on `wait_with_output`
+/// indefinitely, since a hung driver tool must never hang `doctor`/`list`.
+/// Also returns `None` on any spawn failure (binary not found - the common
+/// case in CI/most dev machines, and the primary path this module's own
+/// tests can exercise portably without a real GPU).
+fn run_with_timeout(cmd: &mut Command) -> Option<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => return child.wait_with_output().ok(),
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+fn run_and_capture_stdout(cmd: &mut Command) -> Option<String> {
+    let output = run_with_timeout(cmd)?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout).ok()
+}
+
+// ---------------------------------------------------------------------
+// NVIDIA (Linux/Windows) - `nvidia-smi`
+// ---------------------------------------------------------------------
+
+fn detect_nvidia() -> Option<GpuInfo> {
+    let stdout = run_and_capture_stdout(Command::new("nvidia-smi").args([
+        "--query-gpu=name,memory.total,memory.used",
+        "--format=csv,noheader,nounits",
+    ]))?;
+    parse_nvidia_smi_csv(&stdout)
+}
+
+/// Parses `nvidia-smi --query-gpu=name,memory.total,memory.used
+/// --format=csv,noheader,nounits` output, e.g.
+/// `"NVIDIA GeForce RTX 4090, 24564, 1203"` (memory figures in MiB with
+/// `nounits`). Only the first GPU line is used (multi-GPU budgeting is out
+/// of scope - this module reports one representative GPU, matching M11's
+/// "name, VRAM total" display framing, not a full topology).
+fn parse_nvidia_smi_csv(stdout: &str) -> Option<GpuInfo> {
+    let line = stdout.lines().find(|l| !l.trim().is_empty())?;
+    let mut parts = line.split(',').map(str::trim);
+    let name = parts.next().filter(|s| !s.is_empty()).map(str::to_string);
+    let total_mib: Option<u64> = parts.next().and_then(|s| s.parse().ok());
+    let used_mib: Option<u64> = parts.next().and_then(|s| s.parse().ok());
+    if name.is_none() && total_mib.is_none() {
+        return None;
+    }
+    Some(GpuInfo {
+        vendor: GpuVendor::Nvidia,
+        name,
+        vram_total_bytes: total_mib.map(|mib| mib * 1024 * 1024),
+        vram_used_bytes: used_mib.map(|mib| mib * 1024 * 1024),
+    })
+}
+
+// ---------------------------------------------------------------------
+// AMD (Linux) - `rocm-smi`
+// ---------------------------------------------------------------------
+
+fn detect_amd_rocm() -> Option<GpuInfo> {
+    let stdout =
+        run_and_capture_stdout(Command::new("rocm-smi").args(["--showmeminfo", "vram", "--json"]))?;
+    parse_rocm_smi_json(&stdout)
+}
+
+/// Parses `rocm-smi --showmeminfo vram --json` output, e.g.:
+/// ```json
+/// {"card0": {"VRAM Total Memory (B)": "25757220864", "VRAM Total Used Memory (B)": "512000000"}}
+/// ```
+/// Hand-rolled key lookup (not `serde_json::Value` field-by-struct
+/// deserialization) since `rocm-smi`'s top-level key is a variable card
+/// name (`"card0"`, `"card1"`, ...), not a fixed schema - the first card
+/// object found is used, same "one representative GPU" scope as the
+/// NVIDIA path above.
+fn parse_rocm_smi_json(stdout: &str) -> Option<GpuInfo> {
+    let value: serde_json::Value = serde_json::from_str(stdout).ok()?;
+    let card = value.as_object()?.values().next()?.as_object()?;
+    let total_bytes = card
+        .get("VRAM Total Memory (B)")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok());
+    let used_bytes = card
+        .get("VRAM Total Used Memory (B)")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok());
+    total_bytes.map(|total| GpuInfo {
+        vendor: GpuVendor::Amd,
+        name: None,
+        vram_total_bytes: Some(total),
+        vram_used_bytes: used_bytes,
+    })
+}
+
+// ---------------------------------------------------------------------
+// AMD/Intel (Windows) - Win32 DXGI. See the module doc: a documented stub
+// for this phase, not a real implementation - no Windows target available
+// in this development environment to build or verify FFI bindings against.
+// ---------------------------------------------------------------------
+
+fn detect_windows_dxgi() -> Option<GpuInfo> {
+    None
+}
+
+// ---------------------------------------------------------------------
+// Apple (macOS) - `system_profiler`
+// ---------------------------------------------------------------------
+
+fn detect_apple_display() -> Option<GpuInfo> {
+    let stdout = run_and_capture_stdout(
+        Command::new("system_profiler").args(["SPDisplaysDataType", "-json"]),
+    )?;
+    parse_system_profiler_json(&stdout)
+}
+
+/// Parses `system_profiler SPDisplaysDataType -json` output. Apple Silicon
+/// reports unified memory as `"spdisplays_vram_shared"` (or similar,
+/// varies by macOS version) rather than a fixed hardware chip name - this
+/// looks for `sppci_model`/`_name` for the chip name and any
+/// `*vram*`-suffixed key with a parseable `"N MB"`/`"N GB"` value under the
+/// first display entry, degrading to name-only when no such key is
+/// present (unified-memory total is still available separately via
+/// `system_ram_total_bytes`, so a missing VRAM figure here isn't fatal to
+/// the overall `HardwareInfo`).
+fn parse_system_profiler_json(stdout: &str) -> Option<GpuInfo> {
+    let value: serde_json::Value = serde_json::from_str(stdout).ok()?;
+    let entry = value
+        .get("SPDisplaysDataType")?
+        .as_array()?
+        .first()?
+        .as_object()?;
+
+    let name = entry
+        .get("sppci_model")
+        .or_else(|| entry.get("_name"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let vram_total_bytes = entry
+        .iter()
+        .find(|(k, _)| k.to_lowercase().contains("vram"))
+        .and_then(|(_, v)| v.as_str())
+        .and_then(parse_size_string);
+
+    if name.is_none() && vram_total_bytes.is_none() {
+        return None;
+    }
+    Some(GpuInfo {
+        vendor: GpuVendor::Apple,
+        name,
+        vram_total_bytes,
+        vram_used_bytes: None,
+    })
+}
+
+/// Parses a human-readable size string like `"24576 MB"`/`"24 GB"` into
+/// bytes. Used by the Apple `system_profiler` path, whose memory figures
+/// are unit-suffixed strings rather than a fixed-unit number the way
+/// `nvidia-smi`'s CSV output is.
+fn parse_size_string(s: &str) -> Option<u64> {
+    let s = s.trim();
+    let (number, unit) = s.split_once(' ')?;
+    let number: f64 = number.parse().ok()?;
+    let multiplier: f64 = match unit.to_uppercase().as_str() {
+        "MB" | "MIB" => 1024.0 * 1024.0,
+        "GB" | "GIB" => 1024.0 * 1024.0 * 1024.0,
+        _ => return None,
+    };
+    Some((number * multiplier) as u64)
+}
+
+// ---------------------------------------------------------------------
+// Cross-vendor fallback - `vulkaninfo`. No VRAM figure available this way
+// (matches llamastash's own documented limitation for this path) - name
+// only, so at least *something* better than "CPU-only" shows when a GPU
+// exists but none of the vendor-specific tools above are installed.
+// ---------------------------------------------------------------------
+
+fn detect_vulkan_fallback() -> Option<GpuInfo> {
+    let stdout = run_and_capture_stdout(Command::new("vulkaninfo").arg("--summary"))?;
+    parse_vulkaninfo_summary(&stdout)
+}
+
+/// Parses `vulkaninfo --summary` output for the first `deviceName` line,
+/// e.g. `"deviceName        = NVIDIA GeForce RTX 4090"`. Only reached when
+/// no vendor-specific detection above resolved anything, so this is the
+/// last-resort "there's *a* GPU, we don't know its VRAM" signal.
+fn parse_vulkaninfo_summary(stdout: &str) -> Option<GpuInfo> {
+    let name = stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("deviceName"))
+        .and_then(|rest| rest.trim_start_matches([' ', '=']).split('\n').next())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)?;
+    Some(GpuInfo {
+        vendor: GpuVendor::Other("vulkan".to_string()),
+        name: Some(name),
+        vram_total_bytes: None,
+        vram_used_bytes: None,
+    })
+}
+
+// ---------------------------------------------------------------------
+// System RAM (all platforms) - `sysinfo`
+// ---------------------------------------------------------------------
+
+/// Total system RAM in bytes, via `sysinfo` (see this crate's own
+/// `"system"` feature, added in `Cargo.toml` specifically for this
+/// function - a RAM-total query is commodity functionality a well-
+/// maintained pure-Rust crate already solves portably, not worth
+/// reimplementing per-OS `/proc/meminfo`/`sysctl`/WMI parsing by hand).
+/// `None` only if the underlying platform call itself reports zero, which
+/// `sysinfo` treats as "couldn't determine" on every supported target.
+fn system_ram_total_bytes() -> Option<u64> {
+    let sys = sysinfo::System::new_all();
+    let total = sys.total_memory();
+    (total > 0).then_some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- nvidia-smi -----------------------------------------------------
+
+    #[test]
+    fn parses_a_real_shaped_nvidia_smi_line() {
+        let gpu = parse_nvidia_smi_csv("NVIDIA GeForce RTX 4090, 24564, 1203\n").unwrap();
+        assert_eq!(gpu.vendor, GpuVendor::Nvidia);
+        assert_eq!(gpu.name.as_deref(), Some("NVIDIA GeForce RTX 4090"));
+        assert_eq!(gpu.vram_total_bytes, Some(24564 * 1024 * 1024));
+        assert_eq!(gpu.vram_used_bytes, Some(1203 * 1024 * 1024));
+        assert_eq!(
+            gpu.vram_available_bytes(),
+            Some((24564 - 1203) * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn nvidia_smi_only_reads_the_first_gpu_line() {
+        let gpu = parse_nvidia_smi_csv(
+            "NVIDIA GeForce RTX 4090, 24564, 1203\nNVIDIA GeForce RTX 3090, 24576, 0\n",
+        )
+        .unwrap();
+        assert_eq!(gpu.name.as_deref(), Some("NVIDIA GeForce RTX 4090"));
+    }
+
+    #[test]
+    fn nvidia_smi_empty_output_is_none() {
+        assert!(parse_nvidia_smi_csv("").is_none());
+        assert!(parse_nvidia_smi_csv("\n\n").is_none());
+    }
+
+    #[test]
+    fn nvidia_smi_line_with_no_usable_fields_is_none() {
+        assert!(parse_nvidia_smi_csv(",,\n").is_none());
+    }
+
+    #[test]
+    fn nvidia_smi_degrades_to_name_only_when_memory_fields_are_unparseable() {
+        // A name-bearing but memory-unparseable line still produces a
+        // usable, honestly-partial GpuInfo rather than discarding the name
+        // too - same "partial data beats none" posture as the rest of this
+        // module's parsers.
+        let gpu = parse_nvidia_smi_csv("Some GPU,not-a-number,also-not\n").unwrap();
+        assert_eq!(gpu.name.as_deref(), Some("Some GPU"));
+        assert_eq!(gpu.vram_total_bytes, None);
+        assert_eq!(gpu.vram_used_bytes, None);
+    }
+
+    // -- rocm-smi ---------------------------------------------------------
+
+    #[test]
+    fn parses_a_real_shaped_rocm_smi_json_blob() {
+        let json = r#"{"card0": {"VRAM Total Memory (B)": "25757220864", "VRAM Total Used Memory (B)": "512000000"}}"#;
+        let gpu = parse_rocm_smi_json(json).unwrap();
+        assert_eq!(gpu.vendor, GpuVendor::Amd);
+        assert_eq!(gpu.vram_total_bytes, Some(25_757_220_864));
+        assert_eq!(gpu.vram_used_bytes, Some(512_000_000));
+    }
+
+    #[test]
+    fn rocm_smi_malformed_json_is_none() {
+        assert!(parse_rocm_smi_json("not json").is_none());
+        assert!(parse_rocm_smi_json("{}").is_none());
+        assert!(parse_rocm_smi_json(r#"{"card0": {}}"#).is_none());
+    }
+
+    // -- system_profiler --------------------------------------------------
+
+    #[test]
+    fn parses_a_real_shaped_system_profiler_json_blob() {
+        let json = r#"{
+            "SPDisplaysDataType": [
+                {
+                    "sppci_model": "Apple M3 Max",
+                    "spdisplays_vram_shared": "48 GB"
+                }
+            ]
+        }"#;
+        let gpu = parse_system_profiler_json(json).unwrap();
+        assert_eq!(gpu.vendor, GpuVendor::Apple);
+        assert_eq!(gpu.name.as_deref(), Some("Apple M3 Max"));
+        assert_eq!(gpu.vram_total_bytes, Some(48 * 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn system_profiler_name_only_when_no_vram_key_present() {
+        let json = r#"{"SPDisplaysDataType": [{"sppci_model": "Intel Iris"}]}"#;
+        let gpu = parse_system_profiler_json(json).unwrap();
+        assert_eq!(gpu.name.as_deref(), Some("Intel Iris"));
+        assert_eq!(gpu.vram_total_bytes, None);
+    }
+
+    #[test]
+    fn system_profiler_malformed_or_empty_is_none() {
+        assert!(parse_system_profiler_json("not json").is_none());
+        assert!(parse_system_profiler_json(r#"{"SPDisplaysDataType": []}"#).is_none());
+        assert!(parse_system_profiler_json("{}").is_none());
+    }
+
+    // -- vulkaninfo ---------------------------------------------------------
+
+    #[test]
+    fn parses_a_real_shaped_vulkaninfo_summary() {
+        let text = "Devices:\n========\nGPU0:\n\tdeviceName        = NVIDIA GeForce RTX 4090\n\tdriverVersion     = 550.54.14\n";
+        let gpu = parse_vulkaninfo_summary(text).unwrap();
+        assert_eq!(gpu.vendor, GpuVendor::Other("vulkan".to_string()));
+        assert_eq!(gpu.name.as_deref(), Some("NVIDIA GeForce RTX 4090"));
+        assert_eq!(gpu.vram_total_bytes, None);
+    }
+
+    #[test]
+    fn vulkaninfo_no_device_name_line_is_none() {
+        assert!(parse_vulkaninfo_summary("Devices:\n========\n").is_none());
+    }
+
+    // -- parse_size_string --------------------------------------------------
+
+    #[test]
+    fn parse_size_string_handles_mb_and_gb() {
+        assert_eq!(parse_size_string("1536 MB"), Some(1536 * 1024 * 1024));
+        assert_eq!(parse_size_string("48 GB"), Some(48 * 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn parse_size_string_rejects_unknown_units() {
+        assert_eq!(parse_size_string("48 furlongs"), None);
+        assert_eq!(parse_size_string("garbage"), None);
+    }
+
+    // -- GpuInfo::vram_available_bytes / HardwareInfo::budget_bytes -------
+
+    #[test]
+    fn vram_available_falls_back_to_total_when_used_is_unknown() {
+        let gpu = GpuInfo {
+            vendor: GpuVendor::Nvidia,
+            name: None,
+            vram_total_bytes: Some(1000),
+            vram_used_bytes: None,
+        };
+        assert_eq!(gpu.vram_available_bytes(), Some(1000));
+    }
+
+    #[test]
+    fn vram_available_is_none_when_total_is_unknown() {
+        let gpu = GpuInfo {
+            vendor: GpuVendor::Nvidia,
+            name: None,
+            vram_total_bytes: None,
+            vram_used_bytes: Some(500),
+        };
+        assert_eq!(gpu.vram_available_bytes(), None);
+    }
+
+    #[test]
+    fn budget_bytes_sums_vram_and_ram_when_both_known() {
+        let info = HardwareInfo {
+            gpu: Some(GpuInfo {
+                vendor: GpuVendor::Nvidia,
+                name: None,
+                vram_total_bytes: Some(10_000),
+                vram_used_bytes: Some(2_000),
+            }),
+            system_ram_total_bytes: Some(20_000),
+        };
+        assert_eq!(info.budget_bytes(), Some(8_000 + 20_000));
+    }
+
+    #[test]
+    fn budget_bytes_is_ram_only_when_no_gpu() {
+        let info = HardwareInfo {
+            gpu: None,
+            system_ram_total_bytes: Some(16_000),
+        };
+        assert_eq!(info.budget_bytes(), Some(16_000));
+    }
+
+    #[test]
+    fn budget_bytes_is_none_when_nothing_was_determined() {
+        let info = HardwareInfo {
+            gpu: None,
+            system_ram_total_bytes: None,
+        };
+        assert_eq!(info.budget_bytes(), None);
+    }
+
+    // -- run_with_timeout / spawn-failure degradation ----------------------
+
+    #[test]
+    fn run_with_timeout_returns_none_for_a_nonexistent_binary() {
+        // Portable across CI/dev machines without depending on wall-clock
+        // timeout behavior of a real hung process - exercises the "missing
+        // tool" branch every vendor-detection function above degrades
+        // through, deterministically.
+        let out = run_with_timeout(&mut Command::new(
+            "definitely-not-a-real-binary-crustly-hardware-detect-test",
+        ));
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn run_with_timeout_returns_output_for_a_fast_real_command() {
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello");
+        let out = run_with_timeout(&mut cmd);
+        // `echo` may not exist on every CI image (e.g. minimal Windows
+        // runners); only assert when it actually ran, same "don't assume
+        // tool availability" posture as the vendor probes themselves.
+        if let Some(out) = out {
+            assert!(out.status.success());
+            assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+        }
+    }
+
+    // -- detect_hardware caching -------------------------------------------
+
+    #[test]
+    fn detect_hardware_is_cached_across_calls() {
+        let first = detect_hardware() as *const HardwareInfo;
+        let second = detect_hardware() as *const HardwareInfo;
+        assert_eq!(first, second, "expected the same cached &'static instance");
+    }
+
+    // -- system_ram_total_bytes ----------------------------------------------
+
+    #[test]
+    fn system_ram_total_bytes_returns_a_plausible_value_on_a_real_machine() {
+        // Best-effort - assert only the shape (a real machine reports a
+        // non-zero figure), not a specific number.
+        if let Some(bytes) = system_ram_total_bytes() {
+            assert!(bytes > 0);
+        }
+    }
+}

--- a/src/llm/provider/hardware_detect.rs
+++ b/src/llm/provider/hardware_detect.rs
@@ -8,17 +8,30 @@
 //! Deliberately subprocess-based for every vendor path except one (rather
 //! than SDK/FFI bindings) - consistent with Phase M0's whole point that the
 //! management surface shouldn't need a build-time C/C++ toolchain. The one
-//! exception the plan calls for, Windows AMD/Intel via the Win32 DXGI API,
-//! is a native FFI binding, not a subprocess, and this development
-//! environment has no Windows target to build or test it against; writing
-//! `unsafe` COM interface calls with zero ability to verify they even
-//! compile for their own target is worse than being explicit about the
-//! gap. `detect_windows_dxgi` below is a documented stub returning `None`
-//! for this phase - it falls through to the CPU-only/system-RAM path,
-//! which is this module's own designed-in "clean degradation," not a
-//! crash. NVIDIA-on-Windows is unaffected (`nvidia-smi` is a subprocess,
-//! fully portable). See `ccguf-managment-imrpoment-plan.md` Phase M11 for
-//! the full writeup of this scope decision.
+//! exception the plan calls for, Windows AMD/Intel via the Win32 DXGI API
+//! (`detect_windows_dxgi`, `#[cfg(target_os = "windows")]`), is a native FFI
+//! binding via the official `windows` crate, not a subprocess - matches
+//! llamastash's own documented approach for this specific path.
+//!
+//! **Verification note**: this development environment has no Windows
+//! machine to run the DXGI path against real hardware. It has been
+//! cross-compile type-checked instead (`cargo check --target
+//! x86_64-pc-windows-gnu --features gguf-management`, with `mingw-w64`
+//! installed for the C-linked dependencies elsewhere in the tree that also
+//! need to compile for that target) - the FFI call shapes, struct field
+//! names/types, and safety comments are all verified to type-check against
+//! the real `windows` crate bindings for the real DXGI API, which is
+//! meaningfully more assurance than an unverified stub, but it is still not
+//! a runtime test against actual hardware/drivers. If this ever misbehaves
+//! on a real Windows machine, that's the first thing to check - not
+//! something this module's own test suite can catch, since `cargo test`
+//! only runs on this crate's host target (Linux). The two small pure
+//! helpers this function delegates to (`gpu_vendor_from_pci_id`,
+//! `trim_dxgi_description`) *are* portable and unit-tested on every
+//! platform, isolating as much of the real logic as possible from the
+//! untestable FFI call itself. NVIDIA-on-Windows does not go through this
+//! path at all (`nvidia-smi` is a subprocess, handled identically to
+//! Linux, and tried first).
 //!
 //! Detection runs at most once per process: [`detect_hardware`] caches its
 //! result in a `OnceLock`. Callers that don't need hardware data (a plain
@@ -47,6 +60,10 @@ pub enum GpuVendor {
     Nvidia,
     Amd,
     Apple,
+    /// Only ever produced by the Windows DXGI path (`detect_windows_dxgi`) -
+    /// none of this module's other sources (subprocess-based, per-vendor
+    /// tools) need a separate Intel case.
+    Intel,
     Other(String),
 }
 
@@ -245,11 +262,88 @@ fn parse_rocm_smi_json(stdout: &str) -> Option<GpuInfo> {
 }
 
 // ---------------------------------------------------------------------
-// AMD/Intel (Windows) - Win32 DXGI. See the module doc: a documented stub
-// for this phase, not a real implementation - no Windows target available
-// in this development environment to build or verify FFI bindings against.
+// AMD/Intel (Windows) - Win32 DXGI adapter enumeration. Only reached when
+// nvidia-smi/rocm-smi already found nothing - on Windows that's normally
+// "no NVIDIA GPU/driver present", so this path exists specifically for
+// AMD/Intel, which have no equivalent always-installed CLI tool the way
+// NVIDIA does. See the module doc for how this was verified (cross-compile
+// type-checked, not run against real hardware - no Windows machine in this
+// development environment).
 // ---------------------------------------------------------------------
 
+/// Maps a PCI vendor ID (`DXGI_ADAPTER_DESC1::VendorId`) to a `GpuVendor`.
+/// Pure and portable (no `windows` crate types) - only ever called from
+/// `detect_windows_dxgi` below, but kept compiled on every platform (not
+/// `#[cfg(target_os = "windows")]`) specifically so it's unit-testable from
+/// this crate's actual host target (Linux), not just type-checked via
+/// cross-compilation like the FFI call itself. IDs are the standard,
+/// long-stable PCI-SIG values for these three vendors; `Other` for anything
+/// else (a rarer GPU vendor a user might still have, or a virtualization/
+/// software adapter that slipped through the `DXGI_ADAPTER_FLAG_SOFTWARE`
+/// filter).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn gpu_vendor_from_pci_id(vendor_id: u32) -> GpuVendor {
+    match vendor_id {
+        0x10DE => GpuVendor::Nvidia,
+        0x1002 | 0x1022 => GpuVendor::Amd,
+        0x8086 => GpuVendor::Intel,
+        _ => GpuVendor::Other(format!("pci:{vendor_id:04x}")),
+    }
+}
+
+/// Trims a DXGI adapter description's fixed-size, NUL-padded UTF-16 buffer
+/// (`DXGI_ADAPTER_DESC1::Description: [u16; 128]`) down to its actual text.
+/// Pure and portable for the same reason as `gpu_vendor_from_pci_id` above.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn trim_dxgi_description(raw: &[u16]) -> String {
+    let end = raw.iter().position(|&c| c == 0).unwrap_or(raw.len());
+    String::from_utf16_lossy(&raw[..end])
+}
+
+#[cfg(target_os = "windows")]
+fn detect_windows_dxgi() -> Option<GpuInfo> {
+    use windows::Win32::Graphics::Dxgi::{
+        CreateDXGIFactory1, IDXGIFactory1, DXGI_ADAPTER_FLAG_SOFTWARE,
+    };
+
+    // Safety: `CreateDXGIFactory1`/`EnumAdapters1`/`GetDesc1` are ordinary
+    // COM calls with no preconditions beyond "DXGI is available" - failure
+    // (missing DXGI, no adapters, enumeration exhausted) is reported via
+    // `Result`/`HRESULT`, not UB, and is handled below as "detection found
+    // nothing" rather than a crash, same posture as every subprocess-based
+    // path in this module.
+    let factory: IDXGIFactory1 = unsafe { CreateDXGIFactory1() }.ok()?;
+
+    let mut index = 0u32;
+    loop {
+        let adapter = unsafe { factory.EnumAdapters1(index) }.ok()?;
+        index += 1;
+
+        let Ok(desc) = (unsafe { adapter.GetDesc1() }) else {
+            continue;
+        };
+        // Skip the software/"Microsoft Basic Render Driver" adapter DXGI
+        // always reports alongside real hardware - never what a user means
+        // by "my GPU".
+        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE.0 as u32) != 0 {
+            continue;
+        }
+
+        return Some(GpuInfo {
+            vendor: gpu_vendor_from_pci_id(desc.VendorId),
+            name: Some(trim_dxgi_description(&desc.Description)),
+            vram_total_bytes: Some(desc.DedicatedVideoMemory as u64),
+            // DXGI's static adapter description has no live utilization
+            // figure (matches nvidia-smi's own documented limitation for
+            // this path, per this phase's spec) - `vram_available_bytes`
+            // falls back to the full total, same as every other non-NVIDIA
+            // source in this module.
+            vram_used_bytes: None,
+        });
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
 fn detect_windows_dxgi() -> Option<GpuInfo> {
     None
 }
@@ -584,6 +678,41 @@ mod tests {
             assert!(out.status.success());
             assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
         }
+    }
+
+    // -- Windows DXGI helpers (portable, run on every platform's test suite
+    // even though `detect_windows_dxgi` itself only compiles for real on
+    // Windows - see the module doc's verification note) ---------------------
+
+    #[test]
+    fn gpu_vendor_from_pci_id_recognizes_the_three_named_vendors() {
+        assert_eq!(gpu_vendor_from_pci_id(0x10DE), GpuVendor::Nvidia);
+        assert_eq!(gpu_vendor_from_pci_id(0x1002), GpuVendor::Amd);
+        assert_eq!(gpu_vendor_from_pci_id(0x1022), GpuVendor::Amd);
+        assert_eq!(gpu_vendor_from_pci_id(0x8086), GpuVendor::Intel);
+    }
+
+    #[test]
+    fn gpu_vendor_from_pci_id_falls_back_to_other_for_an_unrecognized_id() {
+        assert_eq!(
+            gpu_vendor_from_pci_id(0xDEAD),
+            GpuVendor::Other("pci:dead".to_string())
+        );
+    }
+
+    #[test]
+    fn trim_dxgi_description_stops_at_the_first_nul() {
+        let mut raw = [0u16; 128];
+        for (i, c) in "AMD Radeon RX 7900 XTX".encode_utf16().enumerate() {
+            raw[i] = c;
+        }
+        assert_eq!(trim_dxgi_description(&raw), "AMD Radeon RX 7900 XTX");
+    }
+
+    #[test]
+    fn trim_dxgi_description_handles_a_buffer_with_no_nul_terminator() {
+        let raw: Vec<u16> = "no terminator".encode_utf16().collect();
+        assert_eq!(trim_dxgi_description(&raw), "no terminator");
     }
 
     // -- detect_hardware caching -------------------------------------------

--- a/src/llm/provider/llama_cpp_models.rs
+++ b/src/llm/provider/llama_cpp_models.rs
@@ -22,6 +22,19 @@ use tokio::sync::mpsc::UnboundedSender;
 /// models is far larger than anyone would default to in practice).
 const ESTIMATE_DEFAULT_CONTEXT_LENGTH: u64 = 8_192;
 
+/// Error-message prefixes this module's `bail!`/`with_context` sites
+/// produce, that `cli::llama_cpp_exit_code` (`src/cli/mod.rs`) matches
+/// against to pick `crustly llama-cpp`'s documented exit codes (11-13).
+/// Declared once and referenced by both the producing and matching sites
+/// (rather than each spelling out the literal separately) so the two
+/// cannot silently drift apart - a wording change here changes what
+/// `bail!` prints AND what the exit-code matcher looks for, in one edit,
+/// since there is exactly one place the text is written down.
+pub(crate) const DISK_SPACE_ERROR_PREFIX: &str = "Not enough disk space";
+pub(crate) const CHECKSUM_MISMATCH_ERROR_PREFIX: &str = "Checksum mismatch for";
+pub(crate) const DOWNLOAD_START_ERROR_PREFIX: &str = "Failed to start download from";
+pub(crate) const DOWNLOAD_FAILED_ERROR_PREFIX: &str = "Download failed for";
+
 /// The context length used for a memory estimate: `native` capped at
 /// [`ESTIMATE_DEFAULT_CONTEXT_LENGTH`], or that default when `native` is
 /// `None` (header didn't set one) - the exact rule Phase M12's fit
@@ -266,13 +279,50 @@ pub fn list_all_local_models(
     extra_model_paths: &[PathBuf],
     ollama_models_dir: Option<&Path>,
 ) -> Result<Vec<LocalGgufModel>> {
-    let mut models = list_local_models(models_dir)?;
-    for extra in extra_model_paths {
-        models.extend(list_local_models(extra)?);
+    // Each source is an independent directory scan / manifest-tree walk
+    // (its own `read_dir` plus one GGUF header parse per file found) with
+    // no data dependency on any other source - run them concurrently
+    // rather than sequentially, per this project's own documented
+    // parallel-dispatch convention for independent work (CLAUDE.md).
+    // `std::thread::scope` lets each closure borrow `extra_model_paths`/
+    // `ollama_models_dir` directly rather than needing owned clones for a
+    // detached `thread::spawn`; this function is already synchronous and
+    // meant to be called off the async runtime (`spawn_blocking`), so
+    // blocking the calling thread on `scope`'s join is the expected cost
+    // here, same as it already was for the un-parallelized version.
+    let (models_dir_result, extra_results, ollama_models) = std::thread::scope(|scope| {
+        let models_dir_handle = scope.spawn(|| list_local_models(models_dir));
+        let extra_handles: Vec<_> = extra_model_paths
+            .iter()
+            .map(|extra| scope.spawn(|| list_local_models(extra)))
+            .collect();
+        let ollama_handle = ollama_models_dir.map(|dir| scope.spawn(|| list_ollama_models(dir)));
+
+        let models_dir_result = models_dir_handle
+            .join()
+            .unwrap_or_else(|_| Err(anyhow::anyhow!("models_dir scan thread panicked")));
+        let extra_results: Vec<Result<Vec<LocalGgufModel>>> = extra_handles
+            .into_iter()
+            .map(|h| {
+                h.join().unwrap_or_else(|_| {
+                    Err(anyhow::anyhow!("extra_model_paths scan thread panicked"))
+                })
+            })
+            .collect();
+        // Best-effort, same as the un-parallelized version: a panicked or
+        // errored Ollama scan just means "nothing found there."
+        let ollama_models = ollama_handle
+            .and_then(|h| h.join().ok())
+            .unwrap_or_default();
+
+        (models_dir_result, extra_results, ollama_models)
+    });
+
+    let mut models = models_dir_result?;
+    for extra_result in extra_results {
+        models.extend(extra_result?);
     }
-    if let Some(ollama_dir) = ollama_models_dir {
-        models.extend(list_ollama_models(ollama_dir));
-    }
+    models.extend(ollama_models);
 
     let models = deduplicate_and_merge(models);
     let mut models = pair_mmproj_files(models);
@@ -590,10 +640,18 @@ fn merge_split_gguf_groups(models: Vec<LocalGgufModel>) -> Vec<LocalGgufModel> {
 
         let (_parent, base, _total) = key;
         let summed_size = parts.iter().map(|p| p.size_bytes).sum();
+        // `parts` is already sorted by part index ascending (above), so
+        // `.find()` - not `.max_by_key()` - is what "prefer the lowest-index
+        // part that actually has a header" means: `max_by_key` breaks ties
+        // by keeping the *last* matching element, which silently preferred
+        // the highest-index part with a parsed header on any tie (realistic:
+        // llama.cpp's own `gguf-split` duplicates the full metadata KV
+        // section into every shard, not just the first). `.unwrap_or(0)`
+        // falls back to part 1 only when *no* part has a header at all.
         let template_index = parts
             .iter()
             .enumerate()
-            .max_by_key(|(_, m)| m.architecture.is_some())
+            .find(|(_, m)| m.architecture.is_some())
             .map(|(i, _)| i)
             .unwrap_or(0);
         let canonical_path = parts[0].path.clone();
@@ -914,7 +972,7 @@ fn check_disk_space(
     const SAFETY_MARGIN_BYTES: u64 = 512 * 1024 * 1024;
     if available < still_needed.saturating_add(SAFETY_MARGIN_BYTES) {
         anyhow::bail!(
-            "Not enough disk space to download '{filename}': need ~{:.2} GB (plus a safety \
+            "{DISK_SPACE_ERROR_PREFIX} to download '{filename}': need ~{:.2} GB (plus a safety \
              margin) but only ~{:.2} GB free at {}",
             still_needed as f64 / 1_073_741_824.0,
             available as f64 / 1_073_741_824.0,
@@ -974,9 +1032,9 @@ pub async fn download_model(
     let response = request
         .send()
         .await
-        .with_context(|| format!("Failed to start download from {url}"))?
+        .with_context(|| format!("{DOWNLOAD_START_ERROR_PREFIX} {url}"))?
         .error_for_status()
-        .with_context(|| format!("Download failed for {url}"))?;
+        .with_context(|| format!("{DOWNLOAD_FAILED_ERROR_PREFIX} {url}"))?;
 
     // A 206 confirms the server actually honored the `Range` request - a
     // server that ignores it and sends 200 (full content) falls through to
@@ -1072,7 +1130,7 @@ pub async fn download_model(
         if !actual.eq_ignore_ascii_case(expected) {
             let _ = tokio::fs::remove_file(&partial_path).await;
             anyhow::bail!(
-                "Checksum mismatch for {filename}: expected {expected}, got {actual}. \
+                "{CHECKSUM_MISMATCH_ERROR_PREFIX} {filename}: expected {expected}, got {actual}. \
                  The partial download has been deleted."
             );
         }
@@ -1786,6 +1844,47 @@ mod tests {
                 .ends_with("big-model-00001-of-00003.gguf"),
             "the canonical path should be the lowest-found part"
         );
+    }
+
+    #[test]
+    fn merge_split_gguf_groups_prefers_the_first_part_with_a_parsed_header_on_a_tie() {
+        // Realistic per M11's own review: llama.cpp's `gguf-split` tool
+        // duplicates the full metadata KV section into every output shard,
+        // not just the first - so more than one part can have
+        // `architecture.is_some()`. The lowest-index part must still win.
+        let dir = PathBuf::from("/models");
+        let mut part1 = fixture_model("big-model-00001-of-00002", None);
+        part1.path = dir.join("big-model-00001-of-00002.gguf");
+        part1.architecture = Some("part1-arch".to_string());
+        let mut part2 = fixture_model("big-model-00002-of-00002", None);
+        part2.path = dir.join("big-model-00002-of-00002.gguf");
+        part2.architecture = Some("part2-arch".to_string());
+
+        let merged = merge_split_gguf_groups(vec![part1, part2]);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(
+            merged[0].architecture.as_deref(),
+            Some("part1-arch"),
+            "the lowest-index part with a parsed header must win the tie, not the last"
+        );
+    }
+
+    #[test]
+    fn merge_split_gguf_groups_falls_back_to_part_one_when_no_part_has_a_header() {
+        let dir = PathBuf::from("/models");
+        let mut part1 = fixture_model("big-model-00001-of-00002", None);
+        part1.path = dir.join("big-model-00001-of-00002.gguf");
+        let mut part2 = fixture_model("big-model-00002-of-00002", None);
+        part2.path = dir.join("big-model-00002-of-00002.gguf");
+
+        let merged = merge_split_gguf_groups(vec![part1, part2]);
+
+        assert_eq!(merged.len(), 1);
+        assert!(merged[0]
+            .path
+            .to_string_lossy()
+            .ends_with("big-model-00001-of-00002.gguf"));
     }
 
     #[test]

--- a/src/llm/provider/llama_cpp_models.rs
+++ b/src/llm/provider/llama_cpp_models.rs
@@ -7,10 +7,20 @@
 
 use anyhow::{Context, Result};
 use futures::StreamExt as _;
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt as _;
 use tokio::sync::mpsc::UnboundedSender;
+
+/// Context length used for `list_local_models`'s memory estimate when a
+/// model's own header doesn't set one (or sets an implausibly large one) -
+/// matches `default_llama_cpp_n_ctx()` (`src/config/mod.rs`), so the
+/// estimate reflects what a freshly-configured provider would actually
+/// allocate, not the model's full trained context (which for some modern
+/// models is far larger than anyone would default to in practice).
+const ESTIMATE_DEFAULT_CONTEXT_LENGTH: u64 = 8_192;
 
 /// A locally-present `.gguf` file - the llama.cpp equivalent of
 /// `ollama_models::LocalModelInfo` (which reports installed models via
@@ -45,6 +55,27 @@ pub struct LocalGgufModel {
     /// found" - this field is advisory display data, not something callers
     /// branch safety-critical behavior on.
     pub has_chat_template: bool,
+    /// A name to display instead of `path`'s filename, when the filename
+    /// itself isn't meaningful - e.g. an Ollama-sourced entry's real path
+    /// is a content-addressed blob (`sha256-<hex>`), so this carries the
+    /// manifest's own `name:tag`. Comma-joined when more than one manifest
+    /// tag resolves to the identical blob. `None` for ordinary
+    /// filesystem-scanned entries, where the filename already is the
+    /// name; callers fall back to `path`'s filename in that case, exactly
+    /// as they did before this field existed.
+    pub display_name: Option<String>,
+    /// Estimated resident memory (weights + KV cache when the header has
+    /// enough geometry) at `ESTIMATE_DEFAULT_CONTEXT_LENGTH` tokens, or the
+    /// header's own native context length if smaller. `None` if
+    /// `parameter_count`/`quantization_hint` weren't determined - see
+    /// `gguf_metadata::estimate_memory_bytes`'s doc comment for the
+    /// "order-of-magnitude, not a guarantee" framing.
+    pub estimated_memory_bytes: Option<u64>,
+    /// Whether `estimated_memory_bytes` includes the KV-cache term.
+    /// `false` when the header lacked the attention geometry to compute
+    /// it, in which case the estimate covers weights only - meaningless
+    /// when `estimated_memory_bytes` is `None`.
+    pub estimated_memory_includes_kv_cache: bool,
 }
 
 /// One progress update from an in-flight `download_model` transfer. The
@@ -130,6 +161,14 @@ pub fn list_local_models(models_dir: &Path) -> Result<Vec<LocalGgufModel>> {
                     .and_then(quantization_hint_from_filename)
             });
 
+        let estimate = header.as_ref().and_then(|h| {
+            let ctx = h
+                .context_length
+                .map(|native| native.min(ESTIMATE_DEFAULT_CONTEXT_LENGTH))
+                .unwrap_or(ESTIMATE_DEFAULT_CONTEXT_LENGTH);
+            super::gguf_metadata::estimate_memory_bytes(h, ctx)
+        });
+
         models.push(LocalGgufModel {
             path,
             size_bytes: fs_metadata.len(),
@@ -139,11 +178,371 @@ pub fn list_local_models(models_dir: &Path) -> Result<Vec<LocalGgufModel>> {
             parameter_count: header.as_ref().and_then(|h| h.parameter_count),
             context_length: header.as_ref().and_then(|h| h.context_length),
             has_chat_template: header.as_ref().is_some_and(|h| h.has_chat_template),
+            display_name: None,
+            estimated_memory_bytes: estimate.map(|e| e.total_bytes),
+            estimated_memory_includes_kv_cache: estimate.is_some_and(|e| e.includes_kv_cache),
         });
     }
 
     models.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(models)
+}
+
+/// Scan every configured source and merge the results: `models_dir`,
+/// `extra_model_paths`, and (when `ollama_models_dir` is `Some` -
+/// `Config::providers::llama_cpp_ollama_models_dir()` already gates this on
+/// the `scan_ollama_models` opt-in) Ollama's manifest tree. This is the
+/// entry point the CLI and TUI should use instead of `list_local_models`
+/// directly; `list_local_models` itself is unchanged (still a single
+/// directory, still what this function calls per source).
+///
+/// A failure scanning one `extra_model_paths` entry fails the whole call
+/// (same "surface real errors" posture `list_local_models` already has for
+/// its one directory) - but the Ollama scan is best-effort and never fails
+/// the call, since a missing/unreadable manifest tree just means "nothing
+/// found there," not a problem with the directories the user explicitly
+/// configured.
+pub fn list_all_local_models(
+    models_dir: &Path,
+    extra_model_paths: &[PathBuf],
+    ollama_models_dir: Option<&Path>,
+) -> Result<Vec<LocalGgufModel>> {
+    let mut models = list_local_models(models_dir)?;
+    for extra in extra_model_paths {
+        models.extend(list_local_models(extra)?);
+    }
+    if let Some(ollama_dir) = ollama_models_dir {
+        models.extend(list_ollama_models(ollama_dir));
+    }
+
+    let mut models = deduplicate_and_merge(models);
+    models.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(models)
+}
+
+/// One layer entry in an Ollama manifest's `layers` array.
+#[derive(Debug, Deserialize)]
+struct OllamaManifestLayer {
+    #[serde(rename = "mediaType")]
+    media_type: String,
+    digest: String,
+}
+
+/// The subset of an Ollama manifest's JSON this module reads. Verified
+/// against Ollama's own source (`server/manifest.go`/`server/images.go`,
+/// `types/model/name.go`) rather than assumed - see
+/// `ccguf-managment-imrpoment-plan.md` Phase M3.
+#[derive(Debug, Deserialize)]
+struct OllamaManifest {
+    layers: Vec<OllamaManifestLayer>,
+}
+
+/// The GGUF model-weights layer's media type - distinct from
+/// `application/vnd.ollama.image.projector` (mmproj, out of scope until
+/// Phase M5), `.../adapter`, `.../template`, `.../license`, etc.
+const OLLAMA_MODEL_LAYER_MEDIA_TYPE: &str = "application/vnd.ollama.image.model";
+
+/// Discover models Ollama has already pulled by reading its manifest tree
+/// at `<ollama_models_dir>/manifests/{host}/{namespace}/{model}/{tag}` -
+/// always exactly 4 path components deep (verified against Ollama's
+/// `Filepath()` layout), so a fixed 4-level `read_dir` nest finds every
+/// manifest without a general recursive walker. Each manifest resolves to
+/// its model-weights blob (`<ollama_models_dir>/blobs/sha256-<hex>`, colon
+/// replaced with a dash - verified against Ollama's own blob-naming code)
+/// and a human-readable `display_name` reconstructed from the manifest's
+/// own path, not guessed from the blob's content-addressed filename.
+///
+/// Best-effort: a missing `manifests/` directory returns an empty list (not
+/// an error - this is likely just "Ollama isn't installed" or "opted in
+/// without Ollama ever having pulled anything"); an individual unreadable
+/// or malformed manifest, or one whose blob is missing (pruned since the
+/// manifest was written), is skipped rather than failing the whole scan.
+fn list_ollama_models(ollama_models_dir: &Path) -> Vec<LocalGgufModel> {
+    let manifests_root = ollama_models_dir.join("manifests");
+    let blobs_root = ollama_models_dir.join("blobs");
+
+    walk_ollama_manifest_files(&manifests_root)
+        .into_iter()
+        .filter_map(|manifest_path| {
+            parse_ollama_manifest(&manifest_path, &manifests_root, &blobs_root)
+        })
+        .collect()
+}
+
+/// Fixed 4-level directory walk (`host/namespace/model/tag`) - deliberately
+/// not a general recursive walker: Ollama's manifest layout is always
+/// exactly this deep, so this is both simpler and immune to the
+/// symlink-loop/unbounded-depth concerns a generic walker would need to
+/// guard against.
+fn walk_ollama_manifest_files(manifests_root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(hosts) = std::fs::read_dir(manifests_root) else {
+        return files;
+    };
+    for host in hosts.flatten() {
+        let Ok(namespaces) = std::fs::read_dir(host.path()) else {
+            continue;
+        };
+        for namespace in namespaces.flatten() {
+            let Ok(models) = std::fs::read_dir(namespace.path()) else {
+                continue;
+            };
+            for model in models.flatten() {
+                let Ok(tags) = std::fs::read_dir(model.path()) else {
+                    continue;
+                };
+                for tag in tags.flatten() {
+                    let path = tag.path();
+                    if path.is_file() {
+                        files.push(path);
+                    }
+                }
+            }
+        }
+    }
+    files
+}
+
+/// Parse one manifest file into a `LocalGgufModel`. `None` on any problem
+/// (unreadable, malformed JSON, no model layer, unresolvable digest,
+/// missing blob, or a path that isn't the expected 4 components deep under
+/// `manifests_root`) - the caller (`list_ollama_models`) treats that as
+/// "skip this one," not a hard failure.
+fn parse_ollama_manifest(
+    manifest_path: &Path,
+    manifests_root: &Path,
+    blobs_root: &Path,
+) -> Option<LocalGgufModel> {
+    let bytes = std::fs::read(manifest_path).ok()?;
+    let manifest: OllamaManifest = serde_json::from_slice(&bytes).ok()?;
+    let model_layer = manifest
+        .layers
+        .iter()
+        .find(|l| l.media_type == OLLAMA_MODEL_LAYER_MEDIA_TYPE)?;
+
+    let hex_digest = model_layer.digest.strip_prefix("sha256:")?;
+    if hex_digest.is_empty() || !hex_digest.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let blob_path = blobs_root.join(format!("sha256-{hex_digest}"));
+    let fs_metadata = std::fs::metadata(&blob_path).ok()?; // also confirms the blob exists
+
+    let rel = manifest_path.strip_prefix(manifests_root).ok()?;
+    let parts: Vec<&str> = rel
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+    let [_host, namespace, model, tag] = parts[..] else {
+        return None;
+    };
+    let display_name = if namespace == "library" {
+        format!("{model}:{tag}")
+    } else {
+        format!("{namespace}/{model}:{tag}")
+    };
+
+    let modified_at = fs_metadata
+        .modified()
+        .ok()
+        .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339())
+        .unwrap_or_default();
+
+    // An Ollama blob's own bytes are a plain GGUF file - the same header
+    // parser applies directly, no Ollama-specific decoding needed for the
+    // model's own contents.
+    let header = super::gguf_metadata::read_gguf_metadata(&blob_path);
+    let quantization_hint = header.as_ref().and_then(|h| h.quantization.clone());
+    let estimate = header.as_ref().and_then(|h| {
+        let ctx = h
+            .context_length
+            .map(|native| native.min(ESTIMATE_DEFAULT_CONTEXT_LENGTH))
+            .unwrap_or(ESTIMATE_DEFAULT_CONTEXT_LENGTH);
+        super::gguf_metadata::estimate_memory_bytes(h, ctx)
+    });
+
+    Some(LocalGgufModel {
+        path: blob_path,
+        size_bytes: fs_metadata.len(),
+        modified_at,
+        quantization_hint,
+        architecture: header.as_ref().and_then(|h| h.architecture.clone()),
+        parameter_count: header.as_ref().and_then(|h| h.parameter_count),
+        context_length: header.as_ref().and_then(|h| h.context_length),
+        has_chat_template: header.as_ref().is_some_and(|h| h.has_chat_template),
+        display_name: Some(display_name),
+        estimated_memory_bytes: estimate.map(|e| e.total_bytes),
+        estimated_memory_includes_kv_cache: estimate.is_some_and(|e| e.includes_kv_cache),
+    })
+}
+
+/// Detects the `<base>-00001-of-00005.gguf` split-file naming convention
+/// (both numbers zero-padded to the same width, per
+/// `ccguf-managment-imrpoment-plan.md` Phase M4). Pure string parsing, no
+/// regex dependency needed. Returns `(base, part_index, total_parts)` -
+/// `part_index` is 1-based, matching the filename's own convention. `None`
+/// if `filename` doesn't match (including a width mismatch between the two
+/// numbers, which the convention requires).
+fn parse_split_gguf_filename(filename: &str) -> Option<(&str, u32, u32)> {
+    let stem = filename.strip_suffix(".gguf")?;
+    let of_pos = stem.rfind("-of-")?;
+    let (before_of, total_str) = (&stem[..of_pos], &stem[of_pos + 4..]);
+    if total_str.is_empty() || !total_str.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let dash_pos = before_of.rfind('-')?;
+    let (base, part_str) = (&before_of[..dash_pos], &before_of[dash_pos + 1..]);
+    if part_str.len() != total_str.len() || !part_str.bytes().all(|b| b.is_ascii_digit()) {
+        return None; // widths must match - that's the whole convention
+    }
+
+    let part: u32 = part_str.parse().ok()?;
+    let total: u32 = total_str.parse().ok()?;
+    if part == 0 || part > total {
+        return None;
+    }
+    Some((base, part, total))
+}
+
+/// Post-process a merged listing from `list_all_local_models`'s sources:
+///
+/// 1. **Canonical-path dedup** - the same underlying file reached two ways
+///    (a symlink in one scanned directory pointing at a file already found
+///    via another, or two Ollama manifest tags pointing at the identical
+///    blob) collapses to one entry. `display_name`s combine
+///    (comma-joined) rather than one being silently dropped; the entry
+///    with the richer header (`architecture.is_some()`, first-seen as a
+///    tiebreak) "wins" for the other fields. Sizes are **not** summed here
+///    - it's the same file counted once, not two files.
+/// 2. **Split-GGUF grouping** - `-00001-of-00005.gguf`-convention parts
+///    collapse into one logical entry: canonical `path` is the
+///    lowest-found part index (GGUF's split convention puts the real
+///    header/metadata in part 1; later shards carry only bookkeeping
+///    keys), `size_bytes` is **summed** (these are genuinely separate
+///    files), `display_name` is the base name, and metadata comes from
+///    whichever found part has it (same "richest wins" rule) - a partial
+///    download (not all parts present yet) is handled honestly rather
+///    than requiring completeness.
+///
+/// `O(n²)` over the input - the expected entry count (tens, not thousands
+/// of models on one machine) doesn't justify a hash-based grouping
+/// implementation's added complexity here.
+fn deduplicate_and_merge(models: Vec<LocalGgufModel>) -> Vec<LocalGgufModel> {
+    let by_canonical_path = merge_by_canonical_path(models);
+    merge_split_gguf_groups(by_canonical_path)
+}
+
+/// True if `richer` has more identifying header data than `current` -
+/// the tiebreak `deduplicate_and_merge`'s two passes both use to decide
+/// which of two entries for "the same logical model" supplies the
+/// metadata fields on the merged result.
+fn is_richer(candidate: &LocalGgufModel, current: &LocalGgufModel) -> bool {
+    candidate.architecture.is_some() && current.architecture.is_none()
+}
+
+fn merge_by_canonical_path(models: Vec<LocalGgufModel>) -> Vec<LocalGgufModel> {
+    let mut by_path: HashMap<PathBuf, LocalGgufModel> = HashMap::new();
+    let mut order: Vec<PathBuf> = Vec::new();
+
+    for model in models {
+        let key = std::fs::canonicalize(&model.path).unwrap_or_else(|_| model.path.clone());
+        match by_path.get_mut(&key) {
+            None => {
+                order.push(key.clone());
+                by_path.insert(key, model);
+            }
+            Some(existing) => {
+                let merged_display_name = match (&existing.display_name, &model.display_name) {
+                    (Some(a), Some(b)) if a != b => Some(format!("{a}, {b}")),
+                    (Some(a), _) => Some(a.clone()),
+                    (None, Some(b)) => Some(b.clone()),
+                    (None, None) => None,
+                };
+                if is_richer(&model, existing) {
+                    let display_name = merged_display_name;
+                    *existing = LocalGgufModel {
+                        display_name,
+                        ..model
+                    };
+                } else {
+                    existing.display_name = merged_display_name;
+                }
+            }
+        }
+    }
+
+    order
+        .into_iter()
+        .filter_map(|key| by_path.remove(&key))
+        .collect()
+}
+
+fn merge_split_gguf_groups(models: Vec<LocalGgufModel>) -> Vec<LocalGgufModel> {
+    let mut groups: HashMap<(PathBuf, String, u32), Vec<LocalGgufModel>> = HashMap::new();
+    let mut order: Vec<(PathBuf, String, u32)> = Vec::new();
+    let mut passthrough: Vec<LocalGgufModel> = Vec::new();
+
+    for model in models {
+        let filename = model
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_string);
+        let parent = model
+            .path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_default();
+        let split = filename
+            .as_deref()
+            .and_then(parse_split_gguf_filename)
+            .map(|(base, part, total)| (base.to_string(), part, total));
+
+        match split {
+            None => passthrough.push(model),
+            Some((base, _part, total)) => {
+                let key = (parent, base, total);
+                if !groups.contains_key(&key) {
+                    order.push(key.clone());
+                }
+                groups.entry(key).or_default().push(model);
+            }
+        }
+    }
+
+    let mut result = passthrough;
+    for key in order {
+        let Some(mut parts) = groups.remove(&key) else {
+            continue;
+        };
+        parts.sort_by_key(|m| {
+            m.path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .and_then(parse_split_gguf_filename)
+                .map(|(_, part, _)| part)
+                .unwrap_or(u32::MAX)
+        });
+
+        let (_parent, base, _total) = key;
+        let summed_size = parts.iter().map(|p| p.size_bytes).sum();
+        let template_index = parts
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, m)| m.architecture.is_some())
+            .map(|(i, _)| i)
+            .unwrap_or(0);
+        let canonical_path = parts[0].path.clone();
+        let modified_at = parts[0].modified_at.clone();
+        let mut merged = parts[template_index].clone();
+        merged.path = canonical_path;
+        merged.modified_at = modified_at;
+        merged.size_bytes = summed_size;
+        merged.display_name = Some(format!("{base}.gguf"));
+
+        result.push(merged);
+    }
+
+    result
 }
 
 /// Parse an `hf:org/repo/file.gguf` shorthand into its parts. Pure
@@ -477,5 +876,320 @@ mod tests {
         });
 
         format!("http://{addr}")
+    }
+
+    // --- M3: multi-source discovery ---
+
+    #[test]
+    fn list_all_local_models_merges_models_dir_and_extra_paths() {
+        let primary = tempfile::tempdir().expect("tempdir");
+        let extra = tempfile::tempdir().expect("tempdir");
+        std::fs::write(primary.path().join("a.gguf"), b"gguf a").expect("write a");
+        std::fs::write(extra.path().join("b.gguf"), b"gguf b").expect("write b");
+
+        let models = list_all_local_models(primary.path(), &[extra.path().to_path_buf()], None)
+            .expect("list");
+
+        let names: Vec<_> = models
+            .iter()
+            .map(|m| m.path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(models.len(), 2);
+        assert!(names.contains(&"a.gguf".to_string()));
+        assert!(names.contains(&"b.gguf".to_string()));
+    }
+
+    #[test]
+    fn list_all_local_models_with_no_ollama_dir_does_not_scan_ollama() {
+        let primary = tempfile::tempdir().expect("tempdir");
+        std::fs::write(primary.path().join("a.gguf"), b"gguf a").expect("write a");
+
+        let models = list_all_local_models(primary.path(), &[], None).expect("list");
+        assert_eq!(models.len(), 1);
+    }
+
+    // --- M3: Ollama manifest discovery ---
+
+    /// Builds a fake `<root>/manifests/<host>/<namespace>/<model>/<tag>`
+    /// manifest file naming `hex_digest` as its model layer, plus the
+    /// matching `<root>/blobs/sha256-<hex_digest>` blob file with
+    /// `blob_body` as its content.
+    fn write_fake_ollama_model(
+        root: &Path,
+        host: &str,
+        namespace: &str,
+        model: &str,
+        tag: &str,
+        hex_digest: &str,
+        blob_body: &[u8],
+    ) {
+        let manifest_dir = root
+            .join("manifests")
+            .join(host)
+            .join(namespace)
+            .join(model);
+        std::fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+        let manifest_json = format!(
+            r#"{{"schemaVersion":2,"layers":[
+                {{"mediaType":"application/vnd.ollama.image.model","digest":"sha256:{hex_digest}","size":{size}}},
+                {{"mediaType":"application/vnd.ollama.image.template","digest":"sha256:{hex_digest}","size":1}}
+            ]}}"#,
+            size = blob_body.len()
+        );
+        std::fs::write(manifest_dir.join(tag), manifest_json).expect("write manifest");
+
+        let blobs_dir = root.join("blobs");
+        std::fs::create_dir_all(&blobs_dir).expect("create blobs dir");
+        std::fs::write(blobs_dir.join(format!("sha256-{hex_digest}")), blob_body)
+            .expect("write blob");
+    }
+
+    const FAKE_DIGEST_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn list_ollama_models_resolves_library_namespace_display_name() {
+        let root = tempfile::tempdir().expect("tempdir");
+        write_fake_ollama_model(
+            root.path(),
+            "registry.ollama.ai",
+            "library",
+            "qwen2.5-coder",
+            "7b",
+            FAKE_DIGEST_A,
+            b"fake gguf blob content",
+        );
+
+        let models = list_ollama_models(root.path());
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].display_name.as_deref(),
+            Some("qwen2.5-coder:7b"),
+            "the default 'library' namespace is omitted, matching Ollama's own display convention"
+        );
+        assert_eq!(models[0].size_bytes, "fake gguf blob content".len() as u64);
+    }
+
+    #[test]
+    fn list_ollama_models_keeps_non_library_namespace_in_display_name() {
+        let root = tempfile::tempdir().expect("tempdir");
+        write_fake_ollama_model(
+            root.path(),
+            "registry.ollama.ai",
+            "myorg",
+            "custom-model",
+            "v1",
+            FAKE_DIGEST_A,
+            b"fake gguf blob content",
+        );
+
+        let models = list_ollama_models(root.path());
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].display_name.as_deref(),
+            Some("myorg/custom-model:v1")
+        );
+    }
+
+    #[test]
+    fn list_ollama_models_on_missing_manifests_dir_returns_empty_not_error() {
+        let root = tempfile::tempdir().expect("tempdir");
+        assert!(list_ollama_models(root.path()).is_empty());
+    }
+
+    #[test]
+    fn list_ollama_models_skips_a_manifest_whose_blob_is_missing() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let manifest_dir = root
+            .path()
+            .join("manifests")
+            .join("registry.ollama.ai")
+            .join("library")
+            .join("pruned-model");
+        std::fs::create_dir_all(&manifest_dir).expect("create manifest dir");
+        std::fs::write(
+            manifest_dir.join("latest"),
+            format!(
+                r#"{{"layers":[{{"mediaType":"application/vnd.ollama.image.model","digest":"sha256:{FAKE_DIGEST_A}","size":1}}]}}"#
+            ),
+        )
+        .expect("write manifest");
+        // Deliberately no matching blob file written.
+
+        assert!(list_ollama_models(root.path()).is_empty());
+    }
+
+    #[test]
+    fn list_all_local_models_merges_two_manifest_tags_sharing_one_blob() {
+        let root = tempfile::tempdir().expect("tempdir");
+        write_fake_ollama_model(
+            root.path(),
+            "registry.ollama.ai",
+            "library",
+            "qwen2.5-coder",
+            "7b",
+            FAKE_DIGEST_A,
+            b"shared blob content",
+        );
+        write_fake_ollama_model(
+            root.path(),
+            "registry.ollama.ai",
+            "library",
+            "qwen2.5-coder",
+            "latest",
+            FAKE_DIGEST_A, // same digest as above - the identical blob, two tags
+            b"shared blob content",
+        );
+
+        let empty_dir = tempfile::tempdir().expect("tempdir");
+        let models = list_all_local_models(empty_dir.path(), &[], Some(root.path())).expect("list");
+
+        assert_eq!(
+            models.len(),
+            1,
+            "two tags pointing at the identical blob must collapse to one entry"
+        );
+        let name = models[0].display_name.as_deref().unwrap_or_default();
+        assert!(name.contains("qwen2.5-coder:7b"));
+        assert!(name.contains("qwen2.5-coder:latest"));
+        assert_eq!(
+            models[0].size_bytes,
+            "shared blob content".len() as u64,
+            "size must not be double-counted for the same underlying blob"
+        );
+    }
+
+    // --- M4: symlink dedup ---
+
+    #[cfg(unix)]
+    #[test]
+    fn list_all_local_models_collapses_a_symlink_to_an_already_found_file() {
+        let primary = tempfile::tempdir().expect("tempdir");
+        let extra = tempfile::tempdir().expect("tempdir");
+        let real_path = primary.path().join("real-model.gguf");
+        std::fs::write(&real_path, b"gguf content").expect("write real file");
+        std::os::unix::fs::symlink(&real_path, extra.path().join("real-model.gguf"))
+            .expect("create symlink");
+
+        let models = list_all_local_models(primary.path(), &[extra.path().to_path_buf()], None)
+            .expect("list");
+
+        assert_eq!(
+            models.len(),
+            1,
+            "a symlink to an already-discovered file must not double-count it"
+        );
+        assert_eq!(models[0].size_bytes, "gguf content".len() as u64);
+    }
+
+    // --- M4: split-GGUF filename parsing and grouping ---
+
+    #[test]
+    fn parse_split_gguf_filename_matches_the_convention() {
+        assert_eq!(
+            parse_split_gguf_filename("model-00001-of-00005.gguf"),
+            Some(("model", 1, 5))
+        );
+        assert_eq!(
+            parse_split_gguf_filename("Qwen-235B-00012-of-00030.gguf"),
+            Some(("Qwen-235B", 12, 30))
+        );
+    }
+
+    #[test]
+    fn parse_split_gguf_filename_rejects_mismatched_widths() {
+        // "1" (1 digit) vs "00005" (5 digits) - the convention requires
+        // equal-width zero-padding on both sides.
+        assert_eq!(parse_split_gguf_filename("model-1-of-00005.gguf"), None);
+    }
+
+    #[test]
+    fn parse_split_gguf_filename_rejects_non_split_names_and_out_of_range_parts() {
+        for name in [
+            "model.gguf",
+            "model-Q4_K_M.gguf",
+            "model-of-00005.gguf",       // no part number before "-of-"
+            "model-00000-of-00005.gguf", // part 0 is out of range (1-based)
+            "model-00006-of-00005.gguf", // part exceeds total
+        ] {
+            assert_eq!(
+                parse_split_gguf_filename(name),
+                None,
+                "should reject: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn list_all_local_models_collapses_a_split_gguf_group() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("big-model-00001-of-00003.gguf"),
+            b"part one",
+        )
+        .expect("write part 1");
+        std::fs::write(
+            dir.path().join("big-model-00002-of-00003.gguf"),
+            b"part two!",
+        )
+        .expect("write part 2");
+        std::fs::write(
+            dir.path().join("big-model-00003-of-00003.gguf"),
+            b"part three!!",
+        )
+        .expect("write part 3");
+
+        let models = list_all_local_models(dir.path(), &[], None).expect("list");
+
+        assert_eq!(models.len(), 1, "three parts must collapse to one entry");
+        assert_eq!(models[0].display_name.as_deref(), Some("big-model.gguf"));
+        assert_eq!(
+            models[0].size_bytes,
+            b"part one".len() as u64 + b"part two!".len() as u64 + b"part three!!".len() as u64
+        );
+        assert!(
+            models[0]
+                .path
+                .to_string_lossy()
+                .ends_with("big-model-00001-of-00003.gguf"),
+            "the canonical path should be the lowest-found part"
+        );
+    }
+
+    #[test]
+    fn list_all_local_models_handles_a_partial_split_group_honestly() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Only part 2 of 3 is present - e.g. an interrupted multi-part
+        // download.
+        std::fs::write(
+            dir.path().join("big-model-00002-of-00003.gguf"),
+            b"part two!",
+        )
+        .expect("write part 2");
+
+        let models = list_all_local_models(dir.path(), &[], None).expect("list");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].size_bytes, b"part two!".len() as u64);
+        assert!(
+            models[0]
+                .path
+                .to_string_lossy()
+                .ends_with("big-model-00002-of-00003.gguf"),
+            "with only one part found, it is its own canonical path"
+        );
+    }
+
+    #[test]
+    fn list_all_local_models_does_not_group_unrelated_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("model-a.gguf"), b"a").expect("write a");
+        std::fs::write(dir.path().join("model-b.gguf"), b"b").expect("write b");
+
+        let models = list_all_local_models(dir.path(), &[], None).expect("list");
+        assert_eq!(
+            models.len(),
+            2,
+            "ordinary unrelated files must stay separate"
+        );
     }
 }

--- a/src/llm/provider/llama_cpp_models.rs
+++ b/src/llm/provider/llama_cpp_models.rs
@@ -20,11 +20,31 @@ pub struct LocalGgufModel {
     pub path: PathBuf,
     pub size_bytes: u64,
     pub modified_at: String,
-    /// Best-effort guess from the filename convention (e.g. "Q4_K_M",
-    /// "Q8_0") when GGUF header metadata isn't read. `None` if nothing
-    /// matches - displayed as "unknown" by callers rather than guessed
-    /// further.
+    /// Best-effort quantization label, layered: the GGUF header's
+    /// `general.file_type` (precise, e.g. "Q4_K_M") when readable, else the
+    /// header's per-tensor type mode (coarser, e.g. "Q4_K"), else a
+    /// filename-convention guess (e.g. spotting "Q4_K_M" as a substring of
+    /// the filename) when the header itself can't be read at all. `None`
+    /// only if none of those three sources produced anything - displayed as
+    /// "unknown" by callers rather than guessed further. See
+    /// `crate::llm::provider::gguf_metadata` for the header parser.
     pub quantization_hint: Option<String>,
+    /// GGUF `general.architecture` (e.g. "llama", "qwen2"). `None` if the
+    /// header couldn't be read or didn't set it.
+    pub architecture: Option<String>,
+    /// Total scalar weight count, summed across the header's tensor-info
+    /// dimensions - independent of quantization. `None` if the header
+    /// couldn't be read.
+    pub parameter_count: Option<u64>,
+    /// The model's trained/native context window, read from the
+    /// architecture-namespaced `*.context_length` GGUF key. `None` if the
+    /// header couldn't be read or didn't set it.
+    pub context_length: Option<u64>,
+    /// Whether the header has a `tokenizer.chat_template` key. `false` (not
+    /// `Option`) if the header couldn't be read, same as "no template
+    /// found" - this field is advisory display data, not something callers
+    /// branch safety-critical behavior on.
+    pub has_chat_template: bool,
 }
 
 /// One progress update from an in-flight `download_model` transfer. The
@@ -89,22 +109,36 @@ pub fn list_local_models(models_dir: &Path) -> Result<Vec<LocalGgufModel>> {
             continue;
         }
 
-        let metadata = entry.metadata()?;
-        let modified_at = metadata
+        let fs_metadata = entry.metadata()?;
+        let modified_at = fs_metadata
             .modified()
             .ok()
             .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339())
             .unwrap_or_default();
-        let quantization_hint = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .and_then(quantization_hint_from_filename);
+
+        // Header-parsed metadata takes priority; the filename-convention
+        // guess is only consulted as a last resort, when the header itself
+        // couldn't be read (see `gguf_metadata::read_gguf_metadata`'s doc
+        // comment for exactly when that happens).
+        let header = super::gguf_metadata::read_gguf_metadata(&path);
+        let quantization_hint = header
+            .as_ref()
+            .and_then(|h| h.quantization.clone())
+            .or_else(|| {
+                path.file_name()
+                    .and_then(|n| n.to_str())
+                    .and_then(quantization_hint_from_filename)
+            });
 
         models.push(LocalGgufModel {
             path,
-            size_bytes: metadata.len(),
+            size_bytes: fs_metadata.len(),
             modified_at,
             quantization_hint,
+            architecture: header.as_ref().and_then(|h| h.architecture.clone()),
+            parameter_count: header.as_ref().and_then(|h| h.parameter_count),
+            context_length: header.as_ref().and_then(|h| h.context_length),
+            has_chat_template: header.as_ref().is_some_and(|h| h.has_chat_template),
         });
     }
 

--- a/src/llm/provider/llama_cpp_models.rs
+++ b/src/llm/provider/llama_cpp_models.rs
@@ -22,6 +22,19 @@ use tokio::sync::mpsc::UnboundedSender;
 /// models is far larger than anyone would default to in practice).
 const ESTIMATE_DEFAULT_CONTEXT_LENGTH: u64 = 8_192;
 
+/// The context length used for a memory estimate: `native` capped at
+/// [`ESTIMATE_DEFAULT_CONTEXT_LENGTH`], or that default when `native` is
+/// `None` (header didn't set one) - the exact rule Phase M12's fit
+/// comparison needs to know the estimate was computed at (see
+/// `LocalGgufModel::estimated_memory_context_length`), extracted here so
+/// both `list_local_models` and `parse_ollama_manifest` compute it
+/// identically rather than duplicating the same two-line rule.
+fn estimate_default_context_length(native: Option<u64>) -> u64 {
+    native
+        .map(|n| n.min(ESTIMATE_DEFAULT_CONTEXT_LENGTH))
+        .unwrap_or(ESTIMATE_DEFAULT_CONTEXT_LENGTH)
+}
+
 /// A locally-present `.gguf` file - the llama.cpp equivalent of
 /// `ollama_models::LocalModelInfo` (which reports installed models via
 /// Ollama's `/api/tags` instead of a directory scan).
@@ -76,6 +89,15 @@ pub struct LocalGgufModel {
     /// it, in which case the estimate covers weights only - meaningless
     /// when `estimated_memory_bytes` is `None`.
     pub estimated_memory_includes_kv_cache: bool,
+    /// The context length `estimated_memory_bytes` was actually computed
+    /// at - `estimate_default_context_length`'s result, i.e. the header's
+    /// native context length capped at `ESTIMATE_DEFAULT_CONTEXT_LENGTH`,
+    /// or that default when the header didn't set one. `None` exactly
+    /// when `estimated_memory_bytes` is `None` (nothing to report a
+    /// context length for). Surfaced by Phase M12's fit annotation so a
+    /// "Tight"/"Won't fit" label is a number a user can sanity-check, not
+    /// just a bare word.
+    pub estimated_memory_context_length: Option<u64>,
     /// Whether this file is a vision/audio projector (mmproj), per the
     /// header's `clip.has_vision_encoder`/`clip.has_audio_encoder`
     /// (verified against llama.cpp's own source, see
@@ -190,13 +212,11 @@ pub fn list_local_models(models_dir: &Path) -> Result<Vec<LocalGgufModel>> {
                     .and_then(quantization_hint_from_filename)
             });
 
-        let estimate = header.as_ref().and_then(|h| {
-            let ctx = h
-                .context_length
-                .map(|native| native.min(ESTIMATE_DEFAULT_CONTEXT_LENGTH))
-                .unwrap_or(ESTIMATE_DEFAULT_CONTEXT_LENGTH);
-            super::gguf_metadata::estimate_memory_bytes(h, ctx)
-        });
+        let estimate_context_length =
+            estimate_default_context_length(header.as_ref().and_then(|h| h.context_length));
+        let estimate = header
+            .as_ref()
+            .and_then(|h| super::gguf_metadata::estimate_memory_bytes(h, estimate_context_length));
         let is_mmproj = match &header {
             Some(h) => h.is_vision_projector || h.is_audio_projector,
             None => path
@@ -217,6 +237,7 @@ pub fn list_local_models(models_dir: &Path) -> Result<Vec<LocalGgufModel>> {
             display_name: None,
             estimated_memory_bytes: estimate.map(|e| e.total_bytes),
             estimated_memory_includes_kv_cache: estimate.is_some_and(|e| e.includes_kv_cache),
+            estimated_memory_context_length: estimate.map(|_| estimate_context_length),
             is_mmproj,
             mmproj_path: None,
         });
@@ -391,13 +412,11 @@ fn parse_ollama_manifest(
     // model's own contents.
     let header = super::gguf_metadata::read_gguf_metadata(&blob_path);
     let quantization_hint = header.as_ref().and_then(|h| h.quantization.clone());
-    let estimate = header.as_ref().and_then(|h| {
-        let ctx = h
-            .context_length
-            .map(|native| native.min(ESTIMATE_DEFAULT_CONTEXT_LENGTH))
-            .unwrap_or(ESTIMATE_DEFAULT_CONTEXT_LENGTH);
-        super::gguf_metadata::estimate_memory_bytes(h, ctx)
-    });
+    let estimate_context_length =
+        estimate_default_context_length(header.as_ref().and_then(|h| h.context_length));
+    let estimate = header
+        .as_ref()
+        .and_then(|h| super::gguf_metadata::estimate_memory_bytes(h, estimate_context_length));
 
     Some(LocalGgufModel {
         path: blob_path,
@@ -411,6 +430,7 @@ fn parse_ollama_manifest(
         display_name: Some(display_name),
         estimated_memory_bytes: estimate.map(|e| e.total_bytes),
         estimated_memory_includes_kv_cache: estimate.is_some_and(|e| e.includes_kv_cache),
+        estimated_memory_context_length: estimate.map(|_| estimate_context_length),
         // No filename-based fallback here: an Ollama blob's on-disk name
         // is always "sha256-<hex>", never anything containing "mmproj".
         is_mmproj: header
@@ -669,6 +689,96 @@ fn pair_mmproj_files(models: Vec<LocalGgufModel>) -> Vec<LocalGgufModel> {
 
     result.extend(bases);
     result
+}
+
+/// How a model's estimated memory footprint (`LocalGgufModel::estimated_memory_bytes`)
+/// compares against a detected hardware budget
+/// (`hardware_detect::HardwareInfo::budget_bytes`) - Phase M12. Three states,
+/// deliberately not a percentage: a false-precision number would imply an
+/// accuracy neither the memory estimate (M2, itself an order-of-magnitude
+/// figure) nor "VRAM+RAM" as a single pooled budget (M11's own documented
+/// simplification - it doesn't model partial-offload behavior) actually has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HardwareFit {
+    /// Comfortably under budget.
+    Fits,
+    /// Under budget, but with little headroom (see `TIGHT_THRESHOLD_RATIO`).
+    Tight,
+    /// Exceeds the detected budget.
+    WontFit,
+    /// Either the model's estimate or the hardware budget (or both)
+    /// couldn't be determined - no comparison is possible.
+    Unknown,
+}
+
+/// The fraction of the budget above which a model that still technically
+/// fits is labeled `Tight` rather than `Fits` - e.g. at the default 0.85, a
+/// model using 90% of the detected budget is `Tight`, one using 60% is
+/// `Fits`. A documented, reasonable default (same posture as
+/// `ESTIMATE_DEFAULT_CONTEXT_LENGTH` above), not a tuned/validated number -
+/// there is no benchmark data behind it (that stays out of scope, M10).
+const TIGHT_THRESHOLD_RATIO: f64 = 0.85;
+
+/// Compares `estimated_memory_bytes` against `budget_bytes`. See
+/// `HardwareFit`'s own doc comment for what each state means.
+pub fn hardware_fit(estimated_memory_bytes: Option<u64>, budget_bytes: Option<u64>) -> HardwareFit {
+    let (Some(estimate), Some(budget)) = (estimated_memory_bytes, budget_bytes) else {
+        return HardwareFit::Unknown;
+    };
+    if estimate > budget {
+        HardwareFit::WontFit
+    } else if estimate as f64 > budget as f64 * TIGHT_THRESHOLD_RATIO {
+        HardwareFit::Tight
+    } else {
+        HardwareFit::Fits
+    }
+}
+
+/// Sorts `models` by fit against `budget_bytes`: `Fits` first, then
+/// `Tight`, then `WontFit`, then `Unknown` last - within a category, the
+/// largest `estimated_memory_bytes` sorts first (the most-capable model
+/// that still fits its category is the most useful one to see at the top,
+/// a reasonable proxy for "best" absent benchmark-ranked data - that axis
+/// stays deferred, M10). Powers `crustly llama-cpp list --best-fit`
+/// (`src/cli/mod.rs`).
+pub fn sort_by_fit(models: &mut [LocalGgufModel], budget_bytes: Option<u64>) {
+    fn rank(fit: HardwareFit) -> u8 {
+        match fit {
+            HardwareFit::Fits => 0,
+            HardwareFit::Tight => 1,
+            HardwareFit::WontFit => 2,
+            HardwareFit::Unknown => 3,
+        }
+    }
+    models.sort_by(|a, b| {
+        let fit_a = hardware_fit(a.estimated_memory_bytes, budget_bytes);
+        let fit_b = hardware_fit(b.estimated_memory_bytes, budget_bytes);
+        rank(fit_a).cmp(&rank(fit_b)).then_with(|| {
+            b.estimated_memory_bytes
+                .unwrap_or(0)
+                .cmp(&a.estimated_memory_bytes.unwrap_or(0))
+        })
+    });
+}
+
+/// The single most-capable already-downloaded model that `Fits` or is
+/// `Tight` against `budget_bytes` - `None` if nothing does (or `models` is
+/// empty, or the budget itself is unknown). Used by `crustly llama-cpp
+/// doctor`'s "largest model your hardware can hold" finding (Phase M9's own
+/// doc comment named this as M11/M12's eventual payoff for that phase).
+pub fn best_fitting_model(
+    models: &[LocalGgufModel],
+    budget_bytes: Option<u64>,
+) -> Option<&LocalGgufModel> {
+    models
+        .iter()
+        .filter(|m| {
+            matches!(
+                hardware_fit(m.estimated_memory_bytes, budget_bytes),
+                HardwareFit::Fits | HardwareFit::Tight
+            )
+        })
+        .max_by_key(|m| m.estimated_memory_bytes.unwrap_or(0))
 }
 
 /// Parse an `hf:org/repo/file.gguf` (or revision-pinned
@@ -1809,5 +1919,119 @@ mod tests {
             2,
             "ordinary unrelated files must stay separate"
         );
+    }
+
+    // -- Phase M12: hardware_fit / sort_by_fit / best_fitting_model --------
+
+    /// A minimal `LocalGgufModel` fixture for the pure fit-comparison
+    /// functions below, which only ever look at `estimated_memory_bytes` -
+    /// every other field is filler, unlike this file's other tests (which
+    /// exercise real `.gguf` byte fixtures through `list_local_models`
+    /// end-to-end).
+    fn fixture_model(name: &str, estimated_memory_bytes: Option<u64>) -> LocalGgufModel {
+        LocalGgufModel {
+            path: PathBuf::from(format!("/models/{name}.gguf")),
+            size_bytes: 0,
+            modified_at: String::new(),
+            quantization_hint: None,
+            architecture: None,
+            parameter_count: None,
+            context_length: None,
+            has_chat_template: false,
+            display_name: Some(name.to_string()),
+            estimated_memory_bytes,
+            estimated_memory_includes_kv_cache: false,
+            estimated_memory_context_length: estimated_memory_bytes.map(|_| 8_192),
+            is_mmproj: false,
+            mmproj_path: None,
+        }
+    }
+
+    #[test]
+    fn hardware_fit_reports_fits_comfortably_under_budget() {
+        assert_eq!(hardware_fit(Some(5_000), Some(10_000)), HardwareFit::Fits);
+    }
+
+    #[test]
+    fn hardware_fit_reports_tight_near_the_threshold() {
+        // 9_000 / 10_000 = 0.90 > TIGHT_THRESHOLD_RATIO (0.85).
+        assert_eq!(hardware_fit(Some(9_000), Some(10_000)), HardwareFit::Tight);
+    }
+
+    #[test]
+    fn hardware_fit_reports_wont_fit_over_budget() {
+        assert_eq!(
+            hardware_fit(Some(11_000), Some(10_000)),
+            HardwareFit::WontFit
+        );
+    }
+
+    #[test]
+    fn hardware_fit_is_unknown_when_estimate_is_missing() {
+        assert_eq!(hardware_fit(None, Some(10_000)), HardwareFit::Unknown);
+    }
+
+    #[test]
+    fn hardware_fit_is_unknown_when_budget_is_missing() {
+        assert_eq!(hardware_fit(Some(5_000), None), HardwareFit::Unknown);
+    }
+
+    #[test]
+    fn sort_by_fit_orders_fits_before_tight_before_wont_fit_before_unknown() {
+        let mut models = vec![
+            fixture_model("wont-fit", Some(20_000)),
+            fixture_model("unknown", None),
+            fixture_model("fits", Some(1_000)),
+            fixture_model("tight", Some(9_000)),
+        ];
+        sort_by_fit(&mut models, Some(10_000));
+        let names: Vec<&str> = models
+            .iter()
+            .map(|m| m.display_name.as_deref().unwrap())
+            .collect();
+        assert_eq!(names, ["fits", "tight", "wont-fit", "unknown"]);
+    }
+
+    #[test]
+    fn sort_by_fit_orders_largest_first_within_a_category() {
+        let mut models = vec![
+            fixture_model("small-fit", Some(1_000)),
+            fixture_model("big-fit", Some(5_000)),
+        ];
+        sort_by_fit(&mut models, Some(10_000));
+        let names: Vec<&str> = models
+            .iter()
+            .map(|m| m.display_name.as_deref().unwrap())
+            .collect();
+        assert_eq!(
+            names,
+            ["big-fit", "small-fit"],
+            "largest still-fitting model should sort first"
+        );
+    }
+
+    #[test]
+    fn best_fitting_model_picks_the_largest_that_fits_or_is_tight() {
+        let models = vec![
+            fixture_model("too-big", Some(20_000)),
+            fixture_model("small", Some(1_000)),
+            fixture_model("tight-but-biggest-that-fits", Some(9_000)),
+        ];
+        let best = best_fitting_model(&models, Some(10_000)).expect("expected a best fit");
+        assert_eq!(
+            best.display_name.as_deref(),
+            Some("tight-but-biggest-that-fits")
+        );
+    }
+
+    #[test]
+    fn best_fitting_model_is_none_when_nothing_fits() {
+        let models = vec![fixture_model("too-big", Some(20_000))];
+        assert!(best_fitting_model(&models, Some(10_000)).is_none());
+    }
+
+    #[test]
+    fn best_fitting_model_is_none_for_an_empty_list() {
+        assert!(best_fitting_model(&[], Some(10_000)).is_none());
     }
 }

--- a/src/llm/provider/llama_cpp_models.rs
+++ b/src/llm/provider/llama_cpp_models.rs
@@ -760,8 +760,10 @@ async fn fetch_hf_lfs_sha256(
 /// filesystem of its nearest existing ancestor (the download target
 /// itself doesn't exist yet, so `path` alone can't be queried directly).
 /// `None` when no matching disk is found - advisory only, callers must
-/// never block a download on an unknown.
-fn available_space_at(path: &Path) -> Option<u64> {
+/// never block a download on an unknown. `pub(crate)` (not just used by
+/// `download_model` below) since `crustly llama-cpp doctor`
+/// (`src/cli/mod.rs`, Phase M9) reports the same figure as a diagnostic.
+pub(crate) fn available_space_at(path: &Path) -> Option<u64> {
     let mut probe = path.to_path_buf();
     while !probe.exists() {
         probe = probe.parent()?.to_path_buf();

--- a/src/llm/provider/llama_cpp_models.rs
+++ b/src/llm/provider/llama_cpp_models.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use tokio::io::AsyncWriteExt as _;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::mpsc::UnboundedSender;
 
 /// Context length used for `list_local_models`'s memory estimate when a
@@ -76,6 +76,22 @@ pub struct LocalGgufModel {
     /// it, in which case the estimate covers weights only - meaningless
     /// when `estimated_memory_bytes` is `None`.
     pub estimated_memory_includes_kv_cache: bool,
+    /// Whether this file is a vision/audio projector (mmproj), per the
+    /// header's `clip.has_vision_encoder`/`clip.has_audio_encoder`
+    /// (verified against llama.cpp's own source, see
+    /// `gguf_metadata::GgufMetadata::is_vision_projector`'s doc comment),
+    /// or - only when the header itself couldn't be read at all - a
+    /// filename containing "mmproj"/"mm-proj"/"mm_proj". A paired
+    /// projector's own entry is removed from the merged listing (see
+    /// `mmproj_path` below); an unpaired one keeps `is_mmproj = true` on
+    /// its own standalone entry so callers can label it, rather than
+    /// showing a mysteriously-named model.
+    pub is_mmproj: bool,
+    /// Set on a *base model* entry once `pair_mmproj_files` confidently
+    /// matches it with a projector in the same directory - `None` for an
+    /// ordinary entry, and always `None` on an entry that is itself
+    /// `is_mmproj` (a projector doesn't get its own `mmproj_path`).
+    pub mmproj_path: Option<PathBuf>,
 }
 
 /// One progress update from an in-flight `download_model` transfer. The
@@ -118,6 +134,19 @@ pub fn quantization_hint_from_filename(filename: &str) -> Option<String> {
         .iter()
         .find(|tag| upper.contains(*tag))
         .map(|tag| tag.to_string())
+}
+
+/// Filename markers (checked case-insensitively) that suggest a `.gguf`
+/// file is a multimodal projector, used only as a fallback when the header
+/// itself couldn't be read at all (`gguf_metadata::read_gguf_metadata`
+/// returned `None`) - when the header *did* parse, its
+/// `is_vision_projector`/`is_audio_projector` fields are the source of
+/// truth, not this heuristic.
+const MMPROJ_FILENAME_MARKERS: &[&str] = &["mmproj", "mm-proj", "mm_proj"];
+
+fn filename_suggests_mmproj(filename: &str) -> bool {
+    let lower = filename.to_lowercase();
+    MMPROJ_FILENAME_MARKERS.iter().any(|m| lower.contains(m))
 }
 
 /// Scan `models_dir` for `*.gguf` files. Ollama's `list_models()`
@@ -168,6 +197,13 @@ pub fn list_local_models(models_dir: &Path) -> Result<Vec<LocalGgufModel>> {
                 .unwrap_or(ESTIMATE_DEFAULT_CONTEXT_LENGTH);
             super::gguf_metadata::estimate_memory_bytes(h, ctx)
         });
+        let is_mmproj = match &header {
+            Some(h) => h.is_vision_projector || h.is_audio_projector,
+            None => path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(filename_suggests_mmproj),
+        };
 
         models.push(LocalGgufModel {
             path,
@@ -181,6 +217,8 @@ pub fn list_local_models(models_dir: &Path) -> Result<Vec<LocalGgufModel>> {
             display_name: None,
             estimated_memory_bytes: estimate.map(|e| e.total_bytes),
             estimated_memory_includes_kv_cache: estimate.is_some_and(|e| e.includes_kv_cache),
+            is_mmproj,
+            mmproj_path: None,
         });
     }
 
@@ -215,7 +253,8 @@ pub fn list_all_local_models(
         models.extend(list_ollama_models(ollama_dir));
     }
 
-    let mut models = deduplicate_and_merge(models);
+    let models = deduplicate_and_merge(models);
+    let mut models = pair_mmproj_files(models);
     models.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(models)
 }
@@ -372,6 +411,12 @@ fn parse_ollama_manifest(
         display_name: Some(display_name),
         estimated_memory_bytes: estimate.map(|e| e.total_bytes),
         estimated_memory_includes_kv_cache: estimate.is_some_and(|e| e.includes_kv_cache),
+        // No filename-based fallback here: an Ollama blob's on-disk name
+        // is always "sha256-<hex>", never anything containing "mmproj".
+        is_mmproj: header
+            .as_ref()
+            .is_some_and(|h| h.is_vision_projector || h.is_audio_projector),
+        mmproj_path: None,
     })
 }
 
@@ -545,40 +590,130 @@ fn merge_split_gguf_groups(models: Vec<LocalGgufModel>) -> Vec<LocalGgufModel> {
     result
 }
 
-/// Parse an `hf:org/repo/file.gguf` shorthand into its parts. Pure
+/// Reduces a `.gguf` filename stem to its "core name" for mmproj pairing:
+/// lowercase, strip every `QUANTIZATION_TAGS` tag and every
+/// `MMPROJ_FILENAME_MARKERS` marker (both checked case-insensitively, in
+/// whichever order they appear), trim leftover `-`/`_`/` ` at the ends.
+/// Two files naming "the same model" (a base model plus its projector)
+/// should reduce to an identical core name once quant/mmproj-specific
+/// decoration is stripped from both - e.g. `"Qwen2-VL-7B-Q4_K_M"` and
+/// `"mmproj-Qwen2-VL-7B-f16"` both reduce to `"qwen2-vl-7b"`.
+fn mmproj_core_name(filename: &str) -> String {
+    let stem = filename.strip_suffix(".gguf").unwrap_or(filename);
+    let mut core = stem.to_lowercase();
+    for marker in MMPROJ_FILENAME_MARKERS {
+        core = core.replace(marker, "");
+    }
+    for tag in QUANTIZATION_TAGS {
+        core = core.replace(&tag.to_lowercase(), "");
+    }
+    core.trim_matches(|c: char| c == '-' || c == '_' || c == ' ')
+        .to_string()
+}
+
+/// Pairs `is_mmproj` entries with a confident-match base model in the same
+/// directory (never across directories), per
+/// `ccguf-managment-imrpoment-plan.md` Phase M5. Conservative by design: a
+/// wrong pairing is actively misleading, so this only pairs on an
+/// unambiguous exact core-name match - zero or more than one candidate
+/// leaves the projector as its own standalone entry rather than guessing.
+/// Run after `deduplicate_and_merge` so it operates on the final,
+/// already-deduplicated listing.
+fn pair_mmproj_files(models: Vec<LocalGgufModel>) -> Vec<LocalGgufModel> {
+    let (mut projectors, mut bases): (Vec<LocalGgufModel>, Vec<LocalGgufModel>) =
+        (Vec::new(), Vec::new());
+    for model in models {
+        if model.is_mmproj {
+            projectors.push(model);
+        } else {
+            bases.push(model);
+        }
+    }
+
+    let mut result = Vec::with_capacity(bases.len() + projectors.len());
+    'projector: for projector in projectors {
+        let Some(filename) = projector.path.file_name().and_then(|n| n.to_str()) else {
+            result.push(projector);
+            continue;
+        };
+        let parent = projector.path.parent();
+        let projector_core = mmproj_core_name(filename);
+
+        let mut match_index = None;
+        for (i, base) in bases.iter().enumerate() {
+            if base.mmproj_path.is_some() {
+                continue; // already paired with a different projector
+            }
+            if base.path.parent() != parent {
+                continue; // never pair across directories
+            }
+            let Some(base_filename) = base.path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if mmproj_core_name(base_filename) == projector_core {
+                if match_index.is_some() {
+                    // A second candidate makes this ambiguous - stand
+                    // alone rather than guess which one is right.
+                    result.push(projector);
+                    continue 'projector;
+                }
+                match_index = Some(i);
+            }
+        }
+
+        match match_index {
+            Some(i) => bases[i].mmproj_path = Some(projector.path.clone()),
+            None => result.push(projector),
+        }
+    }
+
+    result.extend(bases);
+    result
+}
+
+/// Parse an `hf:org/repo/file.gguf` (or revision-pinned
+/// `hf:org/repo/file.gguf@revision`) shorthand into its parts. Pure
 /// string-parsing, no I/O - `None` if `source` isn't in that shorthand
-/// form (a direct URL, for instance).
-fn parse_hf_shorthand(source: &str) -> Option<(&str, &str, &str)> {
+/// form (a direct URL, for instance) or the `@revision` suffix is
+/// malformed (an `@` present with an empty file or revision side).
+fn parse_hf_shorthand(source: &str) -> Option<(&str, &str, &str, Option<&str>)> {
     let rest = source.strip_prefix("hf:")?;
     let mut parts = rest.splitn(3, '/');
     let org = parts.next()?;
     let repo = parts.next()?;
-    let file = parts.next()?;
-    if org.is_empty() || repo.is_empty() || file.is_empty() {
+    let file_and_revision = parts.next()?;
+    if org.is_empty() || repo.is_empty() || file_and_revision.is_empty() {
         return None;
     }
-    Some((org, repo, file))
+
+    let (file, revision) = match file_and_revision.split_once('@') {
+        Some((f, r)) if !f.is_empty() && !r.is_empty() => (f, Some(r)),
+        Some(_) => return None,
+        None => (file_and_revision, None),
+    };
+    Some((org, repo, file, revision))
 }
 
-/// Resolve `source` (a direct URL, or an `hf:org/repo/file.gguf`
+/// Resolve `source` (a direct URL, or an `hf:org/repo/file.gguf[@revision]`
 /// shorthand) into a downloadable URL and, where resolvable, the file's
 /// expected SHA-256 checksum.
 ///
 /// For the `hf:` shorthand, this expands to
-/// `https://huggingface.co/org/repo/resolve/main/file` and queries
-/// Hugging Face's model API (`https://huggingface.co/api/models/org/repo`)
-/// for the file's published LFS SHA-256 - a plain unauthenticated `GET`, no
-/// HuggingFace client dependency needed. A direct URL has no metadata
-/// endpoint to query at all, so it always resolves with `None` - callers
-/// must treat that as "no integrity hash available", not silently skip the
-/// gap (`llama-cpp-2-integration-plan.md` §4.11 point 2).
+/// `https://huggingface.co/org/repo/resolve/<revision-or-main>/file` and
+/// queries Hugging Face's model API for the file's published LFS SHA-256 -
+/// a plain unauthenticated `GET`, no HuggingFace client dependency needed.
+/// A direct URL has no metadata endpoint to query at all, so it always
+/// resolves with `None` - callers must treat that as "no integrity hash
+/// available", not silently skip the gap
+/// (`llama-cpp-2-integration-plan.md` §4.11 point 2).
 pub async fn resolve_download_source(source: &str) -> Result<(String, Option<String>)> {
-    let Some((org, repo, file)) = parse_hf_shorthand(source) else {
+    let Some((org, repo, file, revision)) = parse_hf_shorthand(source) else {
         return Ok((source.to_string(), None));
     };
 
-    let download_url = format!("https://huggingface.co/{org}/{repo}/resolve/main/{file}");
-    let expected_sha256 = fetch_hf_lfs_sha256(org, repo, file).await;
+    let ref_segment = revision.unwrap_or("main");
+    let download_url = format!("https://huggingface.co/{org}/{repo}/resolve/{ref_segment}/{file}");
+    let expected_sha256 = fetch_hf_lfs_sha256(org, repo, file, revision).await;
     Ok((download_url, expected_sha256))
 }
 
@@ -587,8 +722,28 @@ pub async fn resolve_download_source(source: &str) -> Result<(String, Option<Str
 /// non-LFS file, unexpected response shape) rather than propagating an
 /// error - a missing checksum degrades to an explicit warning at the call
 /// site, it does not block the download.
-async fn fetch_hf_lfs_sha256(org: &str, repo: &str, file: &str) -> Option<String> {
-    let api_url = format!("https://huggingface.co/api/models/{org}/{repo}");
+///
+/// When `revision` is `Some`, queries
+/// `/api/models/{org}/{repo}/revision/{revision}` instead of the bare
+/// `/api/models/{org}/{repo}` endpoint - HuggingFace's documented
+/// git-ref-based URL convention (the same shape the download URL itself
+/// already uses via `resolve/{revision}/`). **Unverified against a live
+/// response**: `huggingface.co` is unreachable from this development
+/// sandbox's own network policy (already known, not newly discovered -
+/// see `llama-cpp-2-integration-plan.md`'s prior finding on this exact
+/// point). A wrong guess here costs a missing checksum for pinned
+/// revisions, never a crash or bad data, given this function's existing
+/// degrade-to-`None` posture on any failure.
+async fn fetch_hf_lfs_sha256(
+    org: &str,
+    repo: &str,
+    file: &str,
+    revision: Option<&str>,
+) -> Option<String> {
+    let api_url = match revision {
+        Some(rev) => format!("https://huggingface.co/api/models/{org}/{repo}/revision/{rev}"),
+        None => format!("https://huggingface.co/api/models/{org}/{repo}"),
+    };
     let response = reqwest::get(&api_url).await.ok()?;
     let body: serde_json::Value = response.json().await.ok()?;
     body.get("siblings")?
@@ -599,6 +754,62 @@ async fn fetch_hf_lfs_sha256(org: &str, repo: &str, file: &str) -> Option<String
         .get("sha256")?
         .as_str()
         .map(str::to_string)
+}
+
+/// Best-effort available disk space at `path`'s filesystem, or the
+/// filesystem of its nearest existing ancestor (the download target
+/// itself doesn't exist yet, so `path` alone can't be queried directly).
+/// `None` when no matching disk is found - advisory only, callers must
+/// never block a download on an unknown.
+fn available_space_at(path: &Path) -> Option<u64> {
+    let mut probe = path.to_path_buf();
+    while !probe.exists() {
+        probe = probe.parent()?.to_path_buf();
+    }
+    let canonical = std::fs::canonicalize(&probe).ok()?;
+
+    let disks = sysinfo::Disks::new_with_refreshed_list();
+    disks
+        .list()
+        .iter()
+        // The disk whose mount point is the *longest* matching prefix
+        // wins - handles nested mount points correctly (e.g. a separate
+        // `/home` mount under `/`).
+        .filter(|d| canonical.starts_with(d.mount_point()))
+        .max_by_key(|d| d.mount_point().as_os_str().len())
+        .map(|d| d.available_space())
+}
+
+/// Pure comparison extracted from `download_model`'s disk-space precheck so
+/// the reject-path is unit-testable without depending on real filesystem
+/// free space - every dev/CI machine has generously more of that than any
+/// test download body, making a true end-to-end "insufficient space" test
+/// impractical to set up deterministically. `available_space_at`'s result
+/// is passed in already-resolved rather than this function calling it
+/// itself, which is exactly the seam that makes the fabricated-values test
+/// below possible.
+fn check_disk_space(
+    available: Option<u64>,
+    still_needed: u64,
+    filename: &str,
+    models_dir: &Path,
+) -> Result<()> {
+    let Some(available) = available else {
+        return Ok(()); // unknown - never block on missing information
+    };
+    // A fixed safety margin, not a zero-margin check - leaves room for the
+    // OS/other processes right after the download lands.
+    const SAFETY_MARGIN_BYTES: u64 = 512 * 1024 * 1024;
+    if available < still_needed.saturating_add(SAFETY_MARGIN_BYTES) {
+        anyhow::bail!(
+            "Not enough disk space to download '{filename}': need ~{:.2} GB (plus a safety \
+             margin) but only ~{:.2} GB free at {}",
+            still_needed as f64 / 1_073_741_824.0,
+            available as f64 / 1_073_741_824.0,
+            models_dir.display()
+        );
+    }
+    Ok(())
 }
 
 /// Download `url` into `models_dir`, streaming progress through
@@ -635,20 +846,96 @@ pub async fn download_model(
     let final_path = models_dir.join(filename);
     let partial_path = models_dir.join(format!("{filename}.part"));
 
-    let response = reqwest::get(url)
+    // Resume support: if a `.part` file already exists, ask the server to
+    // continue from where it left off via a `Range` header. Needs
+    // `reqwest::Client` rather than the bare `reqwest::get` free function
+    // used elsewhere in this module, since that has no header control.
+    let existing_bytes = tokio::fs::metadata(&partial_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    let mut request = reqwest::Client::new().get(url);
+    if existing_bytes > 0 {
+        request = request.header(reqwest::header::RANGE, format!("bytes={existing_bytes}-"));
+    }
+    let response = request
+        .send()
         .await
         .with_context(|| format!("Failed to start download from {url}"))?
         .error_for_status()
         .with_context(|| format!("Download failed for {url}"))?;
-    let total_bytes = response.content_length();
 
-    let mut file = tokio::fs::File::create(&partial_path)
-        .await
-        .with_context(|| format!("Failed to create {}", partial_path.display()))?;
+    // A 206 confirms the server actually honored the `Range` request - a
+    // server that ignores it and sends 200 (full content) falls through to
+    // exactly today's from-scratch behavior below, discarding the stale
+    // partial bytes rather than corrupting the file by appending to them.
+    let resumed = existing_bytes > 0 && response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
+    let total_bytes = if resumed {
+        // A 206's own `Content-Length` is the *remaining* bytes, not the
+        // whole file's size.
+        response
+            .content_length()
+            .map(|remaining| existing_bytes + remaining)
+    } else {
+        response.content_length()
+    };
+
+    // Disk-space precheck: only meaningful when both the size still to be
+    // downloaded and the destination's free space are known - skips
+    // silently (never blocks on missing information) otherwise. Reuses
+    // this same in-flight response's `Content-Length` rather than a
+    // separate `HEAD` round-trip.
+    if let Some(total) = total_bytes {
+        let still_needed = total.saturating_sub(if resumed { existing_bytes } else { 0 });
+        check_disk_space(
+            available_space_at(models_dir),
+            still_needed,
+            filename,
+            models_dir,
+        )?;
+    }
+
+    let mut file = if resumed {
+        tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&partial_path)
+            .await
+            .with_context(|| format!("Failed to resume {}", partial_path.display()))?
+    } else {
+        tokio::fs::File::create(&partial_path)
+            .await
+            .with_context(|| format!("Failed to create {}", partial_path.display()))?
+    };
+
     let mut hasher = Sha256::new();
     let mut bytes_downloaded: u64 = 0;
-    let mut stream = response.bytes_stream();
 
+    if resumed {
+        bytes_downloaded = existing_bytes;
+        if expected_sha256.is_some() {
+            // The final checksum must cover the *whole* file, not just the
+            // newly-streamed portion - hash the already-on-disk bytes too,
+            // incrementally (never the whole file in memory at once, even
+            // for a multi-GB partial download).
+            let mut existing_file = tokio::fs::File::open(&partial_path)
+                .await
+                .with_context(|| format!("Failed to re-read {}", partial_path.display()))?;
+            let mut buf = vec![0u8; 1024 * 1024];
+            loop {
+                let n = existing_file
+                    .read(&mut buf)
+                    .await
+                    .with_context(|| format!("Failed to re-read {}", partial_path.display()))?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buf[..n]);
+            }
+        }
+    }
+
+    let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.context("Error while downloading")?;
         hasher.update(&chunk);
@@ -737,7 +1024,25 @@ mod tests {
     fn parse_hf_shorthand_extracts_org_repo_file() {
         assert_eq!(
             parse_hf_shorthand("hf:TheBloke/Llama-2-7B-GGUF/llama-2-7b.Q4_K_M.gguf"),
-            Some(("TheBloke", "Llama-2-7B-GGUF", "llama-2-7b.Q4_K_M.gguf"))
+            Some((
+                "TheBloke",
+                "Llama-2-7B-GGUF",
+                "llama-2-7b.Q4_K_M.gguf",
+                None
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_hf_shorthand_extracts_a_pinned_revision() {
+        assert_eq!(
+            parse_hf_shorthand("hf:TheBloke/Llama-2-7B-GGUF/llama-2-7b.Q4_K_M.gguf@abc123"),
+            Some((
+                "TheBloke",
+                "Llama-2-7B-GGUF",
+                "llama-2-7b.Q4_K_M.gguf",
+                Some("abc123")
+            ))
         );
     }
 
@@ -755,6 +1060,8 @@ mod tests {
             "hf:org/repo",
             "hf:/repo/file",
             "hf:org//file",
+            "hf:org/repo/file.gguf@", // empty revision after "@"
+            "hf:org/repo/@abc123",    // empty file before "@"
         ] {
             assert_eq!(parse_hf_shorthand(bad), None, "should reject: {bad}");
         }
@@ -787,6 +1094,78 @@ mod tests {
             .expect("resolve");
         assert_eq!(url, "https://example.com/model.gguf");
         assert_eq!(sha, None, "a direct URL has no known checksum endpoint");
+    }
+
+    #[tokio::test]
+    async fn resolve_download_source_uses_the_pinned_revision_in_the_url() {
+        let (url, _sha) =
+            resolve_download_source("hf:TheBloke/Llama-2-7B-GGUF/llama-2-7b.Q4_K_M.gguf@abc123")
+                .await
+                .expect("resolve");
+        assert_eq!(
+            url,
+            "https://huggingface.co/TheBloke/Llama-2-7B-GGUF/resolve/abc123/llama-2-7b.Q4_K_M.gguf"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_download_source_defaults_to_main_without_a_revision() {
+        let (url, _sha) =
+            resolve_download_source("hf:TheBloke/Llama-2-7B-GGUF/llama-2-7b.Q4_K_M.gguf")
+                .await
+                .expect("resolve");
+        assert_eq!(
+            url,
+            "https://huggingface.co/TheBloke/Llama-2-7B-GGUF/resolve/main/llama-2-7b.Q4_K_M.gguf"
+        );
+    }
+
+    #[test]
+    fn check_disk_space_rejects_when_available_is_below_needed_plus_margin() {
+        let err = check_disk_space(
+            Some(1_000_000_000),
+            900_000_000,
+            "model.gguf",
+            Path::new("/models"),
+        )
+        .expect_err("900MB needed + 512MB margin exceeds 1GB available");
+        assert!(err.to_string().contains("Not enough disk space"));
+    }
+
+    #[test]
+    fn check_disk_space_allows_when_comfortably_available() {
+        assert!(check_disk_space(
+            Some(100_000_000_000),
+            1_000_000_000,
+            "model.gguf",
+            Path::new("/models")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn check_disk_space_skips_when_available_is_unknown() {
+        assert!(check_disk_space(None, u64::MAX, "model.gguf", Path::new("/models")).is_ok());
+    }
+
+    #[test]
+    fn available_space_at_a_real_directory_returns_a_plausible_value_or_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Best-effort - some sandboxes may not expose disk info at all, so
+        // this only asserts that a `Some` result is a real, non-zero
+        // number, not that a result is always available.
+        if let Some(bytes) = available_space_at(tmp.path()) {
+            assert!(bytes > 0);
+        }
+    }
+
+    #[test]
+    fn available_space_at_walks_up_to_the_nearest_existing_ancestor() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nonexistent = tmp.path().join("does").join("not").join("exist");
+        // Must not panic or loop forever walking up to `tmp` (which does
+        // exist) instead of the nonexistent leaf.
+        let _ = available_space_at(&nonexistent);
     }
 
     #[tokio::test]
@@ -876,6 +1255,148 @@ mod tests {
         });
 
         format!("http://{addr}")
+    }
+
+    /// Like `mock_http_server`, but honors a `Range: bytes=N-` request
+    /// header by returning `206 Partial Content` with only the requested
+    /// tail of `body` - lets `download_model`'s resume path be tested
+    /// without a real remote server.
+    async fn mock_resumable_http_server(body: Vec<u8>) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+
+            let mut request = Vec::new();
+            let mut buf = [0u8; 1024];
+            loop {
+                let n = socket.read(&mut buf).await.expect("read request");
+                if n == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let request_text = String::from_utf8_lossy(&request);
+            let range_start: Option<usize> = request_text
+                .lines()
+                .find(|l| l.to_ascii_lowercase().starts_with("range:"))
+                .and_then(|l| l.split("bytes=").nth(1))
+                .and_then(|s| s.trim().trim_end_matches('-').parse().ok());
+
+            let served: &[u8] = match range_start {
+                Some(start) if start < body.len() => &body[start..],
+                _ => &body[..],
+            };
+
+            let response = match range_start {
+                Some(start) if start < body.len() => format!(
+                    "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes {}-{}/{}\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n",
+                    start,
+                    body.len().saturating_sub(1),
+                    body.len(),
+                    served.len()
+                ),
+                _ => format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    served.len()
+                ),
+            };
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response headers");
+            socket.write_all(served).await.expect("write response body");
+            socket.shutdown().await.ok();
+        });
+
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn download_model_resumes_from_an_existing_partial_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let full_body = b"0123456789ABCDEFGHIJ".to_vec();
+        let already_have = &full_body[..10];
+        tokio::fs::write(tmp.path().join("model.gguf.part"), already_have)
+            .await
+            .expect("seed partial file");
+
+        let server = mock_resumable_http_server(full_body.clone()).await;
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let path = download_model(&format!("{server}/model.gguf"), tmp.path(), None, tx)
+            .await
+            .expect("resumed download should succeed");
+
+        assert_eq!(std::fs::read(&path).expect("read final file"), full_body);
+
+        let mut saw_full_progress = false;
+        while let Ok(p) = rx.try_recv() {
+            assert!(
+                p.bytes_downloaded as usize >= already_have.len(),
+                "progress must reflect true cumulative total, never regress below what was \
+                 already on disk before resuming"
+            );
+            if p.bytes_downloaded as usize == full_body.len() {
+                saw_full_progress = true;
+            }
+        }
+        assert!(saw_full_progress);
+    }
+
+    #[tokio::test]
+    async fn download_model_verifies_checksum_across_a_resumed_download() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let full_body = b"the quick brown fox jumps over the lazy dog, resumed".to_vec();
+        let mut hasher = Sha256::new();
+        hasher.update(&full_body);
+        let expected_sha256 = to_hex(&hasher.finalize());
+
+        let already_have = &full_body[..20];
+        tokio::fs::write(tmp.path().join("model.gguf.part"), already_have)
+            .await
+            .expect("seed partial file");
+
+        let server = mock_resumable_http_server(full_body.clone()).await;
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let path = download_model(
+            &format!("{server}/model.gguf"),
+            tmp.path(),
+            Some(&expected_sha256),
+            tx,
+        )
+        .await
+        .expect("checksum must match across the resumed + already-on-disk bytes");
+
+        assert_eq!(std::fs::read(&path).expect("read final file"), full_body);
+    }
+
+    #[tokio::test]
+    async fn download_model_falls_back_to_a_fresh_start_when_the_server_ignores_range() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let full_body = b"a fresh, non-resumable download".to_vec();
+        // Stale/wrong partial bytes on disk - a server that ignores Range
+        // and returns 200 must discard these, not append to them.
+        tokio::fs::write(tmp.path().join("model.gguf.part"), b"WRONG STALE BYTES")
+            .await
+            .expect("seed stale partial file");
+
+        let server = mock_http_server(full_body.clone()).await; // always 200, ignores Range
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let path = download_model(&format!("{server}/model.gguf"), tmp.path(), None, tx)
+            .await
+            .expect("download should succeed");
+
+        assert_eq!(std::fs::read(&path).expect("read final file"), full_body);
     }
 
     // --- M3: multi-source discovery ---
@@ -1177,6 +1698,101 @@ mod tests {
                 .ends_with("big-model-00002-of-00003.gguf"),
             "with only one part found, it is its own canonical path"
         );
+    }
+
+    // --- M5: mmproj pairing ---
+
+    #[test]
+    fn mmproj_core_name_reduces_a_base_model_and_its_projector_identically() {
+        assert_eq!(
+            mmproj_core_name("Qwen2-VL-7B-Q4_K_M.gguf"),
+            mmproj_core_name("mmproj-Qwen2-VL-7B-f16.gguf"),
+        );
+        assert_eq!(mmproj_core_name("Qwen2-VL-7B-Q4_K_M.gguf"), "qwen2-vl-7b");
+    }
+
+    #[test]
+    fn list_all_local_models_pairs_a_base_model_with_its_mmproj_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("Qwen2-VL-7B-Q4_K_M.gguf"),
+            b"base model bytes",
+        )
+        .expect("write base");
+        std::fs::write(
+            dir.path().join("mmproj-Qwen2-VL-7B-f16.gguf"),
+            b"projector bytes",
+        )
+        .expect("write projector");
+
+        let models = list_all_local_models(dir.path(), &[], None).expect("list");
+
+        assert_eq!(
+            models.len(),
+            1,
+            "a paired projector's own entry must be removed from the listing"
+        );
+        assert!(models[0]
+            .path
+            .to_string_lossy()
+            .ends_with("Qwen2-VL-7B-Q4_K_M.gguf"));
+        assert!(models[0]
+            .mmproj_path
+            .as_ref()
+            .is_some_and(|p| p.to_string_lossy().ends_with("mmproj-Qwen2-VL-7B-f16.gguf")));
+    }
+
+    #[test]
+    fn list_all_local_models_leaves_an_unmatched_mmproj_file_standing_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("mmproj-SomeVisionModel-f16.gguf"),
+            b"projector bytes",
+        )
+        .expect("write projector");
+        std::fs::write(dir.path().join("unrelated-model.gguf"), b"unrelated")
+            .expect("write unrelated");
+
+        let models = list_all_local_models(dir.path(), &[], None).expect("list");
+
+        assert_eq!(models.len(), 2, "no confident match - nothing gets hidden");
+        let projector = models
+            .iter()
+            .find(|m| m.path.to_string_lossy().contains("mmproj"))
+            .expect("projector entry must still be present");
+        assert!(projector.is_mmproj);
+        assert!(projector.mmproj_path.is_none());
+    }
+
+    #[test]
+    fn list_all_local_models_does_not_pair_when_two_candidates_are_ambiguous() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("Model-A-Q4_K_M.gguf"), b"a").expect("write a");
+        std::fs::write(dir.path().join("Model-A-Q8_0.gguf"), b"a2").expect("write a2");
+        std::fs::write(dir.path().join("mmproj-Model-A-f16.gguf"), b"proj").expect("write proj");
+
+        let models = list_all_local_models(dir.path(), &[], None).expect("list");
+
+        assert_eq!(
+            models.len(),
+            3,
+            "two equally-good candidates must not be guessed between"
+        );
+        assert!(models.iter().all(|m| m.mmproj_path.is_none()));
+    }
+
+    #[test]
+    fn list_all_local_models_does_not_pair_across_directories() {
+        let primary = tempfile::tempdir().expect("tempdir");
+        let extra = tempfile::tempdir().expect("tempdir");
+        std::fs::write(primary.path().join("Model-A-Q4_K_M.gguf"), b"a").expect("write a");
+        std::fs::write(extra.path().join("mmproj-Model-A-f16.gguf"), b"proj").expect("write proj");
+
+        let models = list_all_local_models(primary.path(), &[extra.path().to_path_buf()], None)
+            .expect("list");
+
+        assert_eq!(models.len(), 2, "pairing must never cross directories");
+        assert!(models.iter().all(|m| m.mmproj_path.is_none()));
     }
 
     #[test]

--- a/src/llm/provider/mod.rs
+++ b/src/llm/provider/mod.rs
@@ -21,6 +21,8 @@ pub mod anthropic;
 pub mod azure;
 pub mod factory;
 pub mod gemini;
+#[cfg(feature = "gguf-management")]
+pub mod gguf_metadata;
 #[cfg(feature = "llama-cpp")]
 pub mod llama_cpp;
 #[cfg(feature = "llama-cpp-llguidance")]

--- a/src/llm/provider/mod.rs
+++ b/src/llm/provider/mod.rs
@@ -23,6 +23,8 @@ pub mod factory;
 pub mod gemini;
 #[cfg(feature = "gguf-management")]
 pub mod gguf_metadata;
+#[cfg(feature = "gguf-management")]
+pub mod hardware_detect;
 #[cfg(feature = "llama-cpp")]
 pub mod llama_cpp;
 #[cfg(feature = "llama-cpp-llguidance")]

--- a/src/llm/provider/mod.rs
+++ b/src/llm/provider/mod.rs
@@ -25,7 +25,7 @@ pub mod gemini;
 pub mod llama_cpp;
 #[cfg(feature = "llama-cpp-llguidance")]
 pub mod llama_cpp_grammar;
-#[cfg(feature = "llama-cpp")]
+#[cfg(feature = "gguf-management")]
 pub mod llama_cpp_models;
 #[cfg(feature = "ollama")]
 pub mod ollama;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use crustly::{cli, logging};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<std::process::ExitCode> {
     // Parse CLI arguments first to check for debug flag
     let cli_args = cli::Cli::parse();
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -190,6 +190,16 @@ pub struct App {
     llama_cpp_switch_task: Option<tokio::task::JoinHandle<()>>,
     llama_cpp_pending_provider: super::llama_cpp_download::PendingProvider,
     llama_cpp_models_dir: std::path::PathBuf,
+    /// `providers.llama_cpp.extra_model_paths` - additional directories the
+    /// Ctrl+G dialog also scans, beyond `llama_cpp_models_dir`. Empty
+    /// unless configured - see `ccguf-managment-imrpoment-plan.md` M3.
+    llama_cpp_extra_model_paths: Vec<std::path::PathBuf>,
+    /// Ollama's models directory, only `Some` when
+    /// `providers.llama_cpp.scan_ollama_models` opted in
+    /// (`ProviderConfigs::llama_cpp_ollama_models_dir()` already applies
+    /// that gate) - `None` means the Ctrl+G dialog doesn't scan Ollama at
+    /// all, same as before this field existed.
+    llama_cpp_ollama_models_dir: Option<std::path::PathBuf>,
     /// The `[providers.llama_cpp]` config section, applied (minus
     /// `model_path`, which is always the picked file) when Ctrl+G switches
     /// models - mirrors `ollama_config`'s rationale exactly.
@@ -326,6 +336,8 @@ impl App {
                 .unwrap_or_else(|| std::path::PathBuf::from("."))
                 .join("crustly")
                 .join("models"),
+            llama_cpp_extra_model_paths: Vec::new(),
+            llama_cpp_ollama_models_dir: None,
             llama_cpp_config: None,
             llama_cpp_active_model_path: None,
             skills_list: Vec::new(),
@@ -557,6 +569,22 @@ impl App {
     /// and downloads into.
     pub fn set_llama_cpp_models_dir(&mut self, dir: std::path::PathBuf) {
         self.llama_cpp_models_dir = dir;
+    }
+
+    /// Record the extra discovery sources
+    /// (`ProviderConfigs::llama_cpp_extra_model_paths()`/
+    /// `llama_cpp_ollama_models_dir()`) the Ctrl+G dialog also scans,
+    /// beyond `llama_cpp_models_dir`. Separate from
+    /// `set_llama_cpp_models_dir` since the primary directory is also used
+    /// as the download target (`start_llama_cpp_download`), which these
+    /// extra sources are not.
+    pub fn set_llama_cpp_discovery_sources(
+        &mut self,
+        extra_model_paths: Vec<std::path::PathBuf>,
+        ollama_models_dir: Option<std::path::PathBuf>,
+    ) {
+        self.llama_cpp_extra_model_paths = extra_model_paths;
+        self.llama_cpp_ollama_models_dir = ollama_models_dir;
     }
 
     /// Record the `[providers.llama_cpp]` config (and, if the active
@@ -901,9 +929,16 @@ impl App {
                 // Refresh the local model list in the background so a
                 // successful download shows up next time the dialog opens.
                 let models_dir = self.llama_cpp_models_dir.clone();
+                let extra_model_paths = self.llama_cpp_extra_model_paths.clone();
+                let ollama_models_dir = self.llama_cpp_ollama_models_dir.clone();
                 let sender = self.event_sender();
                 tokio::spawn(async move {
-                    let models = super::llama_cpp_download::list_local(models_dir).await;
+                    let models = super::llama_cpp_download::list_local(
+                        models_dir,
+                        extra_model_paths,
+                        ollama_models_dir,
+                    )
+                    .await;
                     let _ = sender.send(TuiEvent::LlamaCppModelsListed(models));
                 });
             }
@@ -2786,9 +2821,16 @@ impl App {
         self.llama_cpp_loading = true;
 
         let models_dir = self.llama_cpp_models_dir.clone();
+        let extra_model_paths = self.llama_cpp_extra_model_paths.clone();
+        let ollama_models_dir = self.llama_cpp_ollama_models_dir.clone();
         let sender = self.event_sender();
         tokio::spawn(async move {
-            let models = super::llama_cpp_download::list_local(models_dir).await;
+            let models = super::llama_cpp_download::list_local(
+                models_dir,
+                extra_model_paths,
+                ollama_models_dir,
+            )
+            .await;
             let _ = sender.send(TuiEvent::LlamaCppModelsListed(models));
         });
 
@@ -4230,6 +4272,9 @@ mod tests {
                 parameter_count: None,
                 context_length: None,
                 has_chat_template: false,
+                display_name: None,
+                estimated_memory_bytes: None,
+                estimated_memory_includes_kv_cache: false,
             },
             super::super::llama_cpp_download::LlamaCppModelSummary {
                 path: std::path::PathBuf::from("/models/b.gguf"),
@@ -4239,6 +4284,9 @@ mod tests {
                 parameter_count: None,
                 context_length: None,
                 has_chat_template: false,
+                display_name: None,
+                estimated_memory_bytes: None,
+                estimated_memory_includes_kv_cache: false,
             },
         ]))
         .await
@@ -4263,6 +4311,9 @@ mod tests {
                 parameter_count: None,
                 context_length: None,
                 has_chat_template: false,
+                display_name: None,
+                estimated_memory_bytes: None,
+                estimated_memory_includes_kv_cache: false,
             },
             super::super::llama_cpp_download::LlamaCppModelSummary {
                 path: std::path::PathBuf::from("/models/b.gguf"),
@@ -4272,6 +4323,9 @@ mod tests {
                 parameter_count: None,
                 context_length: None,
                 has_chat_template: false,
+                display_name: None,
+                estimated_memory_bytes: None,
+                estimated_memory_includes_kv_cache: false,
             },
         ];
 
@@ -4330,6 +4384,9 @@ mod tests {
             parameter_count: None,
             context_length: None,
             has_chat_template: false,
+            display_name: None,
+            estimated_memory_bytes: None,
+            estimated_memory_includes_kv_cache: false,
         }];
 
         app.handle_llama_cpp_models_key(key(KeyCode::Delete))
@@ -4355,6 +4412,9 @@ mod tests {
             parameter_count: None,
             context_length: None,
             has_chat_template: false,
+            display_name: None,
+            estimated_memory_bytes: None,
+            estimated_memory_includes_kv_cache: false,
         }];
         app.llama_cpp_deleting = Some(std::path::PathBuf::from("/models/a.gguf"));
 
@@ -4440,6 +4500,9 @@ mod tests {
             parameter_count: None,
             context_length: None,
             has_chat_template: false,
+            display_name: None,
+            estimated_memory_bytes: None,
+            estimated_memory_includes_kv_cache: false,
         }];
 
         // Enter would normally start a switch to the highlighted model.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -268,6 +268,28 @@ fn quantization_hint_for_path(_path: &std::path::Path) -> Option<String> {
     None
 }
 
+/// The model's native/trained context length and whether it has an
+/// embedded chat template, for the Model Info panel (Ctrl+O) - the
+/// `context_length`/`has_chat_template` counterpart of
+/// `quantization_hint_for_path` above, same cfg-gating rationale
+/// (`ccguf-managment-imrpoment-plan.md` Phase M0/M8). A second,
+/// independent header read from `quantization_hint_for_path`'s - the
+/// Model Info panel is a low-frequency render, not a hot loop, so the
+/// minor duplication isn't worth threading the header through both call
+/// sites for.
+#[cfg(feature = "gguf-management")]
+fn llama_cpp_context_and_chat_template_for_path(path: &std::path::Path) -> (Option<u64>, bool) {
+    match crate::llm::provider::gguf_metadata::read_gguf_metadata(path) {
+        Some(m) => (m.context_length, m.has_chat_template),
+        None => (None, false),
+    }
+}
+
+#[cfg(not(feature = "gguf-management"))]
+fn llama_cpp_context_and_chat_template_for_path(_path: &std::path::Path) -> (Option<u64>, bool) {
+    (None, false)
+}
+
 impl App {
     /// Create a new app instance
     pub fn new(agent_service: Arc<AgentService>, context: ServiceContext) -> Self {
@@ -614,9 +636,13 @@ impl App {
             .llama_cpp_active_model_path
             .as_ref()
             .unwrap_or(&cfg.model_path);
+        let (context_length, has_chat_template) =
+            llama_cpp_context_and_chat_template_for_path(model_path);
         Some(super::llama_cpp_download::LlamaCppModelDetails {
             n_gpu_layers: cfg.n_gpu_layers,
             quantization_hint: quantization_hint_for_path(model_path),
+            context_length,
+            has_chat_template,
         })
     }
 
@@ -3008,6 +3034,49 @@ mod tests {
         let display_msg: DisplayMessage = msg.into();
         assert_eq!(display_msg.role, "user");
         assert_eq!(display_msg.content, "Hello");
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_context_and_chat_template_for_path_reads_a_real_header() {
+        // Hand-crafted minimal GGUF bytes, same pattern as
+        // gguf_metadata.rs's own tests - magic + version + zero tensors +
+        // two KV pairs (a context_length key and chat_template presence).
+        fn push_string(buf: &mut Vec<u8>, s: &str) {
+            buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+            buf.extend_from_slice(s.as_bytes());
+        }
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version
+        buf.extend_from_slice(&0u64.to_le_bytes()); // tensor_count
+        buf.extend_from_slice(&2u64.to_le_bytes()); // kv_count
+
+        push_string(&mut buf, "qwen2.context_length");
+        buf.extend_from_slice(&4u32.to_le_bytes()); // ValueType::U32
+        buf.extend_from_slice(&32768u32.to_le_bytes());
+
+        push_string(&mut buf, "tokenizer.chat_template");
+        buf.extend_from_slice(&8u32.to_le_bytes()); // ValueType::String
+        push_string(&mut buf, "{{ messages }}");
+
+        let file = tempfile::NamedTempFile::new().expect("temp file");
+        std::fs::write(file.path(), &buf).expect("write fixture");
+
+        let (context_length, has_chat_template) =
+            llama_cpp_context_and_chat_template_for_path(file.path());
+        assert_eq!(context_length, Some(32768));
+        assert!(has_chat_template);
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_context_and_chat_template_for_path_degrades_cleanly_on_a_missing_file() {
+        let path = std::path::Path::new("/definitely/does/not/exist/crustly-test.gguf");
+        assert_eq!(
+            llama_cpp_context_and_chat_template_for_path(path),
+            (None, false)
+        );
     }
 
     use crate::db::Database;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -254,50 +254,44 @@ fn plain_textarea() -> TextArea<'static> {
     textarea
 }
 
-/// Best-effort quantization guess for the Model Info panel - `None` when
-/// this build wasn't compiled with `--features gguf-management` (on by
-/// `default`) or nothing could be determined at all. Gated on
-/// `gguf-management`, not `llama-cpp`, since this involves no FFI - see
-/// `ccguf-managment-imrpoment-plan.md` Phase M0. Prefers the real
-/// GGUF-header-parsed value (Phase M1 - precise where `general.file_type`
-/// is set, coarser otherwise) over the filename-convention guess, falling
-/// back to the filename only when the header itself can't be read.
+/// Quantization hint, native/trained context length, and embedded-chat-
+/// template presence for the Model Info panel (Ctrl+O), from a *single*
+/// GGUF header read - `None`/defaults when this build wasn't compiled with
+/// `--features gguf-management` (on by `default`) or nothing could be
+/// determined at all. Gated on `gguf-management`, not `llama-cpp`, since
+/// this involves no FFI - see `ccguf-managment-imrpoment-plan.md` Phase M0.
+///
+/// `render_model_info` (`render.rs`) redraws on every `terminal.draw` while
+/// the panel is open (every ~100ms per the runner's cadence, not the
+/// "low-frequency render" this used to assume when it read the header
+/// twice via two separate functions) - one parse per call halves the
+/// per-frame disk I/O that duplication cost. Full elimination (caching the
+/// parsed header for the lifetime of the active model path) would need a
+/// new `App` field and an invalidation rule; left for a future pass if the
+/// remaining per-frame read still matters in practice.
 #[cfg(feature = "gguf-management")]
-fn quantization_hint_for_path(path: &std::path::Path) -> Option<String> {
-    crate::llm::provider::gguf_metadata::read_gguf_metadata(path)
-        .and_then(|m| m.quantization)
+fn llama_cpp_model_header_summary_for_path(
+    path: &std::path::Path,
+) -> (Option<String>, Option<u64>, bool) {
+    let header = crate::llm::provider::gguf_metadata::read_gguf_metadata(path);
+    let quantization_hint = header
+        .as_ref()
+        .and_then(|m| m.quantization.clone())
         .or_else(|| {
             crate::llm::provider::llama_cpp_models::quantization_hint_from_filename(
                 &path.to_string_lossy(),
             )
-        })
+        });
+    let context_length = header.as_ref().and_then(|m| m.context_length);
+    let has_chat_template = header.as_ref().is_some_and(|m| m.has_chat_template);
+    (quantization_hint, context_length, has_chat_template)
 }
 
 #[cfg(not(feature = "gguf-management"))]
-fn quantization_hint_for_path(_path: &std::path::Path) -> Option<String> {
-    None
-}
-
-/// The model's native/trained context length and whether it has an
-/// embedded chat template, for the Model Info panel (Ctrl+O) - the
-/// `context_length`/`has_chat_template` counterpart of
-/// `quantization_hint_for_path` above, same cfg-gating rationale
-/// (`ccguf-managment-imrpoment-plan.md` Phase M0/M8). A second,
-/// independent header read from `quantization_hint_for_path`'s - the
-/// Model Info panel is a low-frequency render, not a hot loop, so the
-/// minor duplication isn't worth threading the header through both call
-/// sites for.
-#[cfg(feature = "gguf-management")]
-fn llama_cpp_context_and_chat_template_for_path(path: &std::path::Path) -> (Option<u64>, bool) {
-    match crate::llm::provider::gguf_metadata::read_gguf_metadata(path) {
-        Some(m) => (m.context_length, m.has_chat_template),
-        None => (None, false),
-    }
-}
-
-#[cfg(not(feature = "gguf-management"))]
-fn llama_cpp_context_and_chat_template_for_path(_path: &std::path::Path) -> (Option<u64>, bool) {
-    (None, false)
+fn llama_cpp_model_header_summary_for_path(
+    _path: &std::path::Path,
+) -> (Option<String>, Option<u64>, bool) {
+    (None, None, false)
 }
 
 impl App {
@@ -648,11 +642,11 @@ impl App {
             .llama_cpp_active_model_path
             .as_ref()
             .unwrap_or(&cfg.model_path);
-        let (context_length, has_chat_template) =
-            llama_cpp_context_and_chat_template_for_path(model_path);
+        let (quantization_hint, context_length, has_chat_template) =
+            llama_cpp_model_header_summary_for_path(model_path);
         Some(super::llama_cpp_download::LlamaCppModelDetails {
             n_gpu_layers: cfg.n_gpu_layers,
-            quantization_hint: quantization_hint_for_path(model_path),
+            quantization_hint,
             context_length,
             has_chat_template,
         })
@@ -3068,10 +3062,11 @@ mod tests {
 
     #[cfg(feature = "gguf-management")]
     #[test]
-    fn llama_cpp_context_and_chat_template_for_path_reads_a_real_header() {
+    fn llama_cpp_model_header_summary_for_path_reads_a_real_header_once() {
         // Hand-crafted minimal GGUF bytes, same pattern as
         // gguf_metadata.rs's own tests - magic + version + zero tensors +
-        // two KV pairs (a context_length key and chat_template presence).
+        // three KV pairs (quantization, context_length, chat_template
+        // presence) - covering all three return values from one parse.
         fn push_string(buf: &mut Vec<u8>, s: &str) {
             buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
             buf.extend_from_slice(s.as_bytes());
@@ -3080,7 +3075,11 @@ mod tests {
         buf.extend_from_slice(b"GGUF");
         buf.extend_from_slice(&3u32.to_le_bytes()); // version
         buf.extend_from_slice(&0u64.to_le_bytes()); // tensor_count
-        buf.extend_from_slice(&2u64.to_le_bytes()); // kv_count
+        buf.extend_from_slice(&3u64.to_le_bytes()); // kv_count
+
+        push_string(&mut buf, "general.file_type");
+        buf.extend_from_slice(&4u32.to_le_bytes()); // ValueType::U32
+        buf.extend_from_slice(&15u32.to_le_bytes()); // Q4_K_M
 
         push_string(&mut buf, "qwen2.context_length");
         buf.extend_from_slice(&4u32.to_le_bytes()); // ValueType::U32
@@ -3093,20 +3092,25 @@ mod tests {
         let file = tempfile::NamedTempFile::new().expect("temp file");
         std::fs::write(file.path(), &buf).expect("write fixture");
 
-        let (context_length, has_chat_template) =
-            llama_cpp_context_and_chat_template_for_path(file.path());
+        let (quantization_hint, context_length, has_chat_template) =
+            llama_cpp_model_header_summary_for_path(file.path());
+        assert_eq!(quantization_hint.as_deref(), Some("Q4_K_M"));
         assert_eq!(context_length, Some(32768));
         assert!(has_chat_template);
     }
 
     #[cfg(feature = "gguf-management")]
     #[test]
-    fn llama_cpp_context_and_chat_template_for_path_degrades_cleanly_on_a_missing_file() {
+    fn llama_cpp_model_header_summary_for_path_degrades_cleanly_on_a_missing_file() {
         let path = std::path::Path::new("/definitely/does/not/exist/crustly-test.gguf");
-        assert_eq!(
-            llama_cpp_context_and_chat_template_for_path(path),
-            (None, false)
-        );
+        let (quantization_hint, context_length, has_chat_template) =
+            llama_cpp_model_header_summary_for_path(path);
+        assert_eq!(context_length, None);
+        assert!(!has_chat_template);
+        // Falls back to the filename-convention guess when the header
+        // itself can't be read - this fixture's name has no recognizable
+        // quantization tag in it, so that fallback comes up empty too.
+        assert_eq!(quantization_hint, None);
     }
 
     use crate::db::Database;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -208,6 +208,16 @@ pub struct App {
     /// `llama-cpp` - used by the Model Info panel for GPU-layers/quantization
     /// details, since neither is on the generic `Provider` trait.
     llama_cpp_active_model_path: Option<std::path::PathBuf>,
+    /// This machine's detected hardware (Phase M11) - `None` until the
+    /// Ctrl+G dialog's background detection task completes; stays `Some`
+    /// for the rest of the TUI session once set (detection itself is
+    /// separately cached process-wide by `hardware_detect`'s own
+    /// `OnceLock` - this field just avoids re-firing the background task
+    /// on every dialog open).
+    pub llama_cpp_hardware: Option<super::llama_cpp_download::HardwareSummary>,
+    /// Whether the hardware-detection background task is in flight - drives
+    /// the dialog's "detecting hardware…" host-info row.
+    pub llama_cpp_hardware_loading: bool,
 
     // `/skills` slash command state
     pub skills_list: Vec<crate::llm::tools::skill::SkillListing>,
@@ -362,6 +372,8 @@ impl App {
             llama_cpp_ollama_models_dir: None,
             llama_cpp_config: None,
             llama_cpp_active_model_path: None,
+            llama_cpp_hardware: None,
+            llama_cpp_hardware_loading: false,
             skills_list: Vec::new(),
             skills_selected: 0,
             mcp_selected: 0,
@@ -914,6 +926,10 @@ impl App {
                 self.llama_cpp_loading = false;
                 self.llama_cpp_models = models;
                 self.llama_cpp_selected = 0;
+            }
+            TuiEvent::LlamaCppHardwareDetected(hardware) => {
+                self.llama_cpp_hardware_loading = false;
+                self.llama_cpp_hardware = Some(hardware);
             }
             TuiEvent::LlamaCppDownloadProgress(progress) => {
                 self.llama_cpp_download_fraction = progress.fraction();
@@ -2860,6 +2876,20 @@ impl App {
             let _ = sender.send(TuiEvent::LlamaCppModelsListed(models));
         });
 
+        // Hardware detection (Phase M11) spawns subprocesses, so it's only
+        // triggered once per TUI session - the first time this dialog opens
+        // (`hardware_detect`'s own "when this runs" rule) - not on every
+        // subsequent open, even though detection itself is separately
+        // cached process-wide by a `OnceLock` and would be cheap either way.
+        if self.llama_cpp_hardware.is_none() && !self.llama_cpp_hardware_loading {
+            self.llama_cpp_hardware_loading = true;
+            let sender = self.event_sender();
+            tokio::spawn(async move {
+                let hardware = super::llama_cpp_download::detect_hardware_summary().await;
+                let _ = sender.send(TuiEvent::LlamaCppHardwareDetected(hardware));
+            });
+        }
+
         self.switch_mode(AppMode::LlamaCppModelPicker).await
     }
 
@@ -4325,6 +4355,51 @@ mod tests {
         assert_eq!(app.mode, AppMode::LlamaCppModelPicker);
         assert!(app.llama_cpp_loading);
         assert!(app.llama_cpp_models.is_empty());
+        // Phase M11: hardware detection kicks off alongside the model scan
+        // the first time this dialog opens.
+        assert!(app.llama_cpp_hardware_loading);
+        assert!(app.llama_cpp_hardware.is_none());
+    }
+
+    #[tokio::test]
+    async fn ctrl_g_does_not_re_trigger_hardware_detection_on_a_second_open() {
+        let mut app = test_app().await;
+        app.mode = AppMode::Chat;
+        app.llama_cpp_hardware = Some(super::super::llama_cpp_download::HardwareSummary {
+            gpu_name: None,
+            vram_available_bytes: None,
+            system_ram_total_bytes: Some(1),
+        });
+
+        app.handle_key_event(key_mod(KeyCode::Char('g'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+
+        assert!(
+            !app.llama_cpp_hardware_loading,
+            "already-detected hardware must not be re-fetched on a later dialog open"
+        );
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_hardware_detected_clears_loading_state_and_stores_the_result() {
+        let mut app = test_app().await;
+        app.llama_cpp_hardware_loading = true;
+
+        app.handle_event(TuiEvent::LlamaCppHardwareDetected(
+            super::super::llama_cpp_download::HardwareSummary {
+                gpu_name: Some("Test GPU".to_string()),
+                vram_available_bytes: Some(1_000),
+                system_ram_total_bytes: Some(2_000),
+            },
+        ))
+        .await
+        .unwrap();
+
+        assert!(!app.llama_cpp_hardware_loading);
+        let hardware = app.llama_cpp_hardware.expect("hardware must be set");
+        assert_eq!(hardware.gpu_name.as_deref(), Some("Test GPU"));
+        assert_eq!(hardware.budget_bytes(), Some(3_000));
     }
 
     #[tokio::test]
@@ -4344,6 +4419,7 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                estimated_memory_context_length: None,
                 is_mmproj: false,
                 mmproj_path: None,
             },
@@ -4358,6 +4434,7 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                estimated_memory_context_length: None,
                 is_mmproj: false,
                 mmproj_path: None,
             },
@@ -4387,6 +4464,7 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                estimated_memory_context_length: None,
                 is_mmproj: false,
                 mmproj_path: None,
             },
@@ -4401,6 +4479,7 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                estimated_memory_context_length: None,
                 is_mmproj: false,
                 mmproj_path: None,
             },
@@ -4464,6 +4543,7 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            estimated_memory_context_length: None,
             is_mmproj: false,
             mmproj_path: None,
         }];
@@ -4494,6 +4574,7 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            estimated_memory_context_length: None,
             is_mmproj: false,
             mmproj_path: None,
         }];
@@ -4584,6 +4665,7 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            estimated_memory_context_length: None,
             is_mmproj: false,
             mmproj_path: None,
         }];

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -236,13 +236,21 @@ fn plain_textarea() -> TextArea<'static> {
 
 /// Best-effort quantization guess for the Model Info panel - `None` when
 /// this build wasn't compiled with `--features gguf-management` (on by
-/// `default`; nothing to guess from) or the filename doesn't match a known
-/// convention. Gated on `gguf-management`, not `llama-cpp`, since this is
-/// pure filename parsing with no FFI involved - see
-/// `ccguf-managment-imrpoment-plan.md` Phase M0.
+/// `default`) or nothing could be determined at all. Gated on
+/// `gguf-management`, not `llama-cpp`, since this involves no FFI - see
+/// `ccguf-managment-imrpoment-plan.md` Phase M0. Prefers the real
+/// GGUF-header-parsed value (Phase M1 - precise where `general.file_type`
+/// is set, coarser otherwise) over the filename-convention guess, falling
+/// back to the filename only when the header itself can't be read.
 #[cfg(feature = "gguf-management")]
 fn quantization_hint_for_path(path: &std::path::Path) -> Option<String> {
-    crate::llm::provider::llama_cpp_models::quantization_hint_from_filename(&path.to_string_lossy())
+    crate::llm::provider::gguf_metadata::read_gguf_metadata(path)
+        .and_then(|m| m.quantization)
+        .or_else(|| {
+            crate::llm::provider::llama_cpp_models::quantization_hint_from_filename(
+                &path.to_string_lossy(),
+            )
+        })
 }
 
 #[cfg(not(feature = "gguf-management"))]
@@ -4218,11 +4226,19 @@ mod tests {
                 path: std::path::PathBuf::from("/models/a.gguf"),
                 size_bytes: 100,
                 quantization_hint: Some("Q4_K_M".to_string()),
+                architecture: None,
+                parameter_count: None,
+                context_length: None,
+                has_chat_template: false,
             },
             super::super::llama_cpp_download::LlamaCppModelSummary {
                 path: std::path::PathBuf::from("/models/b.gguf"),
                 size_bytes: 200,
                 quantization_hint: None,
+                architecture: None,
+                parameter_count: None,
+                context_length: None,
+                has_chat_template: false,
             },
         ]))
         .await
@@ -4243,11 +4259,19 @@ mod tests {
                 path: std::path::PathBuf::from("/models/a.gguf"),
                 size_bytes: 100,
                 quantization_hint: None,
+                architecture: None,
+                parameter_count: None,
+                context_length: None,
+                has_chat_template: false,
             },
             super::super::llama_cpp_download::LlamaCppModelSummary {
                 path: std::path::PathBuf::from("/models/b.gguf"),
                 size_bytes: 100,
                 quantization_hint: None,
+                architecture: None,
+                parameter_count: None,
+                context_length: None,
+                has_chat_template: false,
             },
         ];
 
@@ -4302,6 +4326,10 @@ mod tests {
             path: std::path::PathBuf::from("/models/a.gguf"),
             size_bytes: 100,
             quantization_hint: None,
+            architecture: None,
+            parameter_count: None,
+            context_length: None,
+            has_chat_template: false,
         }];
 
         app.handle_llama_cpp_models_key(key(KeyCode::Delete))
@@ -4323,6 +4351,10 @@ mod tests {
             path: std::path::PathBuf::from("/models/a.gguf"),
             size_bytes: 100,
             quantization_hint: None,
+            architecture: None,
+            parameter_count: None,
+            context_length: None,
+            has_chat_template: false,
         }];
         app.llama_cpp_deleting = Some(std::path::PathBuf::from("/models/a.gguf"));
 
@@ -4404,6 +4436,10 @@ mod tests {
             path: std::path::PathBuf::from("/models/b.gguf"),
             size_bytes: 100,
             quantization_hint: None,
+            architecture: None,
+            parameter_count: None,
+            context_length: None,
+            has_chat_template: false,
         }];
 
         // Enter would normally start a switch to the highlighted model.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -235,14 +235,17 @@ fn plain_textarea() -> TextArea<'static> {
 }
 
 /// Best-effort quantization guess for the Model Info panel - `None` when
-/// this build wasn't compiled with `--features llama-cpp` (nothing to guess
-/// from) or the filename doesn't match a known convention.
-#[cfg(feature = "llama-cpp")]
+/// this build wasn't compiled with `--features gguf-management` (on by
+/// `default`; nothing to guess from) or the filename doesn't match a known
+/// convention. Gated on `gguf-management`, not `llama-cpp`, since this is
+/// pure filename parsing with no FFI involved - see
+/// `ccguf-managment-imrpoment-plan.md` Phase M0.
+#[cfg(feature = "gguf-management")]
 fn quantization_hint_for_path(path: &std::path::Path) -> Option<String> {
     crate::llm::provider::llama_cpp_models::quantization_hint_from_filename(&path.to_string_lossy())
 }
 
-#[cfg(not(feature = "llama-cpp"))]
+#[cfg(not(feature = "gguf-management"))]
 fn quantization_hint_for_path(_path: &std::path::Path) -> Option<String> {
     None
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4275,6 +4275,8 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                is_mmproj: false,
+                mmproj_path: None,
             },
             super::super::llama_cpp_download::LlamaCppModelSummary {
                 path: std::path::PathBuf::from("/models/b.gguf"),
@@ -4287,6 +4289,8 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                is_mmproj: false,
+                mmproj_path: None,
             },
         ]))
         .await
@@ -4314,6 +4318,8 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                is_mmproj: false,
+                mmproj_path: None,
             },
             super::super::llama_cpp_download::LlamaCppModelSummary {
                 path: std::path::PathBuf::from("/models/b.gguf"),
@@ -4326,6 +4332,8 @@ mod tests {
                 display_name: None,
                 estimated_memory_bytes: None,
                 estimated_memory_includes_kv_cache: false,
+                is_mmproj: false,
+                mmproj_path: None,
             },
         ];
 
@@ -4387,6 +4395,8 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            is_mmproj: false,
+            mmproj_path: None,
         }];
 
         app.handle_llama_cpp_models_key(key(KeyCode::Delete))
@@ -4415,6 +4425,8 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            is_mmproj: false,
+            mmproj_path: None,
         }];
         app.llama_cpp_deleting = Some(std::path::PathBuf::from("/models/a.gguf"));
 
@@ -4503,6 +4515,8 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            is_mmproj: false,
+            mmproj_path: None,
         }];
 
         // Enter would normally start a switch to the highlighted model.

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -92,6 +92,12 @@ pub enum TuiEvent {
     /// dialog (Ctrl+G).
     LlamaCppModelsListed(Vec<super::llama_cpp_download::LlamaCppModelSummary>),
 
+    /// This machine's hardware (GPU/VRAM/RAM) was detected for the llama.cpp
+    /// Local Models dialog's host-info row (Phase M11) - fired once, the
+    /// first time the dialog opens per TUI session (see
+    /// `App::open_llama_cpp_models`).
+    LlamaCppHardwareDetected(super::llama_cpp_download::HardwareSummary),
+
     /// Progress update for an in-flight llama.cpp `.gguf` download.
     LlamaCppDownloadProgress(super::llama_cpp_download::LlamaCppDownloadProgress),
 

--- a/src/tui/llama_cpp_download.rs
+++ b/src/tui/llama_cpp_download.rs
@@ -33,12 +33,19 @@ use tokio::task::JoinHandle;
 
 /// A locally-present `.gguf` file, decoupled from the `llama-cpp` feature so
 /// it can live on the always-compiled `TuiEvent`/`App` state - the TUI
-/// equivalent of `llama_cpp_models::LocalGgufModel`.
+/// equivalent of `llama_cpp_models::LocalGgufModel`. Field-for-field mirror
+/// (see `list_local`'s mapping) so header-parsed metadata added in
+/// `LocalGgufModel` (Phase M1) isn't dropped at this boundary even before a
+/// later phase renders it.
 #[derive(Debug, Clone)]
 pub struct LlamaCppModelSummary {
     pub path: PathBuf,
     pub size_bytes: u64,
     pub quantization_hint: Option<String>,
+    pub architecture: Option<String>,
+    pub parameter_count: Option<u64>,
+    pub context_length: Option<u64>,
+    pub has_chat_template: bool,
 }
 
 /// One progress update from an in-flight download, decoupled from the
@@ -87,6 +94,10 @@ pub async fn list_local(models_dir: PathBuf) -> Vec<LlamaCppModelSummary> {
             path: m.path,
             size_bytes: m.size_bytes,
             quantization_hint: m.quantization_hint,
+            architecture: m.architecture,
+            parameter_count: m.parameter_count,
+            context_length: m.context_length,
+            has_chat_template: m.has_chat_template,
         })
         .collect()
 }
@@ -297,6 +308,10 @@ mod tests {
             path: PathBuf::from(name),
             size_bytes: 1_000_000,
             quantization_hint: Some("Q4_K_M".to_string()),
+            architecture: None,
+            parameter_count: None,
+            context_length: None,
+            has_chat_template: false,
         }
     }
 

--- a/src/tui/llama_cpp_download.rs
+++ b/src/tui/llama_cpp_download.rs
@@ -46,6 +46,9 @@ pub struct LlamaCppModelSummary {
     pub parameter_count: Option<u64>,
     pub context_length: Option<u64>,
     pub has_chat_template: bool,
+    pub display_name: Option<String>,
+    pub estimated_memory_bytes: Option<u64>,
+    pub estimated_memory_includes_kv_cache: bool,
 }
 
 /// One progress update from an in-flight download, decoupled from the
@@ -79,31 +82,48 @@ pub struct LlamaCppModelDetails {
 /// the slot", the provider crosses the thread boundary through this instead.
 pub type PendingProvider = Arc<Mutex<Option<Arc<dyn crate::llm::provider::Provider>>>>;
 
-/// List `.gguf` files already present in `models_dir`. Returns an empty
-/// list (never an error) when the feature isn't compiled in or the
-/// directory can't be read - the dialog just shows "no local models" rather
-/// than surfacing a scan failure the user can't act on.
+/// List `.gguf` files from `models_dir`, `extra_model_paths`, and (when
+/// `Some`) Ollama's manifest tree - see
+/// `llama_cpp_models::list_all_local_models` for the merge/dedup behavior.
+/// Returns an empty list (never an error) when the feature isn't compiled
+/// in or nothing could be scanned - the dialog just shows "no local
+/// models" rather than surfacing a scan failure the user can't act on.
 #[cfg(feature = "gguf-management")]
-pub async fn list_local(models_dir: PathBuf) -> Vec<LlamaCppModelSummary> {
+pub async fn list_local(
+    models_dir: PathBuf,
+    extra_model_paths: Vec<PathBuf>,
+    ollama_models_dir: Option<PathBuf>,
+) -> Vec<LlamaCppModelSummary> {
     use crate::llm::provider::llama_cpp_models;
 
-    llama_cpp_models::list_local_models(&models_dir)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|m| LlamaCppModelSummary {
-            path: m.path,
-            size_bytes: m.size_bytes,
-            quantization_hint: m.quantization_hint,
-            architecture: m.architecture,
-            parameter_count: m.parameter_count,
-            context_length: m.context_length,
-            has_chat_template: m.has_chat_template,
-        })
-        .collect()
+    llama_cpp_models::list_all_local_models(
+        &models_dir,
+        &extra_model_paths,
+        ollama_models_dir.as_deref(),
+    )
+    .unwrap_or_default()
+    .into_iter()
+    .map(|m| LlamaCppModelSummary {
+        path: m.path,
+        size_bytes: m.size_bytes,
+        quantization_hint: m.quantization_hint,
+        architecture: m.architecture,
+        parameter_count: m.parameter_count,
+        context_length: m.context_length,
+        has_chat_template: m.has_chat_template,
+        display_name: m.display_name,
+        estimated_memory_bytes: m.estimated_memory_bytes,
+        estimated_memory_includes_kv_cache: m.estimated_memory_includes_kv_cache,
+    })
+    .collect()
 }
 
 #[cfg(not(feature = "gguf-management"))]
-pub async fn list_local(_models_dir: PathBuf) -> Vec<LlamaCppModelSummary> {
+pub async fn list_local(
+    _models_dir: PathBuf,
+    _extra_model_paths: Vec<PathBuf>,
+    _ollama_models_dir: Option<PathBuf>,
+) -> Vec<LlamaCppModelSummary> {
     Vec::new()
 }
 
@@ -312,6 +332,9 @@ mod tests {
             parameter_count: None,
             context_length: None,
             has_chat_template: false,
+            display_name: None,
+            estimated_memory_bytes: None,
+            estimated_memory_includes_kv_cache: false,
         }
     }
 
@@ -359,7 +382,9 @@ mod tests {
     #[cfg(not(feature = "gguf-management"))]
     #[tokio::test]
     async fn list_local_without_feature_is_empty() {
-        assert!(list_local(PathBuf::from("/tmp/anything")).await.is_empty());
+        assert!(list_local(PathBuf::from("/tmp/anything"), Vec::new(), None)
+            .await
+            .is_empty());
     }
 
     #[cfg(not(feature = "llama-cpp"))]

--- a/src/tui/llama_cpp_download.rs
+++ b/src/tui/llama_cpp_download.rs
@@ -49,6 +49,10 @@ pub struct LlamaCppModelSummary {
     pub display_name: Option<String>,
     pub estimated_memory_bytes: Option<u64>,
     pub estimated_memory_includes_kv_cache: bool,
+    /// The context length `estimated_memory_bytes` was actually computed
+    /// at - see `LocalGgufModel::estimated_memory_context_length`. Used by
+    /// Phase M12's per-row fit tag.
+    pub estimated_memory_context_length: Option<u64>,
     pub is_mmproj: bool,
     pub mmproj_path: Option<PathBuf>,
 }
@@ -88,6 +92,63 @@ pub struct LlamaCppModelDetails {
 /// the slot", the provider crosses the thread boundary through this instead.
 pub type PendingProvider = Arc<Mutex<Option<Arc<dyn crate::llm::provider::Provider>>>>;
 
+/// The Local Models dialog's (Ctrl+G) host-info row - the TUI equivalent of
+/// `hardware_detect::HardwareInfo`, decoupled from the `gguf-management`
+/// feature the same way `LlamaCppModelSummary` is decoupled from
+/// `LocalGgufModel` (Phase M11).
+#[derive(Debug, Clone)]
+pub struct HardwareSummary {
+    pub gpu_name: Option<String>,
+    pub vram_available_bytes: Option<u64>,
+    pub system_ram_total_bytes: Option<u64>,
+}
+
+impl HardwareSummary {
+    /// Mirrors `hardware_detect::HardwareInfo::budget_bytes` - kept here
+    /// too (not just called through to it) since the not-compiled-in
+    /// variant of `detect_hardware_summary` below has no `HardwareInfo` to
+    /// call through to at all.
+    pub fn budget_bytes(&self) -> Option<u64> {
+        match (self.vram_available_bytes, self.system_ram_total_bytes) {
+            (None, None) => None,
+            (vram, ram) => Some(vram.unwrap_or(0) + ram.unwrap_or(0)),
+        }
+    }
+}
+
+/// Detects this machine's hardware for the dialog's host-info row - see
+/// `hardware_detect`'s own module doc for the "when this runs" rule this
+/// respects (only called once, the first time the dialog opens - see
+/// `App::open_llama_cpp_models`). Blocking (subprocess spawns), so this
+/// wraps the real detection in `spawn_blocking` rather than calling it
+/// directly on the async runtime.
+#[cfg(feature = "gguf-management")]
+pub async fn detect_hardware_summary() -> HardwareSummary {
+    tokio::task::spawn_blocking(|| {
+        let info = crate::llm::provider::hardware_detect::detect_hardware();
+        HardwareSummary {
+            gpu_name: info.gpu.as_ref().and_then(|g| g.name.clone()),
+            vram_available_bytes: info.gpu.as_ref().and_then(|g| g.vram_available_bytes()),
+            system_ram_total_bytes: info.system_ram_total_bytes,
+        }
+    })
+    .await
+    .unwrap_or(HardwareSummary {
+        gpu_name: None,
+        vram_available_bytes: None,
+        system_ram_total_bytes: None,
+    })
+}
+
+#[cfg(not(feature = "gguf-management"))]
+pub async fn detect_hardware_summary() -> HardwareSummary {
+    HardwareSummary {
+        gpu_name: None,
+        vram_available_bytes: None,
+        system_ram_total_bytes: None,
+    }
+}
+
 /// List `.gguf` files from `models_dir`, `extra_model_paths`, and (when
 /// `Some`) Ollama's manifest tree - see
 /// `llama_cpp_models::list_all_local_models` for the merge/dedup behavior.
@@ -120,6 +181,7 @@ pub async fn list_local(
         display_name: m.display_name,
         estimated_memory_bytes: m.estimated_memory_bytes,
         estimated_memory_includes_kv_cache: m.estimated_memory_includes_kv_cache,
+        estimated_memory_context_length: m.estimated_memory_context_length,
         is_mmproj: m.is_mmproj,
         mmproj_path: m.mmproj_path,
     })
@@ -343,6 +405,7 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            estimated_memory_context_length: None,
             is_mmproj: false,
             mmproj_path: None,
         }

--- a/src/tui/llama_cpp_download.rs
+++ b/src/tui/llama_cpp_download.rs
@@ -71,11 +71,15 @@ impl LlamaCppDownloadProgress {
 
 /// GPU offload / quantization details for the Model Info panel (Ctrl+O)
 /// when the active provider is `llama-cpp`. Context size is already shown
-/// generically via `App::provider_context_window()` - not duplicated here.
+/// generically via `App::provider_context_window()` - not duplicated here,
+/// though it can legitimately differ from `context_length` below (the
+/// *configured* `n_ctx` vs. the model's own *native/trained* context).
 #[derive(Debug, Clone)]
 pub struct LlamaCppModelDetails {
     pub n_gpu_layers: u32,
     pub quantization_hint: Option<String>,
+    pub context_length: Option<u64>,
+    pub has_chat_template: bool,
 }
 
 /// Shared slot the background switch task drops a freshly-built provider

--- a/src/tui/llama_cpp_download.rs
+++ b/src/tui/llama_cpp_download.rs
@@ -14,11 +14,16 @@
 //! runtime, while the dialog shows a "Loading model…" state.
 //!
 //! Every function is compiled unconditionally so `AppMode::LlamaCppModelPicker`
-//! always exists and always says something sensible; the actual filesystem
-//! scan / download / model construction only run when this crate is built
-//! with `--features llama-cpp` (`list_local`/`spawn_download`/`spawn_delete`
-//! degrade to "nothing found" / a clear "rebuild with..." error, mirroring
-//! `ollama_download.rs`'s not-compiled-in fallbacks).
+//! always exists and always says something sensible; the real implementations
+//! are split across two build-time gates
+//! (`ccguf-managment-imrpoment-plan.md` Phase M0). `list_local`/
+//! `spawn_download`/`spawn_delete` (pure filesystem/HTTP, no FFI) only need
+//! `--features gguf-management` (on by `default`); `build_llama_cpp_provider`/
+//! `spawn_switch` (loads model weights via `LlamaCppProvider::new()`) still
+//! need the heavier `--features llama-cpp`. Each not-compiled-in fallback
+//! degrades to "nothing found" / a clear "rebuild with..." error naming the
+//! specific feature it needs, mirroring `ollama_download.rs`'s not-compiled-in
+//! fallbacks.
 
 use super::events::TuiEvent;
 use std::path::PathBuf;
@@ -71,7 +76,7 @@ pub type PendingProvider = Arc<Mutex<Option<Arc<dyn crate::llm::provider::Provid
 /// list (never an error) when the feature isn't compiled in or the
 /// directory can't be read - the dialog just shows "no local models" rather
 /// than surfacing a scan failure the user can't act on.
-#[cfg(feature = "llama-cpp")]
+#[cfg(feature = "gguf-management")]
 pub async fn list_local(models_dir: PathBuf) -> Vec<LlamaCppModelSummary> {
     use crate::llm::provider::llama_cpp_models;
 
@@ -86,7 +91,7 @@ pub async fn list_local(models_dir: PathBuf) -> Vec<LlamaCppModelSummary> {
         .collect()
 }
 
-#[cfg(not(feature = "llama-cpp"))]
+#[cfg(not(feature = "gguf-management"))]
 pub async fn list_local(_models_dir: PathBuf) -> Vec<LlamaCppModelSummary> {
     Vec::new()
 }
@@ -159,7 +164,7 @@ pub async fn spawn_switch(
 /// Start downloading `source` (a direct URL or `hf:org/repo/file.gguf`
 /// shorthand) into `models_dir` in the background, forwarding progress and
 /// the final result through `event_sender`.
-#[cfg(feature = "llama-cpp")]
+#[cfg(feature = "gguf-management")]
 pub async fn spawn_download(
     source: String,
     models_dir: PathBuf,
@@ -208,7 +213,7 @@ pub async fn spawn_download(
     })
 }
 
-#[cfg(not(feature = "llama-cpp"))]
+#[cfg(not(feature = "gguf-management"))]
 pub async fn spawn_download(
     source: String,
     _models_dir: PathBuf,
@@ -218,8 +223,8 @@ pub async fn spawn_download(
         let _ = event_sender.send(TuiEvent::LlamaCppDownloadFinished {
             source,
             error: Some(
-                "This build of crustly was compiled without the 'llama-cpp' feature. \
-                 Rebuild with `--features llama-cpp`."
+                "This build of crustly was compiled without the 'gguf-management' feature. \
+                 Rebuild with `--features gguf-management`."
                     .to_string(),
             ),
         });
@@ -228,7 +233,7 @@ pub async fn spawn_download(
 
 /// Start deleting the `.gguf` file at `path` in the background, forwarding
 /// the result through `event_sender`.
-#[cfg(feature = "llama-cpp")]
+#[cfg(feature = "gguf-management")]
 pub async fn spawn_delete(
     path: PathBuf,
     event_sender: UnboundedSender<TuiEvent>,
@@ -244,7 +249,7 @@ pub async fn spawn_delete(
     })
 }
 
-#[cfg(not(feature = "llama-cpp"))]
+#[cfg(not(feature = "gguf-management"))]
 pub async fn spawn_delete(
     path: PathBuf,
     event_sender: UnboundedSender<TuiEvent>,
@@ -253,8 +258,8 @@ pub async fn spawn_delete(
         let _ = event_sender.send(TuiEvent::LlamaCppDeleteFinished {
             path,
             error: Some(
-                "This build of crustly was compiled without the 'llama-cpp' feature. \
-                 Rebuild with `--features llama-cpp`."
+                "This build of crustly was compiled without the 'gguf-management' feature. \
+                 Rebuild with `--features gguf-management`."
                     .to_string(),
             ),
         });
@@ -336,7 +341,7 @@ mod tests {
         assert!(filter_local(&models, "mistral").is_empty());
     }
 
-    #[cfg(not(feature = "llama-cpp"))]
+    #[cfg(not(feature = "gguf-management"))]
     #[tokio::test]
     async fn list_local_without_feature_is_empty() {
         assert!(list_local(PathBuf::from("/tmp/anything")).await.is_empty());

--- a/src/tui/llama_cpp_download.rs
+++ b/src/tui/llama_cpp_download.rs
@@ -49,6 +49,8 @@ pub struct LlamaCppModelSummary {
     pub display_name: Option<String>,
     pub estimated_memory_bytes: Option<u64>,
     pub estimated_memory_includes_kv_cache: bool,
+    pub is_mmproj: bool,
+    pub mmproj_path: Option<PathBuf>,
 }
 
 /// One progress update from an in-flight download, decoupled from the
@@ -114,6 +116,8 @@ pub async fn list_local(
         display_name: m.display_name,
         estimated_memory_bytes: m.estimated_memory_bytes,
         estimated_memory_includes_kv_cache: m.estimated_memory_includes_kv_cache,
+        is_mmproj: m.is_mmproj,
+        mmproj_path: m.mmproj_path,
     })
     .collect()
 }
@@ -335,6 +339,8 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            is_mmproj: false,
+            mmproj_path: None,
         }
     }
 

--- a/src/tui/llama_cpp_download.rs
+++ b/src/tui/llama_cpp_download.rs
@@ -50,8 +50,11 @@ pub struct LlamaCppModelSummary {
     pub estimated_memory_bytes: Option<u64>,
     pub estimated_memory_includes_kv_cache: bool,
     /// The context length `estimated_memory_bytes` was actually computed
-    /// at - see `LocalGgufModel::estimated_memory_context_length`. Used by
-    /// Phase M12's per-row fit tag.
+    /// at - see `LocalGgufModel::estimated_memory_context_length`. Appended
+    /// to the Ctrl+G dialog's fit tag (`render.rs`'s `llama_cpp_fit_tag`,
+    /// e.g. `"Fits (ctx 8192)"`) so the assumption behind an estimate is
+    /// never hidden - the same figure `crustly llama-cpp list --best-fit`
+    /// shows for the identical model.
     pub estimated_memory_context_length: Option<u64>,
     pub is_mmproj: bool,
     pub mmproj_path: Option<PathBuf>,
@@ -155,37 +158,72 @@ pub async fn detect_hardware_summary() -> HardwareSummary {
 /// Returns an empty list (never an error) when the feature isn't compiled
 /// in or nothing could be scanned - the dialog just shows "no local
 /// models" rather than surfacing a scan failure the user can't act on.
+/// Blocking (synchronous directory scan + a GGUF header parse per file, and
+/// a possibly-large Ollama manifest tree walk), so - like
+/// `detect_hardware_summary` and `spawn_switch`'s model load just below -
+/// this runs the real work via `spawn_blocking` rather than directly on the
+/// calling task, so it can't stall other work sharing that runtime worker
+/// thread (event handling, streaming responses) while a large model
+/// directory scans.
 #[cfg(feature = "gguf-management")]
 pub async fn list_local(
     models_dir: PathBuf,
     extra_model_paths: Vec<PathBuf>,
     ollama_models_dir: Option<PathBuf>,
 ) -> Vec<LlamaCppModelSummary> {
-    use crate::llm::provider::llama_cpp_models;
+    use crate::llm::provider::llama_cpp_models::{self, LocalGgufModel};
 
-    llama_cpp_models::list_all_local_models(
-        &models_dir,
-        &extra_model_paths,
-        ollama_models_dir.as_deref(),
-    )
-    .unwrap_or_default()
-    .into_iter()
-    .map(|m| LlamaCppModelSummary {
-        path: m.path,
-        size_bytes: m.size_bytes,
-        quantization_hint: m.quantization_hint,
-        architecture: m.architecture,
-        parameter_count: m.parameter_count,
-        context_length: m.context_length,
-        has_chat_template: m.has_chat_template,
-        display_name: m.display_name,
-        estimated_memory_bytes: m.estimated_memory_bytes,
-        estimated_memory_includes_kv_cache: m.estimated_memory_includes_kv_cache,
-        estimated_memory_context_length: m.estimated_memory_context_length,
-        is_mmproj: m.is_mmproj,
-        mmproj_path: m.mmproj_path,
+    tokio::task::spawn_blocking(move || {
+        llama_cpp_models::list_all_local_models(
+            &models_dir,
+            &extra_model_paths,
+            ollama_models_dir.as_deref(),
+        )
+        .unwrap_or_default()
+        .into_iter()
+        .map(|m| {
+            // Destructured with every field named and no `..` rest pattern
+            // - deliberately, as a poor man's exhaustiveness check: a field
+            // added to `LocalGgufModel` fails to compile right here instead
+            // of silently never reaching this TUI-side mirror. See
+            // `cli/mod.rs`'s `LlamaCppModelJson::from` for the identical
+            // safeguard on the `--json` side's own mirror of this struct.
+            let LocalGgufModel {
+                path,
+                size_bytes,
+                modified_at: _,
+                quantization_hint,
+                architecture,
+                parameter_count,
+                context_length,
+                has_chat_template,
+                display_name,
+                estimated_memory_bytes,
+                estimated_memory_includes_kv_cache,
+                estimated_memory_context_length,
+                is_mmproj,
+                mmproj_path,
+            } = m;
+            LlamaCppModelSummary {
+                path,
+                size_bytes,
+                quantization_hint,
+                architecture,
+                parameter_count,
+                context_length,
+                has_chat_template,
+                display_name,
+                estimated_memory_bytes,
+                estimated_memory_includes_kv_cache,
+                estimated_memory_context_length,
+                is_mmproj,
+                mmproj_path,
+            }
+        })
+        .collect()
     })
-    .collect()
+    .await
+    .unwrap_or_default()
 }
 
 #[cfg(not(feature = "gguf-management"))]
@@ -367,11 +405,16 @@ pub async fn spawn_delete(
     })
 }
 
-/// Filter `models` to those whose file name contains `query`
-/// (case-insensitive substring). Empty query returns every model
-/// unfiltered - same shape as `ollama_download::filter_suggestions`, minus
-/// the curated-list/installed-merge logic Ollama needs and this dialog
-/// doesn't (there's only ever one source: the local directory scan).
+/// Filter `models` to those whose `display_name` (when set) or file name
+/// contains `query` (case-insensitive substring). Empty query returns every
+/// model unfiltered - same shape as `ollama_download::filter_suggestions`,
+/// minus the curated-list/installed-merge logic Ollama needs and this
+/// dialog doesn't (there's only ever one source: the local directory scan).
+/// Matching against `display_name` too (not just the raw filename) matters
+/// most for Ollama-sourced entries, whose file name is a meaningless
+/// `sha256-<hex>` blob name - `llama_cpp_model_lines` (`render.rs`) already
+/// prefers `display_name` for exactly that reason, so the search here must
+/// find what that row actually shows.
 pub fn filter_local(models: &[LlamaCppModelSummary], query: &str) -> Vec<LlamaCppModelSummary> {
     let query_lc = query.trim().to_lowercase();
     if query_lc.is_empty() {
@@ -380,10 +423,16 @@ pub fn filter_local(models: &[LlamaCppModelSummary], query: &str) -> Vec<LlamaCp
     models
         .iter()
         .filter(|m| {
-            m.path
+            let name_matches = m
+                .path
                 .file_name()
                 .map(|n| n.to_string_lossy().to_lowercase().contains(&query_lc))
-                .unwrap_or(false)
+                .unwrap_or(false);
+            let display_name_matches = m
+                .display_name
+                .as_deref()
+                .is_some_and(|n| n.to_lowercase().contains(&query_lc));
+            name_matches || display_name_matches
         })
         .cloned()
         .collect()
@@ -450,6 +499,21 @@ mod tests {
     fn filter_local_no_match_returns_empty() {
         let models = vec![model("qwen.gguf")];
         assert!(filter_local(&models, "mistral").is_empty());
+    }
+
+    #[test]
+    fn filter_local_matches_display_name_even_when_filename_does_not() {
+        // Ollama-sourced entries have a meaningless `sha256-<hex>` file
+        // name; the display name is the only thing a user would type.
+        let mut ollama_model = model("sha256-3a8f9c2b1d.gguf");
+        ollama_model.display_name = Some("qwen2.5-coder:7b".to_string());
+        let models = vec![ollama_model, model("llama3.gguf")];
+        let filtered = filter_local(&models, "qwen");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            filtered[0].display_name.as_deref(),
+            Some("qwen2.5-coder:7b")
+        );
     }
 
     #[cfg(not(feature = "gguf-management"))]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2698,6 +2698,10 @@ mod tests {
             path: std::path::PathBuf::from("/models/qwen2.5-coder-7b-Q4_K_M.gguf"),
             size_bytes: 4_294_967_296,
             quantization_hint: Some("Q4_K_M".to_string()),
+            architecture: None,
+            parameter_count: None,
+            context_length: None,
+            has_chat_template: false,
         }];
 
         let screen = render_to_string(&app, 100, 20);

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2042,6 +2042,29 @@ fn format_param_count(n: u64) -> String {
     }
 }
 
+/// Fit label + color against `budget_bytes` - mirrors
+/// `llama_cpp_models::hardware_fit`'s three-threshold logic (`WontFit`/
+/// `Tight`/`Fits`), duplicated here rather than called through to it: that
+/// function lives in `llama_cpp_models`, gated on `gguf-management`, and
+/// this file (the TUI's always-compiled render layer) must not pick up
+/// that gate just for a two-line threshold comparison. `None` when either
+/// side is unknown - matches `HardwareFit::Unknown`'s "no tag at all"
+/// treatment (see `llama_cpp_model_lines`'s caller).
+fn llama_cpp_fit_tag(
+    estimated_memory_bytes: Option<u64>,
+    budget_bytes: Option<u64>,
+) -> Option<(&'static str, Color)> {
+    let (estimate, budget) = (estimated_memory_bytes?, budget_bytes?);
+    const TIGHT_THRESHOLD_RATIO: f64 = 0.85;
+    Some(if estimate > budget {
+        ("Won't fit", Color::Red)
+    } else if estimate as f64 > budget as f64 * TIGHT_THRESHOLD_RATIO {
+        ("Tight", Color::Yellow)
+    } else {
+        ("Fits", Color::Green)
+    })
+}
+
 /// Renders one Ctrl+G dialog entry: always a compact main line (using
 /// `display_name` when set - previously this dialog always showed the raw
 /// filename, which for an Ollama-sourced entry is a meaningless
@@ -2052,9 +2075,16 @@ fn format_param_count(n: u64) -> String {
 /// indented detail line - the "expandable detail line" the source plan
 /// describes, expressed as "expands on selection" rather than a new
 /// keybinding, reusing the dialog's existing up/down selection state.
+///
+/// `budget_bytes` (Phase M12) - this machine's detected VRAM+RAM budget, or
+/// `None` when hardware detection hasn't completed/found anything yet -
+/// appends a color-coded Fits/Tight/Won't fit tag to the main line, next to
+/// the quantization label (glanceable per-row, not buried in the
+/// selected-only detail line below).
 fn llama_cpp_model_lines(
     model: &super::llama_cpp_download::LlamaCppModelSummary,
     is_selected: bool,
+    budget_bytes: Option<u64>,
 ) -> Vec<Line<'static>> {
     let style = if is_selected {
         Style::default()
@@ -2086,10 +2116,23 @@ fn llama_cpp_model_lines(
     let size_gb = model.size_bytes as f64 / 1_073_741_824.0;
     let quant = model.quantization_hint.as_deref().unwrap_or("unknown");
 
-    let mut lines = vec![Line::from(vec![
+    let mut main_line_spans = vec![
         Span::styled(prefix, style),
         Span::styled(format!("{name}  ({size_gb:.2} GB, {quant})"), style),
-    ])];
+    ];
+    if let Some((label, color)) = llama_cpp_fit_tag(model.estimated_memory_bytes, budget_bytes) {
+        // When selected, keep the row's own highlight styling for the tag
+        // too (bold, same fg/bg) rather than the distinct color - a
+        // differently-colored span would punch an inconsistent-looking
+        // hole in the selection highlight bar.
+        let tag_style = if is_selected {
+            style
+        } else {
+            Style::default().fg(color)
+        };
+        main_line_spans.push(Span::styled(format!("  [{label}]"), tag_style));
+    }
+    let mut lines = vec![Line::from(main_line_spans)];
 
     if is_selected {
         let mut parts = Vec::new();
@@ -2130,6 +2173,37 @@ fn llama_cpp_model_lines(
     lines
 }
 
+/// The Ctrl+G dialog's one-line host-info row (Phase M11): "detecting
+/// hardware…" while the background task from `App::open_llama_cpp_models`
+/// is in flight, then a GPU/RAM summary once it completes, or nothing (an
+/// empty line, keeping row positions stable) if detection somehow never
+/// got kicked off - not expected via the normal `open_llama_cpp_models`
+/// path, but a defensive fallback rather than a panic.
+fn llama_cpp_hardware_line(app: &App) -> Line<'static> {
+    let style = Style::default().fg(Color::DarkGray);
+    if app.llama_cpp_hardware_loading {
+        return Line::from(Span::styled("  detecting hardware…", style));
+    }
+    let Some(hardware) = &app.llama_cpp_hardware else {
+        return Line::from("");
+    };
+    let gpu_part = match (&hardware.gpu_name, hardware.vram_available_bytes) {
+        (Some(name), Some(vram)) => {
+            format!(
+                "🖥 {name} (~{:.1} GB VRAM free)",
+                vram as f64 / 1_073_741_824.0
+            )
+        }
+        (Some(name), None) => format!("🖥 {name} (VRAM unknown)"),
+        (None, _) => "🖥 CPU-only".to_string(),
+    };
+    let ram_part = match hardware.system_ram_total_bytes {
+        Some(bytes) => format!("RAM ~{:.1} GB", bytes as f64 / 1_073_741_824.0),
+        None => "RAM unknown".to_string(),
+    };
+    Line::from(Span::styled(format!("  {gpu_part} · {ram_part}"), style))
+}
+
 /// Render the llama.cpp Local Models dialog (Ctrl+G): pick a locally-present
 /// `.gguf` file to switch to, or type a URL/`hf:org/repo/file.gguf`
 /// shorthand to download a new one.
@@ -2159,6 +2233,7 @@ fn render_llama_cpp_models(f: &mut Frame, app: &App, area: Rect) {
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD),
     )]));
+    lines.push(llama_cpp_hardware_line(app));
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
         Span::styled("  > ", Style::default().fg(Color::DarkGray)),
@@ -2190,8 +2265,16 @@ fn render_llama_cpp_models(f: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(Color::DarkGray),
         )));
     } else {
+        let budget_bytes = app
+            .llama_cpp_hardware
+            .as_ref()
+            .and_then(super::llama_cpp_download::HardwareSummary::budget_bytes);
         for (idx, model) in app.llama_cpp_models.iter().enumerate() {
-            lines.extend(llama_cpp_model_lines(model, idx == app.llama_cpp_selected));
+            lines.extend(llama_cpp_model_lines(
+                model,
+                idx == app.llama_cpp_selected,
+                budget_bytes,
+            ));
         }
     }
 
@@ -2809,6 +2892,7 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            estimated_memory_context_length: None,
             is_mmproj: false,
             mmproj_path: None,
         }];
@@ -2833,6 +2917,7 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: Some(5_200_000_000),
             estimated_memory_includes_kv_cache: true,
+            estimated_memory_context_length: None,
             is_mmproj: false,
             mmproj_path: None,
         }
@@ -2851,7 +2936,7 @@ mod tests {
         let mut model = llama_cpp_model_fixture("/models/sha256-abc123.gguf");
         model.display_name = Some("qwen2.5-coder:7b".to_string());
 
-        let lines = llama_cpp_model_lines(&model, false);
+        let lines = llama_cpp_model_lines(&model, false, None);
         let text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("qwen2.5-coder:7b"));
         assert!(!text.contains("sha256-abc123"));
@@ -2861,7 +2946,7 @@ mod tests {
     fn llama_cpp_model_lines_labels_a_paired_and_an_unpaired_mmproj_entry_differently() {
         let mut paired = llama_cpp_model_fixture("/models/a.gguf");
         paired.mmproj_path = Some(std::path::PathBuf::from("/models/mmproj-a.gguf"));
-        let paired_text: String = llama_cpp_model_lines(&paired, false)[0]
+        let paired_text: String = llama_cpp_model_lines(&paired, false, None)[0]
             .spans
             .iter()
             .map(|s| s.content.as_ref())
@@ -2870,7 +2955,7 @@ mod tests {
 
         let mut unpaired = llama_cpp_model_fixture("/models/mmproj-b.gguf");
         unpaired.is_mmproj = true;
-        let unpaired_text: String = llama_cpp_model_lines(&unpaired, false)[0]
+        let unpaired_text: String = llama_cpp_model_lines(&unpaired, false, None)[0]
             .spans
             .iter()
             .map(|s| s.content.as_ref())
@@ -2882,10 +2967,10 @@ mod tests {
     fn llama_cpp_model_lines_shows_a_detail_line_only_when_selected() {
         let model = llama_cpp_model_fixture("/models/a.gguf");
 
-        let unselected = llama_cpp_model_lines(&model, false);
+        let unselected = llama_cpp_model_lines(&model, false, None);
         assert_eq!(unselected.len(), 1, "no detail line when not selected");
 
-        let selected = llama_cpp_model_lines(&model, true);
+        let selected = llama_cpp_model_lines(&model, true, None);
         assert_eq!(selected.len(), 2, "a detail line appears when selected");
         let detail: String = selected[1]
             .spans
@@ -2897,6 +2982,64 @@ mod tests {
         assert!(detail.contains("ctx 32768"));
         assert!(detail.contains("4.8 GB")); // 5.2e9 bytes as GiB (1_073_741_824 divisor)
         assert!(detail.contains("chat template"));
+    }
+
+    #[test]
+    fn llama_cpp_model_lines_shows_a_fit_tag_when_budget_is_known() {
+        let model = llama_cpp_model_fixture("/models/a.gguf"); // 5.2 GB estimate
+        let text: String = llama_cpp_model_lines(&model, false, Some(10_000_000_000))[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(text.contains("[Fits]"), "got: {text}");
+    }
+
+    #[test]
+    fn llama_cpp_model_lines_shows_wont_fit_when_estimate_exceeds_budget() {
+        let model = llama_cpp_model_fixture("/models/a.gguf"); // 5.2 GB estimate
+        let text: String = llama_cpp_model_lines(&model, false, Some(1_000_000_000))[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(text.contains("[Won't fit]"), "got: {text}");
+    }
+
+    #[test]
+    fn llama_cpp_model_lines_shows_no_fit_tag_when_budget_is_unknown() {
+        let model = llama_cpp_model_fixture("/models/a.gguf");
+        let text: String = llama_cpp_model_lines(&model, false, None)[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(!text.contains('['), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_models_dialog_shows_hardware_detecting_state() {
+        let mut app = test_app().await;
+        app.mode = AppMode::LlamaCppModelPicker;
+        app.llama_cpp_hardware_loading = true;
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("detecting hardware"));
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_models_dialog_shows_hardware_summary_once_detected() {
+        let mut app = test_app().await;
+        app.mode = AppMode::LlamaCppModelPicker;
+        app.llama_cpp_hardware = Some(super::super::llama_cpp_download::HardwareSummary {
+            gpu_name: Some("Test GPU 9000".to_string()),
+            vram_available_bytes: Some(21_474_836_480),
+            system_ram_total_bytes: Some(34_359_738_368),
+        });
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("Test GPU 9000"));
+        assert!(screen.contains("RAM"));
     }
 
     #[tokio::test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1613,6 +1613,26 @@ fn render_model_info(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(Color::White),
             ),
         ]));
+        if let Some(native_ctx) = details.context_length {
+            lines.push(Line::from(vec![
+                Span::styled("Nat. ctx: ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("{native_ctx} tokens"),
+                    Style::default().fg(Color::White),
+                ),
+            ]));
+        }
+        lines.push(Line::from(vec![
+            Span::styled("Chat tmpl:", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                if details.has_chat_template {
+                    " yes"
+                } else {
+                    " no"
+                },
+                Style::default().fg(Color::White),
+            ),
+        ]));
     }
 
     lines.push(Line::from(""));
@@ -2006,6 +2026,110 @@ fn render_model_download_deleting(f: &mut Frame, model: &str, area: Rect) {
     f.render_widget(widget, area);
 }
 
+/// Formats a parameter count for compact display (`7_600_000_000 ->
+/// "7.6B"`, `500_000_000 -> "500M"`, `1_500 -> "2K"`) - one significant
+/// decimal place above the million mark, none below it, since a Ctrl+G row
+/// doesn't have room for (and a user doesn't need) an exact count.
+fn format_param_count(n: u64) -> String {
+    if n >= 1_000_000_000 {
+        format!("{:.1}B", n as f64 / 1_000_000_000.0)
+    } else if n >= 1_000_000 {
+        format!("{:.0}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.0}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Renders one Ctrl+G dialog entry: always a compact main line (using
+/// `display_name` when set - previously this dialog always showed the raw
+/// filename, which for an Ollama-sourced entry is a meaningless
+/// `sha256-<hex>` blob name; a split-GGUF group or mmproj-paired entry
+/// already carries a synthesized `display_name` too, from
+/// `list_all_local_models`'s M3/M4/M5 merging - this was the one place
+/// that data wasn't being shown). When `is_selected`, an additional
+/// indented detail line - the "expandable detail line" the source plan
+/// describes, expressed as "expands on selection" rather than a new
+/// keybinding, reusing the dialog's existing up/down selection state.
+fn llama_cpp_model_lines(
+    model: &super::llama_cpp_download::LlamaCppModelSummary,
+    is_selected: bool,
+) -> Vec<Line<'static>> {
+    let style = if is_selected {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::White)
+    };
+    let prefix = if is_selected { "▶ " } else { "  " };
+
+    let mut name = model.display_name.clone().unwrap_or_else(|| {
+        model
+            .path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    });
+    // A paired base model's projector is folded into this entry (its own
+    // row was removed by `pair_mmproj_files`); an unpaired projector keeps
+    // its own row, labeled so it's not just a mysteriously-named model -
+    // same convention as the CLI's `list` printer (`src/cli/mod.rs`).
+    if model.mmproj_path.is_some() {
+        name.push_str(" (+ mmproj)");
+    } else if model.is_mmproj {
+        name.push_str(" [mmproj]");
+    }
+
+    let size_gb = model.size_bytes as f64 / 1_073_741_824.0;
+    let quant = model.quantization_hint.as_deref().unwrap_or("unknown");
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled(prefix, style),
+        Span::styled(format!("{name}  ({size_gb:.2} GB, {quant})"), style),
+    ])];
+
+    if is_selected {
+        let mut parts = Vec::new();
+        if let Some(arch) = &model.architecture {
+            parts.push(arch.clone());
+        }
+        if let Some(params) = model.parameter_count {
+            parts.push(format!("{} params", format_param_count(params)));
+        }
+        if let Some(ctx) = model.context_length {
+            parts.push(format!("ctx {ctx}"));
+        }
+        if let Some(mem) = model.estimated_memory_bytes {
+            let gb = mem as f64 / 1_073_741_824.0;
+            parts.push(if model.estimated_memory_includes_kv_cache {
+                format!("~{gb:.1} GB")
+            } else {
+                format!("~{gb:.1} GB weights")
+            });
+        }
+        parts.push(
+            if model.has_chat_template {
+                "chat template"
+            } else {
+                "no chat template"
+            }
+            .to_string(),
+        );
+
+        if !parts.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("      {}", parts.join(" · ")),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+
+    lines
+}
+
 /// Render the llama.cpp Local Models dialog (Ctrl+G): pick a locally-present
 /// `.gguf` file to switch to, or type a URL/`hf:org/repo/file.gguf`
 /// shorthand to download a new one.
@@ -2067,27 +2191,7 @@ fn render_llama_cpp_models(f: &mut Frame, app: &App, area: Rect) {
         )));
     } else {
         for (idx, model) in app.llama_cpp_models.iter().enumerate() {
-            let is_selected = idx == app.llama_cpp_selected;
-            let style = if is_selected {
-                Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(Color::White)
-            };
-            let prefix = if is_selected { "▶ " } else { "  " };
-            let name = model
-                .path
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            let size_gb = model.size_bytes as f64 / 1_073_741_824.0;
-            let quant = model.quantization_hint.as_deref().unwrap_or("unknown");
-            lines.push(Line::from(vec![
-                Span::styled(prefix, style),
-                Span::styled(format!("{name}  ({size_gb:.2} GB, {quant})"), style),
-            ]));
+            lines.extend(llama_cpp_model_lines(model, idx == app.llama_cpp_selected));
         }
     }
 
@@ -2713,6 +2817,99 @@ mod tests {
         assert!(screen.contains("Local llama.cpp models"));
         assert!(screen.contains("qwen2.5-coder-7b-Q4_K_M.gguf"));
         assert!(screen.contains("Q4_K_M"));
+    }
+
+    fn llama_cpp_model_fixture(
+        name: &str,
+    ) -> super::super::llama_cpp_download::LlamaCppModelSummary {
+        super::super::llama_cpp_download::LlamaCppModelSummary {
+            path: std::path::PathBuf::from(name),
+            size_bytes: 4_294_967_296,
+            quantization_hint: Some("Q4_K_M".to_string()),
+            architecture: Some("qwen2".to_string()),
+            parameter_count: Some(7_000_000_000),
+            context_length: Some(32768),
+            has_chat_template: true,
+            display_name: None,
+            estimated_memory_bytes: Some(5_200_000_000),
+            estimated_memory_includes_kv_cache: true,
+            is_mmproj: false,
+            mmproj_path: None,
+        }
+    }
+
+    #[test]
+    fn format_param_count_formats_at_the_expected_scale() {
+        assert_eq!(format_param_count(7_600_000_000), "7.6B");
+        assert_eq!(format_param_count(500_000_000), "500M");
+        assert_eq!(format_param_count(1_500), "2K");
+        assert_eq!(format_param_count(42), "42");
+    }
+
+    #[test]
+    fn llama_cpp_model_lines_prefers_display_name_over_the_raw_filename() {
+        let mut model = llama_cpp_model_fixture("/models/sha256-abc123.gguf");
+        model.display_name = Some("qwen2.5-coder:7b".to_string());
+
+        let lines = llama_cpp_model_lines(&model, false);
+        let text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("qwen2.5-coder:7b"));
+        assert!(!text.contains("sha256-abc123"));
+    }
+
+    #[test]
+    fn llama_cpp_model_lines_labels_a_paired_and_an_unpaired_mmproj_entry_differently() {
+        let mut paired = llama_cpp_model_fixture("/models/a.gguf");
+        paired.mmproj_path = Some(std::path::PathBuf::from("/models/mmproj-a.gguf"));
+        let paired_text: String = llama_cpp_model_lines(&paired, false)[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(paired_text.contains("(+ mmproj)"));
+
+        let mut unpaired = llama_cpp_model_fixture("/models/mmproj-b.gguf");
+        unpaired.is_mmproj = true;
+        let unpaired_text: String = llama_cpp_model_lines(&unpaired, false)[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(unpaired_text.contains("[mmproj]"));
+    }
+
+    #[test]
+    fn llama_cpp_model_lines_shows_a_detail_line_only_when_selected() {
+        let model = llama_cpp_model_fixture("/models/a.gguf");
+
+        let unselected = llama_cpp_model_lines(&model, false);
+        assert_eq!(unselected.len(), 1, "no detail line when not selected");
+
+        let selected = llama_cpp_model_lines(&model, true);
+        assert_eq!(selected.len(), 2, "a detail line appears when selected");
+        let detail: String = selected[1]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(detail.contains("qwen2"));
+        assert!(detail.contains("7.0B params"));
+        assert!(detail.contains("ctx 32768"));
+        assert!(detail.contains("4.8 GB")); // 5.2e9 bytes as GiB (1_073_741_824 divisor)
+        assert!(detail.contains("chat template"));
+    }
+
+    #[tokio::test]
+    async fn llama_cpp_models_dialog_shows_display_name_not_the_raw_path() {
+        let mut app = test_app().await;
+        app.mode = AppMode::LlamaCppModelPicker;
+        let mut model = llama_cpp_model_fixture("/models/sha256-deadbeef.gguf");
+        model.display_name = Some("qwen2.5-coder:7b".to_string());
+        app.llama_cpp_models = vec![model];
+
+        let screen = render_to_string(&app, 100, 20);
+        assert!(screen.contains("qwen2.5-coder:7b"));
+        assert!(!screen.contains("sha256-deadbeef"));
     }
 
     #[tokio::test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2702,6 +2702,9 @@ mod tests {
             parameter_count: None,
             context_length: None,
             has_chat_template: false,
+            display_name: None,
+            estimated_memory_bytes: None,
+            estimated_memory_includes_kv_cache: false,
         }];
 
         let screen = render_to_string(&app, 100, 20);

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2042,27 +2042,52 @@ fn format_param_count(n: u64) -> String {
     }
 }
 
-/// Fit label + color against `budget_bytes` - mirrors
-/// `llama_cpp_models::hardware_fit`'s three-threshold logic (`WontFit`/
-/// `Tight`/`Fits`), duplicated here rather than called through to it: that
-/// function lives in `llama_cpp_models`, gated on `gguf-management`, and
-/// this file (the TUI's always-compiled render layer) must not pick up
-/// that gate just for a two-line threshold comparison. `None` when either
-/// side is unknown - matches `HardwareFit::Unknown`'s "no tag at all"
-/// treatment (see `llama_cpp_model_lines`'s caller).
+/// Fit label + color against `budget_bytes`, with the context length the
+/// estimate assumed appended when known (`"Fits (ctx 8192)"`) - matches
+/// `crustly llama-cpp list --best-fit`'s wording (`src/cli/mod.rs`) so the
+/// CLI and this dialog never disagree about the same model/hardware pair.
+/// `#[cfg(feature = "gguf-management")]`-gated to match
+/// `llama_cpp_models::hardware_fit`'s own gate exactly (that module's
+/// declaration in `provider/mod.rs` - not just the code inside it - is
+/// behind the same feature), calling through to it for the actual
+/// three-threshold comparison rather than duplicating it, now that both
+/// sides carry the identical gate and can never disagree about which build
+/// they're compiled into. Under the `not(...)` build below, the caller's
+/// `estimated_memory_bytes` is always `None` anyway (nothing populates
+/// `LlamaCppModelSummary`'s estimate fields without this feature), so
+/// always returning `None` here matches the real behavior, not just a
+/// stub. `None` when either side is unknown - matches `HardwareFit::Unknown`'s
+/// "no tag at all" treatment (see `llama_cpp_model_lines`'s caller).
+#[cfg(feature = "gguf-management")]
 fn llama_cpp_fit_tag(
     estimated_memory_bytes: Option<u64>,
+    estimated_memory_context_length: Option<u64>,
     budget_bytes: Option<u64>,
-) -> Option<(&'static str, Color)> {
-    let (estimate, budget) = (estimated_memory_bytes?, budget_bytes?);
-    const TIGHT_THRESHOLD_RATIO: f64 = 0.85;
-    Some(if estimate > budget {
-        ("Won't fit", Color::Red)
-    } else if estimate as f64 > budget as f64 * TIGHT_THRESHOLD_RATIO {
-        ("Tight", Color::Yellow)
-    } else {
-        ("Fits", Color::Green)
-    })
+) -> Option<(String, Color)> {
+    use crate::llm::provider::llama_cpp_models::HardwareFit;
+    let (label, color) = match crate::llm::provider::llama_cpp_models::hardware_fit(
+        estimated_memory_bytes,
+        budget_bytes,
+    ) {
+        HardwareFit::Fits => ("Fits", Color::Green),
+        HardwareFit::Tight => ("Tight", Color::Yellow),
+        HardwareFit::WontFit => ("Won't fit", Color::Red),
+        HardwareFit::Unknown => return None,
+    };
+    let label = match estimated_memory_context_length {
+        Some(ctx) => format!("{label} (ctx {ctx})"),
+        None => label.to_string(),
+    };
+    Some((label, color))
+}
+
+#[cfg(not(feature = "gguf-management"))]
+fn llama_cpp_fit_tag(
+    _estimated_memory_bytes: Option<u64>,
+    _estimated_memory_context_length: Option<u64>,
+    _budget_bytes: Option<u64>,
+) -> Option<(String, Color)> {
+    None
 }
 
 /// Renders one Ctrl+G dialog entry: always a compact main line (using
@@ -2120,7 +2145,11 @@ fn llama_cpp_model_lines(
         Span::styled(prefix, style),
         Span::styled(format!("{name}  ({size_gb:.2} GB, {quant})"), style),
     ];
-    if let Some((label, color)) = llama_cpp_fit_tag(model.estimated_memory_bytes, budget_bytes) {
+    if let Some((label, color)) = llama_cpp_fit_tag(
+        model.estimated_memory_bytes,
+        model.estimated_memory_context_length,
+        budget_bytes,
+    ) {
         // When selected, keep the row's own highlight styling for the tag
         // too (bold, same fg/bg) rather than the distinct color - a
         // differently-colored span would punch an inconsistent-looking
@@ -2984,6 +3013,14 @@ mod tests {
         assert!(detail.contains("chat template"));
     }
 
+    // The three tests below exercise `llama_cpp_fit_tag`'s real threshold
+    // logic, which only exists (and is only ever fed a non-`None` estimate
+    // in practice) when `gguf-management` is compiled in - see that
+    // function's doc comment. `llama_cpp_model_lines_shows_no_fit_tag_when_budget_is_unknown`
+    // just below isn't gated, since "no tag when budget is unknown" holds
+    // in every build.
+
+    #[cfg(feature = "gguf-management")]
     #[test]
     fn llama_cpp_model_lines_shows_a_fit_tag_when_budget_is_known() {
         let model = llama_cpp_model_fixture("/models/a.gguf"); // 5.2 GB estimate
@@ -2995,6 +3032,7 @@ mod tests {
         assert!(text.contains("[Fits]"), "got: {text}");
     }
 
+    #[cfg(feature = "gguf-management")]
     #[test]
     fn llama_cpp_model_lines_shows_wont_fit_when_estimate_exceeds_budget() {
         let model = llama_cpp_model_fixture("/models/a.gguf"); // 5.2 GB estimate
@@ -3004,6 +3042,36 @@ mod tests {
             .map(|s| s.content.as_ref())
             .collect();
         assert!(text.contains("[Won't fit]"), "got: {text}");
+    }
+
+    #[cfg(feature = "gguf-management")]
+    #[test]
+    fn llama_cpp_model_lines_shows_the_context_length_the_estimate_used() {
+        let mut model = llama_cpp_model_fixture("/models/a.gguf"); // 5.2 GB estimate
+        model.estimated_memory_context_length = Some(8_192);
+        let text: String = llama_cpp_model_lines(&model, false, Some(10_000_000_000))[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(text.contains("[Fits (ctx 8192)]"), "got: {text}");
+    }
+
+    #[cfg(not(feature = "gguf-management"))]
+    #[test]
+    fn llama_cpp_model_lines_shows_no_fit_tag_without_the_gguf_management_feature() {
+        // Nothing in a `not(gguf-management)` build ever actually populates
+        // `estimated_memory_bytes`, but even if a caller set it directly
+        // (as this fixture does), the tag must stay suppressed - matches
+        // `llama_cpp_fit_tag`'s `not(feature = ...)` stub always returning
+        // `None`.
+        let model = llama_cpp_model_fixture("/models/a.gguf"); // 5.2 GB estimate
+        let text: String = llama_cpp_model_lines(&model, false, Some(10_000_000_000))[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(!text.contains('['), "got: {text}");
     }
 
     #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2705,6 +2705,8 @@ mod tests {
             display_name: None,
             estimated_memory_bytes: None,
             estimated_memory_includes_kv_cache: false,
+            is_mmproj: false,
+            mmproj_path: None,
         }];
 
         let screen = render_to_string(&app, 100, 20);


### PR DESCRIPTION
Analyzes llamastash (github.com/llamastash/llamastash), a Rust TUI/CLI
for local GGUF model lifecycle management, and maps its GGUF
discovery/metadata/dedup/download capabilities against Crustly's
current llama_cpp_models.rs (list/pull/rm with filename-only
quantization guessing, single-directory scan, no header metadata).

Proposes a phased, additive improvement plan (M0-M10) covering:
decoupling file management from the llama-cpp build feature, a
pure-Rust GGUF header parser, memory/VRAM estimation, multi-source
discovery, dedup, mmproj pairing, download hardening, an agent-facing
JSON/exit-code CLI contract, TUI enhancements, and diagnostics -
while explicitly excluding llamastash's daemon/launcher/proxy
architecture, which Crustly's in-process LlamaCppProvider already
supersedes.

No implementation yet - proposal only.