### PR TITLE
deps: bump the minor-and-patch group with 5 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+checksum = "ef47857a1d4488b528f4a5d5715fa7c3300820897824152234d3fa22b1426657"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.142.0"
+version = "1.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4844547a354fb4e41895f4c9c423e7a7de13e3b2adc3f3493a2f2d8aa397c294"
+checksum = "492a63a8e903a7b8f7c77537ef05fc75d71ba268cf23a0eee41fb6f0da605029"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+checksum = "209f3a6d82a6e9e5f94abbed94c7a26e1c052341002bf57a5fb5481f625896fc"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1538,7 +1538,7 @@ dependencies = [
  "serde-untagged",
  "serde_core",
  "serde_json",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "winnow 1.0.3",
  "yaml-rust2 0.11.0",
 ]
@@ -1903,7 +1903,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "toktrie",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "tower-lsp",
  "tracing",
  "tracing-appender",
@@ -3685,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.1.6"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
+checksum = "2270074a3d26bcac93c1dc5d2845eb4c089e8d761ccf6e0ea266a16004640627"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",
@@ -3871,9 +3871,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.154"
+version = "0.1.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4397360a0bd81be29929a55ad2f49eba27a744a6578f3271894d6f41d86bd15b"
+checksum = "b6450f6d59b4d758b0d92f50a640136c713ec7e08d8ebb0595db03c939b502d4"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -3887,9 +3887,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.154"
+version = "0.1.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a9ea2ce0cdc20bcb1870534022e340b391663f8fe09133951e2fe37fbc29cf"
+checksum = "aaeb4c4a83335b5e3f1ae87aaa3af447a249dac1b1f8b2249e33b1d74da104a3"
 dependencies = [
  "bindgen",
  "cc",
@@ -5527,9 +5527,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-image"
-version = "11.0.6"
+version = "11.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+checksum = "03b7a5dadade9d8a0243267ad40fd1ace6f369cc8f0c5f9f8a0ebd67bfb95f5b"
 dependencies = [
  "base64-simd",
  "icy_sixel",
@@ -7462,9 +7462,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/src/llm/provider/llama_cpp.rs
+++ b/src/llm/provider/llama_cpp.rs
@@ -553,7 +553,14 @@ fn prepare_generation(
         .unwrap_or(DEFAULT_MAX_TOKENS)
         .min(n_ctx.saturating_sub(prompt_tokens.len() as u32));
 
-    let sampler = build_sampler(sampling_defaults, request, default_seed, 0, None);
+    let sampler = build_sampler(
+        model.n_vocab(),
+        sampling_defaults,
+        request,
+        default_seed,
+        0,
+        None,
+    );
 
     // Prefill: decode the whole prompt in one batch. `add_sequence` sets
     // logits=true only on the last token, which is all prefill needs -
@@ -672,6 +679,7 @@ fn run_complete(
             }
 
             maybe_swap_to_constrained_sampler(
+                model.n_vocab(),
                 &text_so_far,
                 swap_possible,
                 &mut grammar_swap_attempted,
@@ -859,6 +867,7 @@ fn run_stream(
             // accumulates the same way, so the trigger and the replay must
             // agree on which window of the response they're each looking at.
             maybe_swap_to_constrained_sampler(
+                model.n_vocab(),
                 &full_text,
                 swap_possible,
                 &mut grammar_swap_attempted,
@@ -1064,7 +1073,13 @@ fn token_to_piece_bytes(
 /// was instead of continuing independently - offsetting by the token count
 /// keeps the result deterministic for a given seed + prefix length without
 /// literally repeating the start of the stream.
+///
+/// `n_vocab` is the loaded model's vocabulary size ([`LlamaModel::n_vocab`]).
+/// `llama-cpp-2` 0.1.156 added it as `LlamaSampler::penalties`'s new first
+/// parameter (previously just `penalty_last_n`/`penalty_repeat`/
+/// `penalty_freq`/`penalty_present`).
 fn build_sampler(
+    n_vocab: i32,
     defaults: &SamplingDefaults,
     request: &LLMRequest,
     default_seed: Option<u32>,
@@ -1100,6 +1115,7 @@ fn build_sampler(
 
     chain.extend([
         LlamaSampler::penalties(
+            n_vocab,
             64,
             defaults.repeat_penalty,
             frequency_penalty,
@@ -1181,8 +1197,10 @@ fn build_grammar_env(_model: &LlamaModel) -> Option<ToolCallGrammarEnv> {
 /// it does not corrupt or block generation. Confirmed by reading
 /// `llguidance` 1.7.6's `Matcher::consume_tokens`/`with_inner` and
 /// `llama-cpp-2` 0.1.153's `llguidance_sampler.rs` directly, not assumed.
+#[allow(clippy::too_many_arguments)]
 #[cfg(feature = "llama-cpp-llguidance")]
 fn try_build_constrained_sampler(
+    n_vocab: i32,
     grammar_env: &ToolCallGrammarEnv,
     offered_tools: &[Tool],
     generated_tokens: &[LlamaToken],
@@ -1193,6 +1211,7 @@ fn try_build_constrained_sampler(
     match super::llama_cpp_grammar::build_tool_call_sampler(grammar_env, offered_tools) {
         Ok(grammar_sampler) => {
             let mut chain = build_sampler(
+                n_vocab,
                 defaults,
                 request,
                 default_seed,
@@ -1218,8 +1237,10 @@ fn try_build_constrained_sampler(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 #[cfg(not(feature = "llama-cpp-llguidance"))]
 fn try_build_constrained_sampler(
+    _n_vocab: i32,
     _grammar_env: &ToolCallGrammarEnv,
     _offered_tools: &[Tool],
     _generated_tokens: &[LlamaToken],
@@ -1243,6 +1264,7 @@ fn try_build_constrained_sampler(
 /// once per response regardless of caller.
 #[allow(clippy::too_many_arguments)]
 fn maybe_swap_to_constrained_sampler(
+    n_vocab: i32,
     text: &str,
     swap_possible: bool,
     grammar_swap_attempted: &mut bool,
@@ -1265,6 +1287,7 @@ fn maybe_swap_to_constrained_sampler(
         return;
     };
     if let Some(constrained) = try_build_constrained_sampler(
+        n_vocab,
         grammar_env,
         offered_tools,
         generated_tokens,
@@ -1514,8 +1537,8 @@ mod tests {
         let defaults = SamplingDefaults::default();
         let request = LLMRequest::new("llama-cpp-model", vec![]);
 
-        let unshifted = build_sampler(&defaults, &request, Some(42), 0, None);
-        let shifted = build_sampler(&defaults, &request, Some(42), 17, None);
+        let unshifted = build_sampler(32_000, &defaults, &request, Some(42), 0, None);
+        let shifted = build_sampler(32_000, &defaults, &request, Some(42), 17, None);
 
         assert_eq!(unshifted.get_seed(), 42);
         assert_eq!(shifted.get_seed(), 42u32.wrapping_add(17));
@@ -1688,6 +1711,7 @@ mod tests {
         let request = LLMRequest::new("llama-cpp-model", vec![]);
 
         let sampler = try_build_constrained_sampler(
+            32_000,
             &grammar_env,
             &tools,
             &[],
@@ -1716,6 +1740,7 @@ mod tests {
         let generated = [LlamaToken(0), LlamaToken(1), LlamaToken(2)];
 
         let sampler = try_build_constrained_sampler(
+            32_000,
             &grammar_env,
             &tools,
             &generated,
@@ -1737,6 +1762,7 @@ mod tests {
         let request = LLMRequest::new("llama-cpp-model", vec![]);
 
         let sampler = try_build_constrained_sampler(
+            32_000,
             &(),
             &tools,
             &[],


### PR DESCRIPTION
Bumps the minor-and-patch group with 5 updates:

| Package | From | To |
| --- | --- | --- |
| [ratatui-image](https://github.com/ratatui/ratatui-image) | `11.0.6` | `11.0.7` |
| [toml](https://github.com/toml-rs/toml) | `1.1.4+spec-1.1.0` | `1.1.5+spec-1.1.0` |
| [aws-sdk-bedrockruntime](https://github.com/awslabs/aws-sdk-rust) | `1.142.0` | `1.143.0` |
| [llama-cpp-2](https://github.com/utilityai/llama-cpp-rs) | `0.1.154` | `0.1.156` |
| [keyring](https://github.com/open-source-cooperative/keyring-rs) | `4.1.6` | `4.2.0` |


Updates `ratatui-image` from 11.0.6 to 11.0.7
- [Release notes](https://github.com/ratatui/ratatui-image/releases)
- [Changelog](https://github.com/ratatui/ratatui-image/blob/master/CHANGELOG.md)
- [Commits](https://github.com/ratatui/ratatui-image/compare/v11.0.6...v11.0.7)

Updates `toml` from 1.1.4+spec-1.1.0 to 1.1.5+spec-1.1.0
- [Commits](https://github.com/toml-rs/toml/compare/toml-v1.1.4...toml-v1.1.5)

Updates `aws-sdk-bedrockruntime` from 1.142.0 to 1.143.0
- [Release notes](https://github.com/awslabs/aws-sdk-rust/releases)
- [Commits](https://github.com/awslabs/aws-sdk-rust/commits)

Updates `llama-cpp-2` from 0.1.154 to 0.1.156
- [Release notes](https://github.com/utilityai/llama-cpp-rs/releases)
- [Commits](https://github.com/utilityai/llama-cpp-rs/compare/0.1.154...0.1.156)

Updates `keyring` from 4.1.6 to 4.2.0
- [Release notes](https://github.com/open-source-cooperative/keyring-rs/releases)
- [Commits](https://github.com/open-source-cooperative/keyring-rs/compare/v4.1.6...v4.2.0)

---
updated-dependencies:
- dependency-name: ratatui-image
  dependency-version: 11.0.7
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: minor-and-patch
- dependency-name: toml
  dependency-version: 1.1.5+spec-1.1.0
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: minor-and-patch
- dependency-name: aws-sdk-bedrockruntime
  dependency-version: 1.143.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: minor-and-patch
- dependency-name: llama-cpp-2
  dependency-version: 0.1.156
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: minor-and-patch
- dependency-name: keyring
  dependency-version: 4.2.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: minor-and-patch
...

Signed-off-by: dependabot[bot] <support@github.com>