### PR TITLE
Add native /review skill with built-in skill fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - [💡 Best Practices for Using Crustly](#-best-practices-for-using-crustly)
 - [👨‍💻 Why Crustly for Coding?](#-why-crustly-for-coding)
 - [📋 Plan Mode — Structured Task Planning](#-plan-mode--structured-task-planning)
+- [🧠 Native Skills — /review & /spec](#-native-skills--review--spec)
 - [🧪 Manual Testing Guide](#-manual-testing-guide)
 - [📊 Performance](#-performance)
 - [🏗️ Architecture](#️-architecture)
@@ -125,13 +126,53 @@ Crustly: [creates comprehensive docs]
 - ✅ **Debugging** - Error analysis and fixes with context
 - ✅ **Refactoring** - Improve code quality
 - ✅ **Documentation** - Generate docs, comments, READMEs
-- ✅ **Code Review** - Get feedback on your code
+- ✅ **Code Review** - Get feedback on your code, or run `/review` for a multi-pass automated audit
 - ✅ **Learning** - Understand complex concepts
 - ✅ **Terminal Workflow** - Stay in your flow, no browser tabs
 
 ---
 
 ## ✨ What's New
+
+### Unreleased — Native `/review` and `/spec` Skills
+
+Two new slash commands work in any project with zero setup, on top of a
+generic fix to how `/`-commands are handled. See
+[🧠 Native Skills](#-native-skills--review--spec) below for the full
+writeup, or the skill source directly at
+[src/llm/tools/builtin_skills/](src/llm/tools/builtin_skills/).
+
+- **`/review`** — multi-pass automated code review of the current diff, a
+  PR, a branch, or a path. Independent correctness/guideline-compliance/
+  security passes dispatch in parallel via the `agent` tool, then a
+  second, skeptical pass filters every finding by confidence before
+  anything is reported — a review that cries wolf gets ignored.
+  `--comment` posts a summary via `gh`, `--fix` applies the surviving
+  findings.
+- **`/spec`** — native Specification-Driven Development:
+  `specify → plan → tasks → implement → analyze`, writing versioned
+  artifacts to `specs/<NNN>-<slug>/`. One skill, phase inferred from
+  trailing args — `/spec "feature description"` starts a new feature,
+  `/spec plan` / `/spec tasks` / `/spec implement` / `/spec analyze`
+  advance it. Includes a constitution gate (simplicity / anti-abstraction
+  / integration-first) during planning. Modeled on the `spec-driven`
+  schema from the same author's external
+  [rustyspec](https://github.com/jyjeanne/rustyspec) and
+  [solidspec](https://github.com/jyjeanne/solidspec) projects — named the
+  polyvalent default among solidspec's 7 workflow schemas — but unlike
+  those (separate CLIs that must hand off to an external agent),
+  `implement` runs natively in this session: Crustly already is the
+  agent, so it drives `task_manager`/`write_file`/`edit_file`/`bash`
+  directly and checks off `tasks.md` as it builds.
+- **Fixed:** nothing previously routed a typed `/<name>` to the `skill`
+  tool that could load it — `/review`, `/spec`, or any project-defined
+  skill just sent literal text to the model instead of triggering. Slash
+  input now resolves any unmatched `/<name>` through the same lookup
+  order `SkillTool` uses (project `.crustly/skills/`, `.claude/skills/`,
+  user-global, then a small set of built-ins compiled into the binary)
+  before falling back to a plain chat message — off the blocking-safe
+  `spawn_blocking` path, so the filesystem walk never stalls TUI
+  rendering.
 
 ### Unreleased — In-Process llama.cpp Provider
 
@@ -871,6 +912,64 @@ into a reviewable, dependency-ordered set of steps you approve before
 anything executes. See **[docs/PLAN_MODE_USER_GUIDE.md](docs/PLAN_MODE_USER_GUIDE.md)**
 for the full workflow, keyboard shortcuts, `PLAN.md` format, plan lifecycle,
 sample prompts, troubleshooting, and FAQ.
+
+---
+
+## 🧠 Native Skills — /review & /spec
+
+Skills are `SKILL.md` prompt files the `skill` tool can load — Crustly
+ships two built into the binary so they work in any project with no setup,
+and any project can override either by dropping its own
+`.crustly/skills/<name>/SKILL.md` (or `.claude/skills/<name>/SKILL.md`)
+of the same name.
+
+### `/review` — multi-pass code review
+
+```
+/review                  # review the current diff / open PR
+/review 123               # review PR #123
+/review --comment         # also post a summary comment via gh
+/review --fix             # apply the surviving findings
+```
+
+Independent correctness, guideline-compliance, and security passes
+dispatch in parallel via the `agent` tool, each scoped to only the
+relevant diff and context. A second, skeptical pass then tries to
+disprove each finding before it's reported — findings that don't survive
+scrutiny are dropped rather than shown, on the theory that a review that
+cries wolf gets ignored.
+
+### `/spec` — Specification-Driven Development
+
+```
+/spec Add CSV export to reports   # start a new feature: specs/001-.../spec.md
+/spec plan                        # architecture plan + constitution gate
+/spec tasks                       # phased, traceable task breakdown
+/spec implement                   # builds it natively, checks off tasks.md
+/spec analyze                     # traceability + test verdict: READY / NEEDS WORK
+```
+
+One skill, phase inferred from the trailing argument. Every feature gets
+a versioned `spec.md` → `plan.md` → `tasks.md` under `specs/<NNN>-<slug>/`,
+so scope and requirements survive contact with an AI agent instead of
+being renegotiated silently mid-implementation.
+
+The workflow is modeled on the `spec-driven` schema from the same
+author's [rustyspec](https://github.com/jyjeanne/rustyspec) and
+[solidspec](https://github.com/jyjeanne/solidspec) — external CLI tools
+implementing several SDD methodologies, of which `spec-driven` is
+documented as the polyvalent default. The key difference here: those
+tools are separate processes that must shell out to an external agent's
+CLI for the `implement` phase. Crustly doesn't need to — `implement` runs
+natively in the same session, driving `task_manager`, `write_file`,
+`edit_file`, and `bash` directly against `tasks.md`.
+
+### Writing your own
+
+Any `.crustly/skills/<name>/SKILL.md` in your project (or
+`~/.config/crustly/skills/<name>/SKILL.md` globally) becomes a slash
+command automatically — no registration step. Run `/skills` to see every
+skill currently discoverable, project-local and built-in alike.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,6 +97,47 @@ design/safety reasoning (documented in the plan's §0.0 Phase 4b entry) is
 judged sound enough to ship unverified, but a real run is the next step for
 whoever has a model and terminal to try it against.
 
+### Unreleased — Native `/review` and `/spec` Skills
+Closed a gap where the `skill` tool (Phase 4) could load a `SKILL.md` file
+but nothing actually routed a typed `/<name>` slash command to it — and
+shipped two built-in skills on top of the fix.
+
+- **Generic slash-command → skill routing** — `try_handle_slash_command`
+  now resolves any unmatched `/<name>` through the same lookup order
+  `SkillTool` uses (project `.crustly/skills/`, `.claude/skills/`,
+  user-global, then a built-in fallback tier) before falling through to a
+  plain chat message. Runs off `spawn_blocking` since it does filesystem
+  walks, matching `SkillTool::execute`'s existing pattern — a fix applied
+  after `/code-review` caught the first version blocking the TUI's
+  draw/handle-key loop on every submitted `/word`
+- **Built-in skill fallback tier** — a small set of skills ship compiled
+  into the binary via `include_str!`, so they work in any project with
+  zero setup; always overridable by a project/user file of the same name.
+  `list_skills()` surfaces them the same way it does file-based skills,
+  deduplicating against any shadowing override
+- **`/review`** — multi-pass automated code review of the current diff, a
+  PR, a branch, or a path: independent correctness/guideline-compliance/
+  security passes dispatched in parallel via the `agent` tool, then a
+  second, skeptical pass filters findings by confidence before anything
+  is reported. Optional `--comment` (posts a summary via `gh`) and
+  `--fix` (applies surviving findings via `edit_file`/`apply_patch`)
+- **`/spec`** — native Specification-Driven Development workflow
+  (`specify → plan → tasks → implement → analyze`), writing to
+  `specs/<NNN>-<slug>/`. Studied from the author's own external
+  [rustyspec](https://github.com/jyjeanne/rustyspec) and
+  [solidspec](https://github.com/jyjeanne/solidspec) projects and modeled
+  on solidspec's `spec-driven` schema — documented there as the
+  polyvalent default among its 7 workflow schemas (`minimal`,
+  `spec-driven`, `security-first`, `tdd-driven`, `intent-driven`,
+  `apex-driven`, `intent-apex`). Unlike those tools, which are separate
+  CLIs and must hand off `implement` to an external agent's CLI, Crustly's
+  `implement` phase runs natively in-session via its own
+  `task_manager`/`write_file`/`edit_file`/`bash` tools, checking off
+  `tasks.md` as it builds. Includes a constitution gate (simplicity /
+  anti-abstraction / integration-first) during `plan`
+- Content of both skills is original — written fresh for Crustly's own
+  tool names and architecture, not ported from any external source
+
 ---
 
 ## Upcoming Milestones

--- a/src/llm/tools/builtin_skills/review.md
+++ b/src/llm/tools/builtin_skills/review.md
@@ -30,7 +30,7 @@ not review unrelated code just to have something to say.
 
 Use `glob` to find `CLAUDE.md` and `AGENTS.md` at the repo root and in any
 directory that contains a changed file (or one of its parents). Read the
-ones that exist with `read`. These are the compliance bar for Step 4 —
+ones that exist with `read_file`. These are the compliance bar for Step 4 —
 skip this step's findings entirely if no such files exist.
 
 ## Step 3: Summarize the change
@@ -96,7 +96,7 @@ dedicated GitHub review-comment tool.
 ## Optional: `--fix`
 
 For findings from Step 6 that have an unambiguous, self-contained fix, apply
-it with `edit` or `apply_patch` and note in the final summary which
+it with `edit_file` or `apply_patch` and note in the final summary which
 findings were fixed automatically versus left for manual attention.
 Findings that require an architectural decision are never auto-fixed —
 report them instead.

--- a/src/llm/tools/builtin_skills/review.md
+++ b/src/llm/tools/builtin_skills/review.md
@@ -1,0 +1,102 @@
+---
+name: review
+description: Multi-pass automated code review of the current diff, a PR, a branch, or a path — checks for correctness bugs and CLAUDE.md/AGENTS.md compliance, filters findings by confidence, and optionally posts a summary or applies fixes.
+---
+
+# Review
+
+Review a change for real defects and project-guideline violations, using
+independent passes so a single agent's blind spot doesn't become the whole
+review. Only report findings that survive a second, skeptical look — a
+review that cries wolf gets ignored.
+
+## Step 1: Determine the target
+
+Figure out what to review, in this priority order:
+
+1. An explicit argument was given — a PR number, a branch name, or a file
+   path. Resolve a PR number with `bash` (`gh pr view <n> --json ...`,
+   `gh pr diff <n>`); resolve a branch with `git diff <base>...<branch>`.
+2. No argument, but the current branch has an open PR against its
+   upstream — use `git diff <upstream>...HEAD`.
+3. Otherwise fall back to whatever is actually different: working-tree
+   changes (`git diff HEAD`), or if that's empty, the last commit
+   (`git diff HEAD~1`).
+
+If none of these produce a non-empty diff, say so plainly and stop — do
+not review unrelated code just to have something to say.
+
+## Step 2: Gather project guidelines
+
+Use `glob` to find `CLAUDE.md` and `AGENTS.md` at the repo root and in any
+directory that contains a changed file (or one of its parents). Read the
+ones that exist with `read`. These are the compliance bar for Step 4 —
+skip this step's findings entirely if no such files exist.
+
+## Step 3: Summarize the change
+
+Read the diff and write a short (3-6 sentence) summary of what changed and
+why, inferred from the diff and any PR title/description. This summary is
+handed to every review pass in Step 4 so agents that only see a diff still
+have intent to check against.
+
+## Step 4: Independent review passes
+
+Dispatch review passes in parallel with the `agent` tool rather than doing
+them serially in this same context — each pass should see only the diff,
+the Step 3 summary, and (for the guideline pass) the Step 2 files, so its
+verdict isn't anchored by another pass's framing:
+
+- **Correctness pass** — read the diff for logic errors, off-by-one bugs,
+  unhandled error cases, and anything that would not compile or would
+  panic. Only flag problems inside the changed lines; pre-existing issues
+  nearby are out of scope.
+- **Guideline-compliance pass** — check the diff against the CLAUDE.md /
+  AGENTS.md files gathered in Step 2. Only flag a violation you can quote
+  the exact rule for; skip anything you'd have to infer or paraphrase the
+  rule to justify.
+- **Security pass** — check for injection, path traversal, unsafe
+  deserialization, secrets in code, and missing input validation in the
+  changed lines only.
+
+Run two or three passes when the diff is small; for a large diff, split
+it by file or module across more parallel agents instead of asking one
+agent to hold the whole thing in mind.
+
+Every pass reports findings as `{file, line, summary, why}` — no finding
+without a concrete file and line.
+
+## Step 5: Filter by confidence
+
+Findings are cheap to produce and expensive to trust. For each finding
+from Step 4, spawn a second, independent agent whose only job is to try to
+disprove it — given just the finding and the relevant few lines of diff,
+does it hold up? Drop anything that doesn't survive this pass, and drop
+anything where the two passes disagree on severity. Prefer reporting
+nothing over reporting a plausible-sounding false positive.
+
+## Step 6: Report
+
+- No findings survived: say so in one line — do not manufacture minor
+  nitpicks to justify the review having run.
+- Findings survived: list each with its file:line, a one-sentence summary,
+  and the concrete failure it causes (bad input, wrong output, crash) —
+  not a vague "could be improved."
+
+Stop here unless `--comment` or `--fix` was passed.
+
+## Optional: `--comment`
+
+Post the Step 6 report as a single summary comment via `bash` (`gh pr
+comment <n> --body-file -`), scoped to whatever `gh pr` subcommands are on
+the `security.allow_bash` allowlist. This posts one summary comment, not
+per-line inline comments — do not attempt line-anchored comments without a
+dedicated GitHub review-comment tool.
+
+## Optional: `--fix`
+
+For findings from Step 6 that have an unambiguous, self-contained fix, apply
+it with `edit` or `apply_patch` and note in the final summary which
+findings were fixed automatically versus left for manual attention.
+Findings that require an architectural decision are never auto-fixed —
+report them instead.

--- a/src/llm/tools/builtin_skills/spec.md
+++ b/src/llm/tools/builtin_skills/spec.md
@@ -1,0 +1,129 @@
+---
+name: spec
+description: Specification-Driven Development workflow - turns a feature description into a versioned spec, plan, and task list under specs/, then builds it natively (no external agent handoff) and validates the result. Advance phases with trailing args (e.g. "/spec plan", "/spec tasks", "/spec implement", "/spec analyze") or start a new feature with a description.
+---
+
+# Spec
+
+Insert a structured specification layer between an idea and its code, so
+scope, edge cases, and traceability survive contact with an AI agent. Every
+feature gets `specs/<NNN>-<slug>/spec.md` → `plan.md` → `tasks.md`, all
+version-controlled, all driving what actually gets built.
+
+## Determine phase and target feature
+
+The trailing argument (after "Additional arguments:") decides what happens:
+
+- **A phase word** (`plan`, `tasks`, `implement`, `analyze`) with no feature
+  number — advance the current feature (the one on the current git branch,
+  or the highest-numbered `specs/NNN-*` directory) to that phase.
+- **A phase word plus a number** (`plan 003`) — advance that specific feature.
+- **Anything else, or no active feature exists yet** — treat the whole
+  argument as a new feature description and start at Step 1 (Specify).
+- **No argument and no active feature** — ask what feature to specify; don't
+  guess.
+
+Never skip a phase whose artifact doesn't exist yet: `tasks` requires
+`plan.md`, `implement` requires `tasks.md`, `analyze` requires all three.
+If the prerequisite is missing, say so and run that phase first instead of
+proceeding on stale or absent context.
+
+## Step 1: Specify
+
+1. Use `bash`/`glob` to find the next feature number: highest existing
+   `specs/NNN-*` + 1, zero-padded to 3 digits (`001` if none exist).
+2. Derive a short kebab-case slug from the description (3-5 words).
+3. Write `specs/<NNN>-<slug>/spec.md` containing:
+   - **User stories**, each tagged `P1`/`P2`/`P3` by priority, written as
+     "As a ..., I want ..., so that ...".
+   - **Functional requirements**, numbered `FR-001`, `FR-002`, ... — each
+     one sentence, each testable.
+   - **Acceptance scenarios** per story, in Given/When/Then form.
+   - Any genuine ambiguity in the description gets a `[NEEDS CLARIFICATION:
+     specific question]` marker inline — do not silently guess at
+     unstated scope, but don't manufacture markers for things a reasonable
+     default answers.
+   - A short quality checklist: no vague terms ("fast", "user-friendly")
+     left unquantified, no requirement without a matching acceptance
+     scenario.
+4. If `[NEEDS CLARIFICATION]` markers exist, list them and ask the user to
+   resolve them before moving on — resolving them means editing `spec.md`
+   directly (a full separate clarifications log is unnecessary overhead
+   for most features; add one only if the project already keeps one).
+
+Stop here. The user reviews `spec.md` before `plan` runs against it.
+
+## Step 2: Plan (`plan` argument)
+
+1. Read `spec.md`. If unresolved `[NEEDS CLARIFICATION]` markers remain,
+   stop and say which ones block planning.
+2. Read the project's own `CLAUDE.md`/`AGENTS.md` (root and any relevant
+   subdirectory) the same way the `review` skill does — the architecture
+   this plan produces must fit the existing codebase, not a generic one.
+3. Write `specs/<NNN>-<slug>/plan.md` with:
+   - **Architecture summary**: what modules/files are added or changed,
+     and why, in terms of the existing module layout.
+   - **Data model** (if the feature has one): entities, fields,
+     relationships — inline as a section, not a separate file.
+   - **Constitution check** — a short gate before anything gets built:
+     - *Simplicity*: does this need a new abstraction layer, or does an
+       existing module already do most of this?
+     - *Anti-abstraction*: are existing crates/tools used directly, or is
+       this wrapping something that didn't need wrapping?
+     - *Integration-first*: can this be tested against the real
+       tool/service it touches, or does it only work against a mock?
+     Gate violations are reported, not silently fixed and not blocking —
+     note them in `plan.md` and let the user decide whether to proceed.
+4. If the plan reveals the spec itself was wrong or incomplete, say so and
+   propose the spec edit — don't quietly plan around a bad requirement.
+
+## Step 3: Tasks (`tasks` argument)
+
+1. Read `plan.md`. Break the work into phases:
+   - **Setup** — anything needed before any story can be built.
+   - **Foundational** — shared code every story depends on.
+   - One phase **per user story**, ordered by priority (P1 first).
+2. Write `specs/<NNN>-<slug>/tasks.md` as a checklist, each task:
+   - Numbered `T001`, `T002`, ...
+   - Tagged `[US1]`/`[US2]`/... with the story it serves, and `[P]` when
+     it can run in parallel with siblings in its phase (touches disjoint
+     files, no shared state).
+   - Small enough to review in one sitting — split anything that would
+     touch more than a handful of files or mix unrelated concerns.
+   - Referencing the `FR-###` it satisfies, so `analyze` can trace it back.
+
+## Step 4: Implement (`implement` argument)
+
+Build it directly in this session — there is no separate agent to hand off
+to. Use the `task` tool to track progress against `tasks.md`, and `write`/
+`edit`/`bash` to make the changes:
+
+1. Work phase by phase, in the order `tasks.md` lists them. Within a
+   phase, tasks marked `[P]` may be done in either order; do not
+   parallelize tasks that aren't marked `[P]` — they share state or files.
+2. After each task (or each small batch of `[P]` tasks in the same area),
+   run the project's own test/check commands (see `CLAUDE.md`) before
+   moving on — a task isn't done because the code was written, it's done
+   because it still compiles and passes.
+3. Edit `tasks.md` to check off each completed task (`[ ]` → `[X]`) as you
+   go, so `tasks.md` stays an honest progress record, not just a plan.
+4. If a task turns out to need something the plan didn't anticipate, note
+   the deviation in `tasks.md` next to that task rather than silently
+   diverging from the written plan.
+
+## Step 5: Analyze (`analyze` argument)
+
+Read-only — this validates, it does not edit `spec.md`/`plan.md`/`tasks.md`.
+
+1. Trace every `FR-###` in `spec.md` to a task in `tasks.md` that
+   implements it, and every task back to the requirement it serves.
+   Flag requirements with no task, and tasks with no requirement.
+2. Check `tasks.md` completion against what's actually in the working
+   tree — a task checked `[X]` whose described change isn't present is a
+   finding, not a formality.
+3. Re-run the project's tests; report pass/fail, not just "should pass."
+4. Write `specs/<NNN>-<slug>/analysis-report.md` with the findings above
+   plus a closing verdict: **READY** (traceable, tested, no open
+   `[NEEDS CLARIFICATION]` markers) or **NEEDS WORK** (list exactly what,
+   file:line where relevant) — the same bar the `review` skill's Step 6
+   report applies to a diff.

--- a/src/llm/tools/builtin_skills/spec.md
+++ b/src/llm/tools/builtin_skills/spec.md
@@ -95,8 +95,8 @@ Stop here. The user reviews `spec.md` before `plan` runs against it.
 ## Step 4: Implement (`implement` argument)
 
 Build it directly in this session — there is no separate agent to hand off
-to. Use the `task` tool to track progress against `tasks.md`, and `write`/
-`edit`/`bash` to make the changes:
+to. Use the `task_manager` tool to track progress against `tasks.md`, and
+`write_file`/`edit_file`/`bash` to make the changes:
 
 1. Work phase by phase, in the order `tasks.md` lists them. Within a
    phase, tasks marked `[P]` may be done in either order; do not

--- a/src/llm/tools/skill.rs
+++ b/src/llm/tools/skill.rs
@@ -155,7 +155,7 @@ impl Tool for SkillTool {
 
         let json = serde_json::to_string_pretty(&output).map_err(ToolError::Json)?;
 
-        Ok(ToolResult::success(json).with_metadata("path".to_string(), output.path.clone()))
+        Ok(ToolResult::success(json).with_metadata("path".to_string(), output.path))
     }
 }
 

--- a/src/llm/tools/skill.rs
+++ b/src/llm/tools/skill.rs
@@ -26,7 +26,10 @@ use std::path::{Path, PathBuf};
 /// precedence — see `resolve_skill` — so these are defaults, not overrides.
 mod builtin {
     /// `(name, SKILL.md contents)` pairs, checked case-insensitively.
-    const SKILLS: &[(&str, &str)] = &[("review", include_str!("builtin_skills/review.md"))];
+    const SKILLS: &[(&str, &str)] = &[
+        ("review", include_str!("builtin_skills/review.md")),
+        ("spec", include_str!("builtin_skills/spec.md")),
+    ];
 
     pub(super) fn lookup(name: &str) -> Option<&'static str> {
         SKILLS
@@ -579,6 +582,22 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let skills = list_skills(tmp.path());
         assert!(skills.iter().any(|s| s.name == "review"));
+    }
+
+    #[test]
+    fn resolve_skill_content_falls_back_to_builtin_spec_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (content, description) = resolve_skill_content("spec", tmp.path())
+            .expect("built-in spec skill should resolve with no project skill present");
+        assert!(content.contains("name: spec"));
+        assert!(description.is_some());
+    }
+
+    #[test]
+    fn list_skills_includes_builtin_spec_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills = list_skills(tmp.path());
+        assert!(skills.iter().any(|s| s.name == "spec"));
     }
 
     #[test]

--- a/src/llm/tools/skill.rs
+++ b/src/llm/tools/skill.rs
@@ -10,6 +10,8 @@
 //!   3. `~/.config/crustly/skills/<name>/SKILL.md` — user-global
 //!   4. `~/.claude/skills/<name>/SKILL.md` — user-global (Claude Code compat)
 //!   5. Direct `.md` file in any of the above directories (legacy flat layout)
+//!   6. A built-in skill compiled into the binary (see [`builtin`]) — works with
+//!      no project setup at all, and is shadowed by any of the above.
 
 use super::error::{Result, ToolError};
 use super::r#trait::{Tool, ToolCapability, ToolExecutionContext, ToolResult};
@@ -17,6 +19,26 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
+
+/// Skills shipped with crustly itself, embedded at compile time so `/review`
+/// (and future built-ins) work in any project without a `.crustly/skills/`
+/// directory. A project or user skill of the same name always takes
+/// precedence — see `resolve_skill` — so these are defaults, not overrides.
+mod builtin {
+    /// `(name, SKILL.md contents)` pairs, checked case-insensitively.
+    const SKILLS: &[(&str, &str)] = &[("review", include_str!("builtin_skills/review.md"))];
+
+    pub(super) fn lookup(name: &str) -> Option<&'static str> {
+        SKILLS
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, content)| *content)
+    }
+
+    pub(super) fn names() -> impl Iterator<Item = &'static str> {
+        SKILLS.iter().map(|(n, _)| *n)
+    }
+}
 
 pub struct SkillTool;
 
@@ -104,24 +126,28 @@ impl Tool for SkillTool {
             ));
         }
 
-        let skill_path = tokio::task::spawn_blocking({
+        let resolved = tokio::task::spawn_blocking({
             let name = name.clone();
             let cwd = context.working_directory.clone();
-            move || resolve_skill_path(&name, &cwd)
+            move || resolve_skill(&name, &cwd)
         })
         .await
         .map_err(|e| ToolError::Execution(format!("task panicked: {e}")))?
-        .map_err(ToolError::Execution)?;
+        .ok_or_else(|| ToolError::Execution(format!("unknown skill: {name}")))?;
 
-        let contents = tokio::fs::read_to_string(&skill_path)
-            .await
-            .map_err(ToolError::Io)?;
+        let path_display = resolved.display();
+        let contents = match resolved {
+            SkillSource::File(path) => tokio::fs::read_to_string(&path)
+                .await
+                .map_err(ToolError::Io)?,
+            SkillSource::Builtin(content) => content.to_string(),
+        };
 
         let description = parse_skill_frontmatter_value(&contents, "description");
 
         let output = SkillOutput {
             skill: name,
-            path: skill_path.display().to_string(),
+            path: path_display,
             args: input.args,
             description,
             prompt: contents,
@@ -129,8 +155,54 @@ impl Tool for SkillTool {
 
         let json = serde_json::to_string_pretty(&output).map_err(ToolError::Json)?;
 
-        Ok(ToolResult::success(json).with_metadata("path".to_string(), output.path))
+        Ok(ToolResult::success(json).with_metadata("path".to_string(), output.path.clone()))
     }
+}
+
+/// Where a resolved skill's content came from — a real file, or a built-in
+/// compiled into the binary. Kept alongside the borrowed `&'static str` so
+/// callers don't need to re-run resolution just to read the content.
+enum SkillSource {
+    File(PathBuf),
+    Builtin(&'static str),
+}
+
+impl SkillSource {
+    fn display(&self) -> String {
+        match self {
+            SkillSource::File(path) => path.display().to_string(),
+            SkillSource::Builtin(_) => "<builtin>".to_string(),
+        }
+    }
+}
+
+/// Resolve `name` to its content, trying file-based lookup first (project-local,
+/// then user-global) and falling back to a built-in skill. Returns `None` if
+/// neither has it.
+fn resolve_skill(name: &str, cwd: &Path) -> Option<SkillSource> {
+    if let Ok(path) = resolve_skill_path(name, cwd) {
+        return Some(SkillSource::File(path));
+    }
+    builtin::lookup(name).map(SkillSource::Builtin)
+}
+
+/// Synchronous convenience wrapper for non-tool callers (e.g. the TUI resolving
+/// a `/name` slash command directly) that just want the content and
+/// description, without going through the `Tool` trait. Reads file-based
+/// skills eagerly, so should not be called from a context where blocking I/O
+/// is unacceptable — the TUI's key-handling path already does equivalent
+/// synchronous reads for `list_skills`.
+pub(crate) fn resolve_skill_content(name: &str, cwd: &Path) -> Option<(String, Option<String>)> {
+    let name = name.trim().trim_start_matches('/');
+    if name.is_empty() || name.contains('\0') || name.split(['/', '\\']).any(|c| c == "..") {
+        return None;
+    }
+    let content = match resolve_skill(name, cwd)? {
+        SkillSource::File(path) => std::fs::read_to_string(path).ok()?,
+        SkillSource::Builtin(content) => content.to_string(),
+    };
+    let description = parse_skill_frontmatter_value(&content, "description");
+    Some((content, description))
 }
 
 /// Resolve the SKILL.md path for `name`, searching project-local then user-global roots.
@@ -262,6 +334,19 @@ pub(crate) fn list_skills(cwd: &Path) -> Vec<SkillListing> {
                     root: root.clone(),
                 });
             }
+        }
+    }
+
+    // Built-ins fill in any name not already provided by a project/user file,
+    // matching the precedence `resolve_skill` uses.
+    for name in builtin::names() {
+        if seen.insert(name.to_lowercase()) {
+            let content = builtin::lookup(name).unwrap_or_default();
+            skills.push(SkillListing {
+                description: parse_skill_frontmatter_value(content, "description"),
+                name: name.to_string(),
+                root: PathBuf::from("<builtin>"),
+            });
         }
     }
 
@@ -455,5 +540,65 @@ mod tests {
         // No .crustly/ or .claude/ under tmp.path() at all - just confirms
         // this doesn't panic when there's nothing to find.
         let _ = list_skills(tmp.path());
+    }
+
+    #[test]
+    fn resolve_skill_content_falls_back_to_builtin_review_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        // No .crustly/skills/review anywhere under tmp - only the built-in exists.
+        let (content, description) = resolve_skill_content("review", tmp.path())
+            .expect("built-in review skill should resolve with no project skill present");
+        assert!(content.contains("name: review"));
+        assert!(description.is_some());
+    }
+
+    #[test]
+    fn resolve_skill_content_prefers_project_file_over_builtin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join(".crustly").join("skills").join("review");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\ndescription: Project override\n---\nCustom body.",
+        )
+        .unwrap();
+
+        let (content, description) = resolve_skill_content("review", tmp.path()).unwrap();
+        assert_eq!(description.as_deref(), Some("Project override"));
+        assert!(content.contains("Custom body."));
+    }
+
+    #[test]
+    fn resolve_skill_content_returns_none_for_unknown_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(resolve_skill_content("not-a-real-skill", tmp.path()).is_none());
+    }
+
+    #[test]
+    fn list_skills_includes_builtin_review_skill() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skills = list_skills(tmp.path());
+        assert!(skills.iter().any(|s| s.name == "review"));
+    }
+
+    #[test]
+    fn list_skills_lets_project_skill_shadow_builtin_of_same_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join(".crustly").join("skills").join("review");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\ndescription: Project override\n---\nCustom body.",
+        )
+        .unwrap();
+
+        let skills = list_skills(tmp.path());
+        let matches: Vec<_> = skills.iter().filter(|s| s.name == "review").collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "builtin should be shadowed, not duplicated"
+        );
+        assert_eq!(matches[0].description.as_deref(), Some("Project override"));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1409,7 +1409,27 @@ impl App {
                 self.switch_mode(AppMode::Help).await?;
                 Ok(true)
             }
-            _ => Ok(false),
+            _ => {
+                // Not a built-in UI command - check whether it names a discoverable
+                // skill (project-local, user-global, or a built-in like `/review`)
+                // before giving up and treating it as a plain chat message. When one
+                // resolves, the skill's SKILL.md body becomes the actual message sent
+                // to the agent, with any trailing text passed through as arguments.
+                let name = command.trim_start_matches('/');
+                let Some((prompt, _description)) =
+                    crate::llm::tools::skill::resolve_skill_content(name, &self.working_directory)
+                else {
+                    return Ok(false);
+                };
+                let args = trimmed[command.len()..].trim();
+                let message = if args.is_empty() {
+                    prompt
+                } else {
+                    format!("{prompt}\n\nAdditional arguments: {args}")
+                };
+                self.send_message(message).await?;
+                Ok(true)
+            }
         }
     }
 
@@ -4003,6 +4023,43 @@ mod tests {
 
         assert!(!handled);
         assert_eq!(app.mode, AppMode::Chat);
+    }
+
+    /// `/review` isn't a built-in UI command like `/help` - it should resolve
+    /// through the generic skill-lookup fallback (to the built-in `review`
+    /// skill, since no `.crustly/skills/review` exists in the test cwd) and be
+    /// handled as a message to the agent, not fall through as literal chat text.
+    #[tokio::test]
+    async fn slash_review_resolves_to_the_builtin_skill() {
+        let mut app = test_app().await;
+        app.create_new_session().await.unwrap();
+
+        let handled = app.try_handle_slash_command("/review").await.unwrap();
+
+        assert!(handled, "/review should resolve via the skill fallback");
+        let sent = app
+            .messages
+            .last()
+            .expect("send_message should have appended the user message");
+        assert_eq!(sent.role, "user");
+        assert!(
+            sent.content.contains("name: review"),
+            "the agent should receive the skill's SKILL.md content, not the literal \"/review\" text: {}",
+            sent.content
+        );
+    }
+
+    /// Trailing text after the skill name (e.g. `/review 42`) must reach the
+    /// agent too, not get silently dropped in favor of the bare skill body.
+    #[tokio::test]
+    async fn slash_review_with_arguments_appends_them_to_the_skill_prompt() {
+        let mut app = test_app().await;
+        app.create_new_session().await.unwrap();
+
+        app.try_handle_slash_command("/review 42").await.unwrap();
+
+        let sent = app.messages.last().unwrap();
+        assert!(sent.content.contains("Additional arguments: 42"));
     }
 
     /// Regression: ratatui-textarea underlines the cursor line by default, so

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4073,6 +4073,26 @@ mod tests {
         assert!(sent.content.contains("Additional arguments: 42"));
     }
 
+    /// Same fallback, different built-in: `/spec` should resolve to the SDD
+    /// workflow skill, with a new feature description passed through as args.
+    #[tokio::test]
+    async fn slash_spec_resolves_to_the_builtin_skill_with_arguments() {
+        let mut app = test_app().await;
+        app.create_new_session().await.unwrap();
+
+        let handled = app
+            .try_handle_slash_command("/spec Add CSV export to reports")
+            .await
+            .unwrap();
+
+        assert!(handled, "/spec should resolve via the skill fallback");
+        let sent = app.messages.last().unwrap();
+        assert!(sent.content.contains("name: spec"));
+        assert!(sent
+            .content
+            .contains("Additional arguments: Add CSV export to reports"));
+    }
+
     /// Regression: ratatui-textarea underlines the cursor line by default, so
     /// everything typed into the chat input rendered underlined. All three
     /// paths that (re)build the textarea must clear that style - a fresh app,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1415,10 +1415,21 @@ impl App {
                 // before giving up and treating it as a plain chat message. When one
                 // resolves, the skill's SKILL.md body becomes the actual message sent
                 // to the agent, with any trailing text passed through as arguments.
-                let name = command.trim_start_matches('/');
-                let Some((prompt, _description)) =
-                    crate::llm::tools::skill::resolve_skill_content(name, &self.working_directory)
-                else {
+                //
+                // Resolution walks every ancestor directory of cwd (plus the user's
+                // home) doing blocking filesystem I/O - the same lookup SkillTool
+                // wraps in spawn_blocking. Run it off this task too: this fallback
+                // fires on every submitted "/word", and the TUI's draw/handle-key
+                // loop is sequential, so blocking here would stall rendering on a
+                // deep cwd or a slow/network-mounted HOME.
+                let name = command.trim_start_matches('/').to_string();
+                let cwd = self.working_directory.clone();
+                let resolved = tokio::task::spawn_blocking(move || {
+                    crate::llm::tools::skill::resolve_skill_content(&name, &cwd)
+                })
+                .await
+                .map_err(|e| anyhow::anyhow!("skill lookup task panicked: {e}"))?;
+                let Some((prompt, _description)) = resolved else {
                     return Ok(false);
                 };
                 let args = trimmed[command.len()..].trim();


### PR DESCRIPTION
Adds a multi-pass automated code review workflow as a skill built into
the binary, invocable via /review with no project setup required:

- src/llm/tools/builtin_skills/review.md: original SKILL.md content
  describing a review flow scoped to crustly's own tools (agent tool
  for parallel review passes, bash+gh for target/comment handling,
  edit/apply_patch for --fix), with a confidence-filtering pass before
  anything is reported.

- src/llm/tools/skill.rs: adds a built-in-skill fallback tier to the
  skill lookup, used only when no .crustly/skills or .claude/skills
  file (project or user) provides the name, so a project can still
  override it. list_skills() surfaces built-ins the same way, deduping
  against file-based skills of the same name. Adds
  resolve_skill_content() as a sync entry point for non-tool callers.

- src/tui/app.rs: try_handle_slash_command now falls back to resolving
  any unmatched /<name> as a skill (project, user, or built-in) before
  giving up and sending the raw text as a chat message - closing the
  gap where SkillTool existed but nothing actually routed slash input
  to it. Trailing text after the command name is passed through as
  arguments.